### PR TITLE
v0.1.9 fixed broken registration and syncing. Finally discovered why …

### DIFF
--- a/meerschaum/Pipe/_attributes.py
+++ b/meerschaum/Pipe/_attributes.py
@@ -44,21 +44,21 @@ def columns(self, columns):
     else:
         self._parameters['columns'] = columns
 
-def get_columns(self, *args):
+def get_columns(self, *args, error=True):
     """
     Check if the requested columns are defined
     """
-    from meerschaum.utils.warnings import error, warn
+    from meerschaum.utils.warnings import error as _error, warn
     col_names = []
     for col in args:
         col_name = None
         try:
             col_name = self.columns[col]
-            if col_name is None:
-                error(f"Please define the name of the '{col}' column for Pipe '{self}'.")
+            if col_name is None and error:
+                _error(f"Please define the name of the '{col}' column for Pipe '{self}'.")
         except:
             col_name = None
-        if col_name is None: error(f"Missing '{col}'" + f" column for Pipe '{self}'.")
+        if col_name is None and error: _error(f"Missing '{col}'" + f" column for Pipe '{self}'.")
         col_names.append(col_name)
     if len(col_names) == 1:
         return col_names[0]

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -63,18 +63,48 @@ class SQLConnector(Connector):
             error(f"Flavor '{self.flavor}' is not supported by Meerschaum SQLConnector")
         self.verify_attributes(self.flavor_configs[self.flavor]['requirements'], debug=debug)
 
-        ### build the sqlalchemy engine and set DATABASE_URL
-        self.engine, self.DATABASE_URL = self.create_engine(include_uri=True, debug=debug)
-
         self.wait = wait
         if self.wait:
             from meerschaum.utils.misc import wait_for_connection
             wait_for_connection(connector=self.db, debug=debug)
 
+        ### store the PID  anf thread at initialization so we can dispose of the Pool in child processes or threads
+        import os; self._pid = os.getpid()
+        import threading; self._thread = threading.current_thread()
+        self._debug = debug
+
         ### create a sqlalchemy session for building ORM queries
         #  self.Session = sqlalchemy_orm.sessionmaker()
         #  self.Session.configure(bind=self.engine)
         #  self.session = self.Session()
+
+    @property
+    def engine(self):
+        import os, threading
+        ### build the sqlalchemy engine
+        if '_engine' not in self.__dict__:
+            self._engine = self.create_engine(debug=self._debug)
+
+        same_process = os.getpid() == self._pid
+        same_thread = threading.current_thread() is self._thread
+
+        ### handle child processes
+        if not same_process:
+            self._pid = os.getpid()
+            self._thread = threading.current_thread()
+            from meerschaum.utils.warnings import warn
+            warn(f"Different PID detected. Disposing of connections...")
+            self._engine.dispose()
+
+        ### handle different threads
+        if not same_thread:
+            pass
+
+        return self._engine
+
+    @property
+    def DATABASE_URL(self):
+        return str(self.engine)
 
     @property
     def metadata(self):
@@ -92,6 +122,10 @@ class SQLConnector(Connector):
             self._db = databases.Database(self.DATABASE_URL)
         return self._db
 
-    def __del__(self):
-        pass
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
+    def __call__(self): return self
+
+    #  def __del__(self):
+        #  pass
         #  self.session.close()


### PR DESCRIPTION
…SQLConnectors break multiprocessing; SQLAlchemy connection Pools are QueuePools and cannot be pickled. Not sure if findind a workaround is worth the effort. Wrote process checking to the engine method of the SQLConnector class (deferred initializing lazily) and disposes of connection pool when a new process is detected (which currently can't occur due to the pickle issue).