### PR TITLE
🚀 Deploy v1.2.0 to `main`

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,19 +7,34 @@ on:
         description: 'Run the pytest script.'
         required: false
         default: ""
-  # push:
-    # branches: [ main ]
+  push:
+    branches: [ main, staging ]
+  pull_request:
+    branches:
+      - main
+      - staging
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup dev tools
         env:
           MRSM_SKIP_DOCKER_EXPERIMENTAL: 1
         run: ./scripts/setup.sh
-      - name: pytest
+      - name: Install db drivers
+        run: sudo ./scripts/drivers.sh
+      # - name: Setup tmate session
+        # uses: mxschmitt/action-tmate@v3
+        # with:
+          # limit-access-to-actor: true
+      - name: Integration tests
         env:
           COMPOSE_INTERACTIVE_NO_CLI: 1
         run: ./scripts/test.sh db
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: api-log
+          path: test_root/logs/test_api.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ scratch/
 /portable/
 /test_root/
 /tests/data/
+/test_plugins/
 docs/pdoc/*
 docs/site/*
 file_system_store/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,70 @@
 # 🪵 Changelog
 
-## 1.1.x Releases
+## 1.2.x Releases
 
 This is the current release cycle, so future features will be updated below.
+
+### v1.2.0
+
+**Improvements**
+
+- **Added the action `start connectors`.**  
+  This command allows you to wait until all of the specified connectors are available and accepting connections. This feature is very handy when paired with the new `MRSM_SQL_X` URI environment variables.
+
+- **Added `MRSM_PLUGINS_DIR`.**  
+  This one's been on my to-do list for quite a bit! You can now place your plugins in a dedicated, version-controlled directory outside of your root directory.
+  
+  Like `MRSM_ROOT_DIR`, specify a path with the environment variable `MRSM_PLUGINS_DIR`:
+
+  ```bash
+  MRSM_PLUGINS_DIR=plugins \
+    mrsm show plugins
+  ```
+
+- **Allow for symlinking in URI environment variables.**  
+  You may now reference configuration keys within URI variables:
+
+  ```bash
+  MRSM_SQL_FOO=postgresql://user:MRSM{meerschaum:connectors:sql:main:password}@localhost:5432/db
+  ```
+
+- **Increased token expiration window to 12 hours.**  
+  This should reduce the number of login requests needed.
+
+- **Improved virtual environment verification.**  
+  More edge cases have been addressed.
+
+- **Symlink Meerschaum into `Plugin` virtual environments.**  
+  If plugins do not specify `Meerschaum` in the `required` list, Meerschaum will be symlinked to the currently running package.
+
+**Breaking changes**
+
+- **API endpoints for registering and editing users changed.**  
+  To comply with OAuth2 convention, the API endpoint for registering a user is now a url-encoded form submission to `/users/register` (`/user/edit` for editing).
+
+    ***You must upgrade both the server and client to v1.2.0+ to login to your API instances.***
+
+- **Replaced `meerschaum.utils.sql.update_query()` with `meerschaum.utils.sql.get_update_queries()`.**  
+  The new function returns a list of query strings rather than a single query. These queries are executed within a single transaction.
+
+**Bugfixes**
+
+- **Removed version enforcement in `pip_install()`.**  
+  This changed behavior allows for custom version constraints to be specified in Meerschaum plugins.
+
+- **Backported `UPDATE FROM` query for older versions of SQLite.**  
+  The current mutable data logic uses an `UPDATE FROM` query, but this syntax is only present in versions of SQLite greater than 3.33.0 (released 2020-08-14). This releases splits the same logic into `DELETE` and `INSERT` queries for older versions of SQLite.
+
+- **Fixed missing suggestions for shell-only commands.**  
+  Completions for commands like `instance` are now suggested.
+
+- **Fixed an issue with killing background jobs.**  
+  The signals were not being sent correctly, so this release includes better job process management.
+
+
+## 1.1.x Releases
+
+The 1.1.x series brought a lot of great new features, notably connector URI parsing (e.g. `MRSM_SQL_<LABEL>`), parsing underscores as spaces in actions, and rewriting the Docker image to run at as a normal user.
 
 ### v1.1.9 – v1.1.10
 
@@ -62,6 +124,7 @@ The first four versions following the initial v1.1.0 release addressed breaking 
   ```bash
   mrsm foo bar
   ```
+
 - **Create a `SQLConnector` or `APIConnector` directly from a URI.**  
   If you already have a connection string, you can skip providing credentials and build a connector directly from the URI. If you omit a `label`, then the lowercase form of `'<username>@<host>/<database>'` is used:
 
@@ -170,6 +233,7 @@ The v1.0.0 release was big news. A ton of features, bugfixes, and perfomance imp
   with Venv(Plugin('noaa')):
       import requests
   ```
+
 - **Removed `--isolated` from `pip_install`.**  
   Virtual environments will now respect environment variables and your global `pip` configuration (`~/.pip/pip.conf`).
 - **Fixed issues for Python 3.7**

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -1,8 +1,70 @@
 # 🪵 Changelog
 
-## 1.1.x Releases
+## 1.2.x Releases
 
 This is the current release cycle, so future features will be updated below.
+
+### v1.2.0
+
+**Improvements**
+
+- **Added the action `start connectors`.**  
+  This command allows you to wait until all of the specified connectors are available and accepting connections. This feature is very handy when paired with the new `MRSM_SQL_X` URI environment variables.
+
+- **Added `MRSM_PLUGINS_DIR`.**  
+  This one's been on my to-do list for quite a bit! You can now place your plugins in a dedicated, version-controlled directory outside of your root directory.
+  
+  Like `MRSM_ROOT_DIR`, specify a path with the environment variable `MRSM_PLUGINS_DIR`:
+
+  ```bash
+  MRSM_PLUGINS_DIR=plugins \
+    mrsm show plugins
+  ```
+
+- **Allow for symlinking in URI environment variables.**  
+  You may now reference configuration keys within URI variables:
+
+  ```bash
+  MRSM_SQL_FOO=postgresql://user:MRSM{meerschaum:connectors:sql:main:password}@localhost:5432/db
+  ```
+
+- **Increased token expiration window to 12 hours.**  
+  This should reduce the number of login requests needed.
+
+- **Improved virtual environment verification.**  
+  More edge cases have been addressed.
+
+- **Symlink Meerschaum into `Plugin` virtual environments.**  
+  If plugins do not specify `Meerschaum` in the `required` list, Meerschaum will be symlinked to the currently running package.
+
+**Breaking changes**
+
+- **API endpoints for registering and editing users changed.**  
+  To comply with OAuth2 convention, the API endpoint for registering a user is now a url-encoded form submission to `/users/register` (`/user/edit` for editing).
+
+    ***You must upgrade both the server and client to v1.2.0+ to login to your API instances.***
+
+- **Replaced `meerschaum.utils.sql.update_query()` with `meerschaum.utils.sql.get_update_queries()`.**  
+  The new function returns a list of query strings rather than a single query. These queries are executed within a single transaction.
+
+**Bugfixes**
+
+- **Removed version enforcement in `pip_install()`.**  
+  This changed behavior allows for custom version constraints to be specified in Meerschaum plugins.
+
+- **Backported `UPDATE FROM` query for older versions of SQLite.**  
+  The current mutable data logic uses an `UPDATE FROM` query, but this syntax is only present in versions of SQLite greater than 3.33.0 (released 2020-08-14). This releases splits the same logic into `DELETE` and `INSERT` queries for older versions of SQLite.
+
+- **Fixed missing suggestions for shell-only commands.**  
+  Completions for commands like `instance` are now suggested.
+
+- **Fixed an issue with killing background jobs.**  
+  The signals were not being sent correctly, so this release includes better job process management.
+
+
+## 1.1.x Releases
+
+The 1.1.x series brought a lot of great new features, notably connector URI parsing (e.g. `MRSM_SQL_<LABEL>`), parsing underscores as spaces in actions, and rewriting the Docker image to run at as a normal user.
 
 ### v1.1.9 – v1.1.10
 
@@ -62,6 +124,7 @@ The first four versions following the initial v1.1.0 release addressed breaking 
   ```bash
   mrsm foo bar
   ```
+
 - **Create a `SQLConnector` or `APIConnector` directly from a URI.**  
   If you already have a connection string, you can skip providing credentials and build a connector directly from the URI. If you omit a `label`, then the lowercase form of `'<username>@<host>/<database>'` is used:
 
@@ -170,6 +233,7 @@ The v1.0.0 release was big news. A ton of features, bugfixes, and perfomance imp
   with Venv(Plugin('noaa')):
       import requests
   ```
+
 - **Removed `--isolated` from `pip_install`.**  
   Virtual environments will now respect environment variables and your global `pip` configuration (`~/.pip/pip.conf`).
 - **Fixed issues for Python 3.7**

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -619,12 +619,16 @@ class Shell(cmd.Cmd):
 
         return True, "Success"
 
+
     def complete_instance(self, text: str, line: str, begin_index: int, end_index: int):
+    #  def complete_instance(action: List[str], **kw):
         from meerschaum.utils.misc import get_connector_labels
         from meerschaum.actions.arguments._parse_arguments import parse_line
         args = parse_line(line)
-        _text = args['action'][1] if len(args['action']) > 1 else ""
+        action = args['action']
+        _text = action[1] if len(action) > 1 else ""
         return get_connector_labels('api', 'sql', search_term=_text, ignore_exact_match=True)
+
 
     def do_repo(
             self,

--- a/meerschaum/actions/__init__.py
+++ b/meerschaum/actions/__init__.py
@@ -245,11 +245,11 @@ def get_completer(
 
 def _get_parent_plugin(stacklevel: int = 1) -> Union[str, None]:
     """If this function is called from outside a Meerschaum plugin, it will return None."""
-    from meerschaum.config._paths import PLUGINS_RESOURCES_PATH
+    from meerschaum.config._paths import PLUGINS_INTERNAL_DIR_PATH
     import inspect, re
     parent_globals = inspect.stack()[stacklevel][0].f_globals
     parent_file = parent_globals.get('__file__', '')
-    if str(PLUGINS_RESOURCES_PATH) not in parent_file:
+    if str(PLUGINS_INTERNAL_DIR_PATH) not in parent_file:
         return None
     return parent_globals['__name__'].replace('plugins.', '').split('.')[0]
 

--- a/meerschaum/actions/_entry.py
+++ b/meerschaum/actions/_entry.py
@@ -7,7 +7,7 @@ The entry point for launching Meerschaum actions.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, List, Optional
+from meerschaum.utils.typing import SuccessTuple, List, Optional, Dict
 
 def _entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
     """Parse arguments and launch a Meerschaum action.
@@ -38,6 +38,7 @@ def _entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
         from meerschaum.utils.schedule import schedule_function
         return schedule_function(_entry_with_args, args['schedule'], **args)
     return _entry_with_args(**args)
+
 
 def _entry_with_args(
         _actions: Optional[Dict[str, Callable[[Any], SuccessTuple]]] = None,

--- a/meerschaum/actions/arguments/_parse_arguments.py
+++ b/meerschaum/actions/arguments/_parse_arguments.py
@@ -30,11 +30,11 @@ def parse_arguments(sysargs: List[str]) -> Dict[str, Any]:
     """
     import shlex
     import copy
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
 
     sub_arguments = []
     sub_arg_indices = []
-    begin_decorator, end_decorator = _static_config()['system']['arguments']['sub_decorators']
+    begin_decorator, end_decorator = STATIC_CONFIG['system']['arguments']['sub_decorators']
     found_begin_decorator = False
     for i, word in enumerate(sysargs):
         is_sub_arg = False
@@ -81,6 +81,10 @@ def parse_arguments(sysargs: List[str]) -> Dict[str, Any]:
             _action.append(a)
         args_dict = {'action': _action, 'sysargs': sysargs, 'text': shlex.join(sysargs)}
         unknown = []
+
+    false_flags = [arg for arg, val in args_dict.items() if val is False]
+    for arg in false_flags:
+        args_dict.pop(arg, None)
 
     args_dict['sysargs'] = sysargs
     args_dict['filtered_sysargs'] = filtered_sysargs
@@ -155,6 +159,8 @@ def parse_synonyms(
         args_dict['instance'] = args_dict['mrsm_instance']
     if args_dict.get('skip_check_existing', None):
         args_dict['check_existing'] = False
+    if args_dict.get('venv', None) in ('None', '[None]'):
+        args_dict['venv'] = None
     return args_dict
 
 
@@ -179,9 +185,7 @@ def parse_dict_to_sysargs(
                 sysargs += [t[0]]
         else:
             ### Add list flags
-            if (
-                isinstance(args_dict[a], list) or isinstance(args_dict[a], tuple)
-            ):
+            if isinstance(args_dict[a], (list, tuple)):
                 if len(args_dict[a]) > 0:
                     sysargs += [t[0]] + list(args_dict[a])
 
@@ -230,12 +234,17 @@ def remove_leading_action(
     """
     from meerschaum.actions import get_action, get_main_action_name
     from meerschaum.utils.warnings import warn
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     action_function = get_action(action, _actions=_actions)
     if action_function is None:
         return action
 
-    UNDERSCORE_STANDIN = _static_config()['system']['arguments']['underscore_standin']
+    UNDERSCORE_STANDIN = STATIC_CONFIG['system']['arguments']['underscore_standin']
+
+    ### e.g. 'show'
+    main_action_name = get_main_action_name(action, _actions)
+    if main_action_name is None:
+        return []
 
     ### Replace underscores with a standin so we can preserve the exising underscores.
     _action = []
@@ -244,9 +253,6 @@ def remove_leading_action(
 
     ### e.g. 'show_pipes_baz'
     action_str = '_'.join(_action)
-
-    ### e.g. 'show'
-    main_action_name = get_main_action_name(_action, _actions)
 
     ### e.g. 'show_pipes'
     action_name = action_function.__name__.lstrip('_')
@@ -257,7 +263,7 @@ def remove_leading_action(
     ### Strip away any leading prefices.
     action_name = action_name[main_action_index:]
 
-    if not action_str.startswith(action_name):
+    if not action_str.replace(UNDERSCORE_STANDIN, '_').startswith(action_name):
         warn(f"Unable to parse '{action_str}' for action '{action_name}'.")
         return action
     

--- a/meerschaum/actions/arguments/_parser.py
+++ b/meerschaum/actions/arguments/_parser.py
@@ -114,6 +114,7 @@ groups['pipes'] = parser.add_argument_group(title='Pipes options')
 groups['sync'] = parser.add_argument_group(title='Sync options')
 groups['api'] = parser.add_argument_group(title='API options')
 groups['plugins'] = parser.add_argument_group(title='Plugins options')
+groups['packages'] = parser.add_argument_group(title='Packages options')
 groups['debug'] = parser.add_argument_group(title='Debugging options')
 groups['misc'] = parser.add_argument_group(title='Miscellaneous options')
 
@@ -247,7 +248,8 @@ groups['api'].add_argument(
     '-p', '--port', type=int, help="The port on which to run the Web API server"
 )
 groups['api'].add_argument(
-    '--host', type=str, help="The host address to bind to for the API server. Defaults to '0.0.0.0'."
+    '--host', type=str,
+    help="The host address to bind to for the API server. Defaults to '0.0.0.0'."
 )
 groups['api'].add_argument(
     '-w', '--workers', type=int,
@@ -276,6 +278,11 @@ groups['plugins'].add_argument(
     help="Meerschaum plugins repository to connect to. Specify an API label (default: 'mrsm')"
 )
 
+### Packages options
+groups['packages'].add_argument(
+    '--venv', type=str,
+    help="Choose which virtual environment to target when installing or removing packages.",
+)
 ### Debugging Arguments
 groups['debug'].add_argument(
     '--debug', action="store_true", help="Print debug statements (max verbosity)"

--- a/meerschaum/actions/uninstall.py
+++ b/meerschaum/actions/uninstall.py
@@ -144,10 +144,13 @@ def _complete_uninstall_plugins(action: Optional[List[str]] = None, **kw) -> Lis
             possibilities.append(name)
     return possibilities
 
+class NoVenv:
+    pass
 
 def _uninstall_packages(
         action: Optional[List[str]] = None,
         sub_args: Optional[List[str]] = None,
+        venv: Union[str, None, NoVenv] = NoVenv,
         yes: bool = False,
         force: bool = False,
         noask: bool = False,
@@ -162,14 +165,26 @@ def _uninstall_packages(
     """
     if not action:
         return False, f"No packages to uninstall."
+
     from meerschaum.utils.warnings import info
     from meerschaum.utils.packages import pip_uninstall
+
+    if venv is NoVenv:
+        venv = 'mrsm'
+
     if not (yes or force) and noask:
         return False, "Skipping uninstallation. Add `-y` or `-f` to agree to the uninstall prompt."
-    if pip_uninstall(*action, args=sub_args + (['-y'] if (yes or force) else []), debug=debug):
+
+    if pip_uninstall(
+        *action,
+        args = sub_args + (['-y'] if (yes or force) else []),
+        venv = venv,
+        debug = debug,
+    ):
         return True, (
             f"Successfully removed packages from virtual environment 'mrsm':\n" + ', '.join(action)
         )
+
     return False, f"Failed to uninstall packages:\n" + ', '.join(action)
 
 

--- a/meerschaum/actions/upgrade.py
+++ b/meerschaum/actions/upgrade.py
@@ -7,7 +7,7 @@ Upgrade your current Meerschaum environment
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, Any, List, Optional
+from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Union
 
 def upgrade(
         action: Optional[List[str]] = None,
@@ -104,8 +104,12 @@ def _upgrade_meerschaum(
     return True, "Success"
 
 
+class NoVenv:
+    pass
+
 def _upgrade_packages(
         action: Optional[List[str]] = None,
+        venv: Union[str, None, NoVenv] = NoVenv,
         yes: bool = False,
         force: bool = False,
         noask: bool = False,
@@ -132,6 +136,8 @@ def _upgrade_packages(
     from meerschaum.utils.misc import print_options
     if action is None:
         action = []
+    if venv is NoVenv:
+        venv = 'mrsm'
     if len(action) == 0:
         group = 'full'
     else:

--- a/meerschaum/api/_events.py
+++ b/meerschaum/api/_events.py
@@ -9,7 +9,7 @@ Declare FastAPI events in this module (startup, shutdown, etc.).
 import sys, os, time
 from meerschaum.api import app, get_api_connector, get_uvicorn_config, debug, uvicorn_config_path
 from meerschaum.utils.debug import dprint
-from meerschaum.utils.misc import retry_connect
+from meerschaum.connectors.poll import retry_connect
 from meerschaum.utils.threading import Thread
 
 @app.on_event("startup")
@@ -27,10 +27,10 @@ async def startup():
         await shutdown()
         os._exit(1)
 
+
 @app.on_event("shutdown")
 async def shutdown():
     if debug:
         dprint("Closing connection...")
     if get_api_connector().type == 'sql':
         get_api_connector().engine.dispose()
-

--- a/meerschaum/api/_oauth2.py
+++ b/meerschaum/api/_oauth2.py
@@ -31,4 +31,3 @@ def generate_secret_key() -> str:
 
 SECRET = generate_secret_key()
 manager = LoginManager(SECRET, token_url=endpoints['login'])
-

--- a/meerschaum/api/routes/_login.py
+++ b/meerschaum/api/routes/_login.py
@@ -12,7 +12,8 @@ from fastapi.security import OAuth2PasswordRequestForm
 from starlette.responses import Response, JSONResponse
 from meerschaum.api import endpoints, get_api_connector, app, debug, manager, no_auth
 from meerschaum.core import User
-from meerschaum.config.static import _static_config
+from meerschaum.config.static import STATIC_CONFIG
+
 
 @manager.user_loader()
 def load_user(
@@ -22,6 +23,7 @@ def load_user(
     Create the `meerschaum.core.User` object from the username.
     """
     return User(username, instance=get_api_connector())
+
 
 @app.post(endpoints['login'], tags=['Users'])
 def login(
@@ -43,18 +45,15 @@ def login(
     if not correct_password:
         raise InvalidCredentialsException
 
-    expires_minutes = _static_config()['api']['oauth']['token_expires_minutes']
+    expires_minutes = STATIC_CONFIG['api']['oauth']['token_expires_minutes']
     expires_delta = datetime.timedelta(minutes=expires_minutes)
     expires_dt = datetime.datetime.utcnow() + expires_delta
     access_token = manager.create_access_token(
         data = dict(sub=username),
         expires = expires_delta
     )
-    #  response.set_cookie(key="user_id", value=get_api_connector().get_user_id(user))
     return {
         'access_token': access_token,
         'token_type': 'bearer',
         'expires' : expires_dt,
     }
-
-

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -168,18 +168,19 @@ def read_config(
                     except Exception as e:
                         import traceback
                         traceback.print_exc()
-                    _single_key_config = (
-                        search_and_substitute_config({key: _config_key}) if substitute
-                        else {key: _config_key}
-                    )
-                    config[key] = _single_key_config[key]
-                    if (
-                        symlinks_key in _single_key_config
-                            and key in _single_key_config[symlinks_key]
-                    ):
-                        if symlinks_key not in config:
-                            config[symlinks_key] = {}
-                        config[symlinks_key][key] = _single_key_config[symlinks_key][key]
+                        _config_key = {}
+                _single_key_config = (
+                    search_and_substitute_config({key: _config_key}) if substitute
+                    else {key: _config_key}
+                )
+                config[key] = _single_key_config[key]
+                if (
+                    symlinks_key in _single_key_config
+                    and key in _single_key_config[symlinks_key]
+                ):
+                    if symlinks_key not in config:
+                        config[symlinks_key] = {}
+                    config[symlinks_key][key] = _single_key_config[symlinks_key][key]
                 break
             except Exception as e:
                 print(f"Unable to parse {filename}!")

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.1.10"
+__version__ = "1.2.0"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -9,116 +9,123 @@ Insert non-user-editable configuration files here.
 import os
 import uuid
 from meerschaum.utils.misc import generate_password
+
+__all__ = ['STATIC_CONFIG']
+
 SERVER_ID = os.environ.get('MRSM_SERVER_ID', generate_password(6))
-static_config = None
+STATIC_CONFIG = {
+    'api': {
+        'endpoints': {
+            'index': '/',
+            'favicon': '/favicon.ico',
+            'plugins': '/plugins',
+            'pipes': '/pipes',
+            'metadata': '/metadata',
+            'actions': '/actions',
+            'users': '/users',
+            'login': '/login',
+            'connectors': '/connectors',
+            'version': '/version',
+            'chaining': '/chaining',
+            'websocket': '/ws',
+            'dash': '/dash',
+            'term': '/term',
+            'info': '/info',
+        },
+        'oauth': {
+            'token_expires_minutes': 720,
+        },
+    },
+    'environment': {
+        'config': 'MRSM_CONFIG',
+        'patch': 'MRSM_PATCH',
+        'root': 'MRSM_ROOT_DIR',
+        'plugins': 'MRSM_PLUGINS_DIR',
+        'runtime': 'MRSM_RUNTIME',
+        'id': 'MRSM_SERVER_ID',
+        'uri_regex': r'MRSM_(SQL|API)_(\d*[a-zA-Z][a-zA-Z0-9-_+]*$)',
+        'prefix': 'MRSM_',
+    },
+    'config': {
+        'default_filetype': 'json',
+        'symlinks_key': '_symlinks',
+    },
+    'system': {
+        'arguments': {
+            'sub_decorators': (
+                '[',
+                ']'
+            ),
+            'underscore_standin': '<UNDERSCORE>', ### Temporary replacement for parsing.
+        },
+        'urls': {
+            'get-pip.py': 'https://bootstrap.pypa.io/get-pip.py',
+        },
+        'success': {
+            'ignore': (
+                'Success',
+                'success'
+                'Succeeded',
+                '',
+                None,
+            ),
+        },
+        'prompt': {
+            'web': False,
+        },
+        'fetch_pipes_keys': {
+            'negation_prefix': '_',
+        },
+    },
+    'connectors': {
+        'default_label': 'main',
+    },
+    'users': {
+        'password_hash': {
+            'schemes': [
+                'pbkdf2_sha256',
+            ],
+            'default': 'pbkdf2_sha256',
+            'pbkdf2_sha256__default_rounds': 30000,
+        },
+        'min_username_length': 3,
+        'max_username_length': 26,
+        'min_password_length': 5,
+    },
+    'plugins': {
+        'repo_separator': '@',
+        'lock_sleep_total': 1.0,
+        'lock_sleep_increment': 0.1,
+    },
+    'pipes': {
+        'dtypes': {
+            'min_ratio_columns_changed_for_full_astype': 0.5,
+        },
+    },
+    'setup': {
+        'name': 'meerschaum',
+        'formal_name': 'Meerschaum',
+        'app_id': 'io.meerschaum',
+        'description': 'Sync Time-Series Pipes with Meerschaum',
+        'url': 'https://meerschaum.io',
+        'project_urls': {
+            'Documentation': 'https://docs.meerschaum.io',
+            'Changelog': 'https://meerschaum.io/news/changelog',
+            'GitHub': 'https://github.com/bmeares/Meerschaum',
+            'Homepage': 'https://meerschaum.io',
+            'Donate': 'https://github.com/sponsors/bmeares',
+            'Discord': 'https://discord.gg/8U8qMUjvcc',
+        },
+        'author': 'Bennett Meares',
+        'author_email': 'bennett.meares@gmail.com',
+        'maintainer_email': 'bennett.meares@gmail.com',
+        'license': 'Apache Software License 2.0',
+    },
+}
+
 
 def _static_config():
-    global static_config
-    if static_config is None:
-        static_config = {
-            'api': {
-                'endpoints': {
-                    'index': '/',
-                    'favicon': '/favicon.ico',
-                    'plugins': '/plugins',
-                    'pipes': '/pipes',
-                    'metadata': '/metadata',
-                    'actions': '/actions',
-                    'users': '/users',
-                    'login': '/login',
-                    'connectors': '/connectors',
-                    'version': '/version',
-                    'chaining': '/chaining',
-                    'websocket': '/ws',
-                    'dash': '/dash',
-                    'term': '/term',
-                    'info': '/info',
-                },
-                'oauth': {
-                    'token_expires_minutes': 15,
-                },
-            },
-            'environment': {
-                'config': 'MRSM_CONFIG',
-                'patch': 'MRSM_PATCH',
-                'root': 'MRSM_ROOT_DIR',
-                'runtime': 'MRSM_RUNTIME',
-                'id': 'MRSM_SERVER_ID',
-                'uri_regex': r'MRSM_(SQL|API)_(\d*[a-zA-Z][a-zA-Z0-9-_+]*$)',
-                'prefix': 'MRSM_',
-            },
-            'config': {
-                'default_filetype': 'json',
-                'symlinks_key': '_symlinks',
-            },
-            'system': {
-                'arguments': {
-                    'sub_decorators': (
-                        '[',
-                        ']'
-                    ),
-                    'underscore_standin': '<UNDERSCORE>', ### Temporary replacement for parsing.
-                },
-                'urls': {
-                    'get-pip.py': 'https://bootstrap.pypa.io/get-pip.py',
-                },
-                'success': {
-                    'ignore': (
-                        'Success',
-                        'success'
-                        'Succeeded',
-                        '',
-                        None,
-                    ),
-                },
-                'prompt': {
-                    'web': False,
-                },
-                'fetch_pipes_keys': {
-                    'negation_prefix': '_',
-                },
-            },
-            'connectors': {
-                'default_label': 'main',
-            },
-            'users': {
-                'password_hash': {
-                    'schemes': [
-                        'pbkdf2_sha256',
-                    ],
-                    'default': 'pbkdf2_sha256',
-                    'pbkdf2_sha256__default_rounds': 30000,
-                },
-                'min_username_length': 3,
-                'max_username_length': 26,
-                'min_password_length': 5,
-            },
-            'plugins': {
-                'repo_separator': '@',
-            },
-            'pipes': {
-                'dtypes': {
-                    'min_ratio_columns_changed_for_full_astype': 0.5,
-                },
-            },
-            'setup': {
-                'name': 'meerschaum',
-                'formal_name': 'Meerschaum',
-                'app_id': 'io.meerschaum',
-                'description': 'Sync Time-Series Pipes with Meerschaum',
-                'url': 'https://meerschaum.io',
-                'project_urls': {
-                    'Documentation': 'https://docs.meerschaum.io',
-                    'Changelog': 'https://meerschaum.io/news/changelog',
-                    'GitHub': 'https://github.com/bmeares/Meerschaum',
-                    'Homepage': 'https://meerschaum.io',
-                    'Donate': 'https://github.com/sponsors/bmeares',
-                    'Discord': 'https://discord.gg/8U8qMUjvcc',
-                },
-                'author': 'Bennett Meares',
-                'author_email': 'bennett.meares@gmail.com',
-                'maintainer_email': 'bennett.meares@gmail.com',
-                'license': 'Apache Software License 2.0',
-            },
-        }
-    return static_config
+    """
+    Alias function for the global `STATIC_CONFIG` dictionary.
+    """
+    return STATIC_CONFIG

--- a/meerschaum/connectors/api/_login.py
+++ b/meerschaum/connectors/api/_login.py
@@ -56,15 +56,14 @@ def test_connection(
         **kw: Any
     ) -> Union[bool, None]:
     """Test if a successful connection to the API may be made."""
-    from meerschaum.utils.misc import retry_connect
+    from meerschaum.connectors.poll import retry_connect
     _default_kw = {
         'max_retries': 1, 'retry_wait': 0, 'warn': False,
-        'connector': self, 'enforce_chaining': False
+        'connector': self, 'enforce_chaining': False,
+        'enforce_login': False,
     }
     _default_kw.update(kw)
     try:
         return retry_connect(**_default_kw)
     except Exception as e:
         return False
-
-

--- a/meerschaum/connectors/api/_users.py
+++ b/meerschaum/connectors/api/_users.py
@@ -39,14 +39,16 @@ def edit_user(
     ) -> SuccessTuple:
     """Edit an existing user."""
     import json
-    from meerschaum.config.static import _static_config
-    r_url = f"{_static_config()['api']['endpoints']['users']}/{user.username}/edit"
-    params = {
-        'password' : user.password,
-        'email' : user.email,
-        'attributes' : user.attributes,
+    from meerschaum.config.static import STATIC_CONFIG
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['users']}/edit"
+    data = {
+        'username': user.username,
+        'password': user.password,
+        'type': user.type,
+        'email': user.email,
+        'attributes': json.dumps(user.attributes),
     }
-    response = self.post(r_url, json=user.attributes, params=params, debug=debug)
+    response = self.post(r_url, data=data, debug=debug)
     try:
         _json = json.loads(response.text)
         if isinstance(_json, dict) and 'detail' in _json:
@@ -58,6 +60,7 @@ def edit_user(
 
     return tuple(success_tuple)
 
+
 def register_user(
         self,
         user: 'meerschaum.core.User',
@@ -67,13 +70,17 @@ def register_user(
     """Register a new user."""
     import json
     from meerschaum.config.static import _static_config
-    r_url = f"{_static_config()['api']['endpoints']['users']}/{user.username}/register"
-    params = {
-        'password'  : user.password,
-        'email'     : user.email,
-        'attributes': user.attributes,
+    r_url = f"{_static_config()['api']['endpoints']['users']}/register"
+    data = {
+        'username': user.username,
+        'password': user.password,
+        'attributes': json.dumps(user.attributes),
     }
-    response = self.post(r_url, json=user.attributes, params=params, debug=debug)
+    if user.type:
+        data['type'] = user.type
+    if user.email:
+        data['email'] = user.email
+    response = self.post(r_url, data=data, debug=debug)
     try:
         _json = json.loads(response.text)
         if isinstance(_json, dict) and 'detail' in _json:
@@ -84,6 +91,7 @@ def register_user(
         return False, msg
 
     return tuple(success_tuple)
+
     
 def get_user_id(
         self,

--- a/meerschaum/connectors/parse.py
+++ b/meerschaum/connectors/parse.py
@@ -7,7 +7,7 @@ Utility functions for parsing connector keys.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import Mapping, Any, SuccessTuple, Union, Optional, Dict
+from meerschaum.utils.typing import Mapping, Any, SuccessTuple, Union, Optional, Dict, Tuple
 
 def parse_connector_keys(
         keys: str,

--- a/meerschaum/connectors/poll.py
+++ b/meerschaum/connectors/poll.py
@@ -1,0 +1,225 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Poll database and API connections.
+"""
+
+from meerschaum.utils.typing import InstanceConnector, Union, Optional
+
+def retry_connect(
+        connector: Union[InstanceConnector, None] = None,
+        max_retries: int = 50,
+        retry_wait: int = 3,
+        workers: int = 1,
+        warn: bool = True,
+        print_on_connect: bool = False,
+        enforce_chaining: bool = True,
+        enforce_login: bool = True,
+        debug: bool = False,
+    ) -> bool:
+    """
+    Keep trying to connect to the database.
+
+    Parameters
+    ----------
+    connector: Union[InstanceConnector, None], default None
+        The connector to the instance.
+
+    max_retries: int, default 40
+        How many time to try connecting.
+
+    retry_wait: int, default 3
+        The number of seconds between retries.
+
+    workers: int, default 1
+        How many worker thread connections to make.
+
+    warn: bool, default True
+        If `True`, print a warning in case the connection fails.
+
+    print_on_connect: bool, default False
+        If `True`, print a message when a successful connection is established.
+
+    enforce_chaining: bool, default True
+        If `False`, ignore the configured chaining option.
+
+    enforce_login: bool, default True
+        If `False`, ignore an invalid login.
+
+    debug: bool, default False
+        Verbosity toggle.
+
+    Returns
+    -------
+    Whether a connection could be made.
+
+    """
+    import json
+    from meerschaum.utils.venv import venv_exec
+    from meerschaum.utils.packages import attempt_import
+
+    kw = {
+        'connector_keys': str(connector),
+        'max_retries': max_retries,
+        'retry_wait': retry_wait,
+        'workers': workers,
+        'warn': warn,
+        'print_on_connect': print_on_connect,
+        'enforce_chaining': enforce_chaining,
+        'enforce_login': enforce_login,
+        'debug': debug,
+    }
+
+    dill = attempt_import('dill', lazy=False)
+    code = (
+        "import sys, json\n"
+        + "from meerschaum.utils.typing import Optional\n\n"
+        + dill.source.getsource(_wrap_retry_connect) + '\n\n'
+        + f"kw = json.loads({json.dumps(json.dumps(kw))})\n"
+        + "success = _wrap_retry_connect(**kw)\n"
+        + "sys.exit((0 if success else 1))"
+    )
+    return venv_exec(code, venv=None, debug=debug)
+
+
+def _wrap_retry_connect(
+        connector_keys: Optional[str] = None,
+        max_retries: int = 50,
+        retry_wait: int = 3,
+        workers: int = 1,
+        print_on_connect: bool = False,
+        warn: bool = True,
+        enforce_chaining: bool = True,
+        enforce_login: bool = True,
+        debug: bool = False,
+    ) -> bool:
+    """
+    Keep trying to connect to the database.
+
+    Parameters
+    ----------
+    connector_keys: Optional[str], default None
+        The keys of the connector to the instance.
+
+    max_retries: int, default 40
+        How many time to try connecting.
+
+    retry_wait: int, default 3
+        The number of seconds between retries.
+
+    workers: int, default 1
+        How many worker thread connections to make.
+
+    warn: bool, default True
+        If `True`, print a warning in case the connection fails.
+
+    print_on_connect: bool, default False
+        If `True`, print a message when a successful connection is established.
+
+    enforce_chaining: bool, default True
+        If `False`, ignore the configured chaining option.
+
+    enforce_login: bool, default True
+        If `False`, ignore an invalid login.
+
+    debug: bool, default False
+        Verbosity toggle.
+
+    Returns
+    -------
+    Whether a connection could be made.
+
+    """
+    from meerschaum.utils.warnings import warn as _warn, error, info
+    from meerschaum.utils.debug import dprint
+    from meerschaum.connectors.parse import parse_instance_keys
+    from meerschaum.utils.packages import attempt_import
+    from meerschaum.utils.sql import test_queries
+    from meerschaum.utils.misc import timed_input
+    from functools import partial
+    import time
+
+    connector = parse_instance_keys(connector_keys)
+    if connector.type not in ('sql', 'api'):
+        return None
+
+    retries = 0
+    connected, chaining_status = False, None
+    while retries < max_retries:
+        if debug:
+            dprint(f"Trying to connect to '{connector}'...")
+            dprint(f"Attempt ({retries + 1} / {max_retries})")
+
+        if connector.type == 'sql':
+
+            def _connect(_connector):
+                ### Test queries like `SELECT 1`.
+                connect_query = test_queries.get(connector.flavor, test_queries['default'])
+                if _connector.exec(connect_query) is None:
+                    raise Exception("Failed to connect.")
+
+            try:
+                _connect(connector)
+                connected = True
+            except Exception as e:
+                if warn:
+                    print(e)
+                connected = False
+
+        elif connector.type == 'api':
+            ### If the remote instance does not allow chaining, don't even try logging in.
+            if not isinstance(chaining_status, bool):
+                chaining_status = connector.get_chaining_status(debug=debug)
+                if chaining_status is None:
+                    connected = None
+                elif chaining_status is False:
+                    if enforce_chaining:
+                        if warn:
+                            _warn(
+                                f"Meerschaum instance '{connector}' does not allow chaining " +
+                                "and cannot be used as the parent for this instance.",
+                                stack = False
+                            )
+                        return False
+
+                    ### Allow is the option to ignore chaining status.
+                    chaining_status = True
+
+            if chaining_status:
+                connected = (
+                    connector.login(warn=warn, debug=debug)[0]
+                ) if enforce_login else True
+
+                if not connected and warn:
+                    _warn(f"Unable to login to '{connector}'!", stack=False)
+
+        if connected:
+            if print_on_connect:
+                info(f"Connected to '{connector}'.")
+            return True
+
+        if warn:
+            _warn(
+                f"Connection to '{connector}' failed.\n    "
+                + f"Press [Enter] to retry or wait {retry_wait} seconds.",
+                stack = False
+            )
+            if workers and workers > 1:
+                info(
+                    f"To quit, press CTRL-C, then 'q' + [Enter] for each worker"
+                    + f" ({workers})."
+                )
+            info(f"Failed connection attempt ({retries + 1} / {max_retries})")
+
+        try:
+            if retry_wait > 0:
+                text = timed_input(retry_wait)
+                if text in ('q', 'quit', 'pass', 'exit', 'stop'):
+                    return None
+        except KeyboardInterrupt:
+            return None
+        retries += 1
+
+    return False

--- a/meerschaum/connectors/sql/SQLConnector.py
+++ b/meerschaum/connectors/sql/SQLConnector.py
@@ -162,7 +162,7 @@ class SQLConnector(Connector):
 
         self.wait = wait
         if self.wait:
-            from meerschaum.utils.misc import retry_connect
+            from meerschaum.connectors.poll import retry_connect
             retry_connect(connector=self, debug=debug)
 
         if connect:
@@ -210,6 +210,10 @@ class SQLConnector(Connector):
 
     @property
     def DATABASE_URL(self):
+        return str(self.engine.url)
+
+    @property
+    def URI(self):
         return str(self.engine.url)
 
     @property

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -18,7 +18,7 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.formatting import pprint
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.packages import import_pandas
     if df is None:
         if debug:
@@ -95,7 +95,7 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
         return df
 
     if len(common_dtypes) == len(df_dtypes):
-        min_ratio = _static_config()['pipes']['dtypes']['min_ratio_columns_changed_for_full_astype']
+        min_ratio = STATIC_CONFIG['pipes']['dtypes']['min_ratio_columns_changed_for_full_astype']
         if (
             len(common_diff_dtypes) >= int(len(common_dtypes) * min_ratio)
         ):
@@ -135,6 +135,8 @@ def infer_dtypes(self, persist: bool=False, debug: bool=False) -> Dict[str, Any]
     """
     if not self.exists(debug=debug):
         dtypes = {}
+        if not self.columns:
+            return {}
         if 'datetime' in self.columns:
             dtypes[self.columns['datetime']] = 'datetime64[ns]'
         return dtypes

--- a/meerschaum/utils/daemon/Daemon.py
+++ b/meerschaum/utils/daemon/Daemon.py
@@ -192,23 +192,17 @@ class Daemon:
 
         Parameters
         ----------
-        keep_daemon_output :
+        keep_daemon_output: bool, default True
             If `False`, delete the daemon's output directory upon exiting.
-            Defaults to `True`.
-        allow_dirty_run :
+
+        allow_dirty_run: bool, default False
             If `True`, run the daemon, even if the `daemon_id` directory exists.
             This option is dangerous because if the same `daemon_id` runs twice,
             the last to finish will overwrite the output of the first.
-            Defaults to `False`.
-        keep_daemon_output: bool :
-             (Default value = True)
-        allow_dirty_run: bool :
-             (Default value = False)
-        debug: bool :
-             (Default value = False)
 
         Returns
         -------
+        A SuccessTuple indicating success.
 
         """
         self.mkdir_if_not_exists(allow_dirty_run)
@@ -237,6 +231,7 @@ class Daemon:
 
         Returns
         -------
+        A SuccessTuple indicating success.
 
         """
         daemoniker, psutil = attempt_import('daemoniker', 'psutil')
@@ -247,9 +242,9 @@ class Daemon:
         if process is None or not process.is_running():
             return True, "Process has already stopped."
         try:
-            p.terminate()
-            p.kill()
-            p.wait(timeout=10)
+            process.terminate()
+            process.kill()
+            process.wait(timeout=10)
         except Exception as e:
             return False, f"Failed to kill job {self} with exception: {e}"
         return True, "Success"
@@ -273,50 +268,45 @@ class Daemon:
 
     def _send_signal(
             self,
-            signal : daemoniker.DaemonikerSignal,
-            timeout : Optional[Union[float, int]] = 3,
-            check_timeout_interval : float = 0.1,
-        ):
+            signal,
+            timeout: Optional[Union[float, int]] = 3,
+            check_timeout_interval: float = 0.1,
+        ) -> SuccessTuple:
         """Send a signal to the daemon process.
 
         Parameters
         ----------
-        signal :
+        signal:
             The signal the send to the daemon.
             Examples include `daemoniker.SIGINT` and `daemoniker.SIGTERM`.
-        timeout :
+
+        timeout:
             The maximum number of seconds to wait for a process to terminate.
             Defaults to 3.
-        check_timeout_interval :
+
+        check_timeout_interval: float, default 0.1
             The number of seconds to wait between checking if the process is still running.
             Defaults to 0.1.
-        signal : daemoniker.DaemonikerSignal :
-            
-        timeout : Optional[Union[float :
-            
-        int]] :
-             (Default value = 3)
-        check_timeout_interval : float :
-             (Default value = 0.1)
 
         Returns
         -------
-
+        A SuccessTuple indicating success.
         """
         import time
         daemoniker = attempt_import('daemoniker')
 
         try:
-            daemoniker.send(str(self.pid_path), daemoniker.SIGINT)
+            daemoniker.send(str(self.pid_path), signal)
         except Exception as e:
             return False, str(e)
         if timeout is None:
             return True, f"Successfully sent '{signal}' to daemon '{self.daemon_id}'."
-        begin = time.time()
-        while (time.time() - begin) < timeout:
+        begin = time.perf_counter()
+        while (time.perf_counter() - begin) < timeout:
             if not self.pid_path.exists():
                 return True, f"Successfully stopped daemon '{self.daemon_id}'."
             time.sleep(check_timeout_interval)
+
         return False, (
             f"Failed to stop daemon '{self.daemon_id}' within {timeout} second"
             + ('s' if timeout != 1 else '') + '.'
@@ -353,17 +343,8 @@ class Daemon:
 
     def mkdir_if_not_exists(self, allow_dirty_run : bool = False):
         """Create the Daemon's directory.
-        
         If `allow_dirty_run` is `False` and the directory already exists,
-
-        Parameters
-        ----------
-        allow_dirty_run : bool :
-             (Default value = False)
-
-        Returns
-        -------
-
+        raise a `FileExistsError`.
         """
         try:
             self.path.mkdir(parents=True, exist_ok=False)
@@ -384,21 +365,13 @@ class Daemon:
     @property
     def process(self) -> Union['psutil.Process', None]:
         """
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-        type
-            If the job is not running, return `None`.
-
+        Return the psutil process for the Daemon.
         """
         psutil = attempt_import('psutil')
         pid = self.pid
         if pid is None:
             return None
-        if not '_process' in self.__dict__ or self._process.pid != int(pid):
+        if '_process' not in self.__dict__ or self.__dict__['_process'].pid != int(pid):
             try:
                 self._process = psutil.Process(int(pid))
             except Exception as e:
@@ -407,29 +380,40 @@ class Daemon:
                 return None
         return self._process
 
+
     @property
     def path(self) -> pathlib.Path:
-        """ """
+        """
+        Return the path for this Daemon's directory.
+        """
         return DAEMON_RESOURCES_PATH / self.daemon_id
 
     @property
     def properties_path(self):
-        """ """
+        """
+        Return the `propterties.json` path for this Daemon.
+        """
         return self.path / 'properties.json'
 
     @property
     def stdout_path(self):
-        """ """
+        """
+        Return the path to redirect stdout into.
+        """
         return self.log_path
 
     @property
     def stderr_path(self):
-        """ """
+        """
+        Return the path to redirect stderr into.
+        """
         return self.log_path
 
     @property
     def log_path(self):
-        """ """
+        """
+        Return the log path.
+        """
         return LOGS_RESOURCES_PATH / (self.daemon_id + '.log')
 
     @property
@@ -440,35 +424,22 @@ class Daemon:
     def log_text(self) -> Optional[str]:
         """Read the log file and return its contents.
         Returns `None` if the log file does not exist.
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
         """
         if not self.log_path.exists():
             return None
         try:
-            with open(self.log_path, 'r') as f:
+            with open(self.log_path, 'r', encoding='utf-8') as f:
                 text = f.read()
         except Exception as e:
             warn(e)
             text = None
         return text
 
+
     @property
     def pid(self) -> str:
         """Read the PID file and return its contents.
         Returns `None` if the PID file does not exist.
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
         """
         if not self.pid_path.exists():
             return None
@@ -480,25 +451,33 @@ class Daemon:
             text = None
         return text.rstrip('\n') if text is not None else text
 
+
     @property
     def pid_path(self) -> pathlib.Path:
-        """ """
+        """
+        Return the path to a file containing the PID for this Daemon.
+        """
         return self.path / 'process.pid'
+
 
     @property
     def pickle_path(self) -> pathlib.Path:
-        """ """
+        """
+        Return the path for the pickle file.
+        """
         return self.path / 'pickle.pkl'
+
 
     def read_properties(self) -> Optional[Dict[str, Any]]:
         """Read the properties JSON file and return the dictionary."""
         if not self.properties_path.exists():
             return None
         try:
-            with open(self.properties_path, 'r') as file:
+            with open(self.properties_path, 'r', encoding='utf-8') as file:
                 return json.load(file)
         except Exception as e:
             return {}
+
 
     def read_pickle(self) -> Daemon:
         """Read a Daemon's pickle file and return the `Daemon`."""
@@ -517,18 +496,11 @@ class Daemon:
             error(msg)
         return daemon
 
+
     @property
     def properties(self) -> Optional[Dict[str, Any]]:
         """
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-        type
-            read the properties JSON file.
-
+        Return the contents of the properties JSON file.
         """
         _file_properties = self.read_properties()
         if not self._properties:
@@ -542,20 +514,15 @@ class Daemon:
 
     @property
     def hidden(self) -> bool:
-        """ """
+        """
+        Return a bool indicating whether this Daemon should be displayed.
+        """
         return self.daemon_id.startswith('_') or self.daemon_id.startswith('.')
 
 
     def write_properties(self) -> SuccessTuple:
         """Write the properties dictionary to the properties JSON file
         (only if self.properties exists).
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
         """
         success, msg = False, f"No properties to write for daemon '{self.daemon_id}'."
         if self.properties is not None:
@@ -567,6 +534,7 @@ class Daemon:
             except Exception as e:
                 success, msg = False, str(e)
         return success, msg
+
 
     def write_pickle(self) -> SuccessTuple:
         """Write the pickle file for the daemon."""
@@ -581,20 +549,14 @@ class Daemon:
             traceback.print_exception(type(e), e, e.__traceback__)
         return success, msg
 
-    def cleanup(self, keep_logs: bool = False):
+
+    def cleanup(self, keep_logs: bool = False) -> None:
         """Remove a daemon's directory after execution.
 
         Parameters
         ----------
-        keep_logs :
+        keep_logs: bool, default False
             If `True`, skip deleting the daemon's log file.
-            Defaults to `False`.
-        keep_logs: bool :
-             (Default value = False)
-
-        Returns
-        -------
-
         """
         if self.path.exists():
             try:

--- a/meerschaum/utils/daemon/Log.py
+++ b/meerschaum/utils/daemon/Log.py
@@ -14,6 +14,10 @@ from meerschaum.utils.typing import Optional, Union, List
 
 
 class Log:
+    """
+    Manage the offset of a rolling logfile.
+    """
+
     def __init__(
         self,
         file_path: pathlib.Path,
@@ -27,7 +31,7 @@ class Log:
         self._handle = None
 
         if self._offset_file_path.exists() and os.path.getsize(self._offset_file_path):
-            with open(self._offset_file_path, 'r') as f:
+            with open(self._offset_file_path, 'r', encoding='utf-8') as f:
                 self._offset = int(f.readline().strip())
 
 
@@ -71,7 +75,8 @@ class Log:
         import gzip
         if not self._handle or self._handle.closed:
             self._handle = (
-                open(self.file_path, 'r', 1) if not str(self.file_path).endswith('.gz')
+                open(self.file_path, 'r', 1, encoding='utf-8')
+                if not str(self.file_path).endswith('.gz')
                 else gzip.open(self.file_path, 'r')
             )
             self._handle.seek(self._offset)
@@ -81,7 +86,7 @@ class Log:
 
     def _update_offset_file_path(self):
         offset = self._file_handle().tell()
-        with open(self._offset_file_path, 'w') as f:
+        with open(self._offset_file_path, 'w', encoding='utf-8') as f:
             f.write(f"{offset}\n")
         self._since_update = 0
 
@@ -109,4 +114,3 @@ class Log:
 
     def __iter__(self):
         return self
-

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -175,7 +175,7 @@ def string_to_dict(
 
     """
     if params_string == "":
-        return dict()
+        return {}
 
     import json
 
@@ -748,8 +748,7 @@ def timed_input(
     The input string entered by the user.
 
     """
-    from meerschaum.utils.prompt import prompt as _prompt
-    import signal
+    import signal, time
 
     class TimeoutExpired(Exception):
         """Raise this exception when the timeout is reached."""
@@ -762,138 +761,17 @@ def timed_input(
     signal.alarm(seconds) # produce SIGALRM in `timeout` seconds
 
     try:
-        #  return _prompt(prompt, icon=icon, **kw)
         return input(prompt)
     except TimeoutExpired:
         return None
+    except EOFError:
+        try:
+            print(prompt)
+            time.sleep(seconds)
+        except TimeoutExpired:
+            return None
     finally:
         signal.alarm(0) # cancel alarm
-
-
-def retry_connect(
-        connector: Union[InstanceConnector, None] = None,
-        max_retries: int = 40,
-        retry_wait: int = 3,
-        workers: int = 1,
-        warn: bool = True,
-        enforce_chaining: bool = True,
-        debug: bool = False,
-    ) -> bool:
-    """
-    Keep trying to connect to the database.
-
-    Parameters
-    ----------
-    connector: Union[InstanceConnector, None], default None
-        The connector to the instance.
-
-    max_retries: int, default 40
-        How many time to try connecting.
-
-    retry_wait: int, default 3
-        The number of seconds between retries.
-
-    workers: int, default 1
-        How many worker thread connections to make.
-
-    warn: bool, default True
-        If `True`, print a warning in case the connection fails.
-
-    enforce_chaining: bool, default True
-        If False, ignore the configured chaining option.
-
-    debug: bool, default False
-        Verbosity toggle.
-
-    Returns
-    -------
-    Whether a connection could be made.
-
-    """
-    from meerschaum.utils.warnings import warn as _warn, error, info
-    from meerschaum.utils.debug import dprint
-    from meerschaum import get_connector
-    from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.sql import test_queries
-    from functools import partial
-    import time
-
-    ### Get default connector if None is provided.
-    if connector is None:
-        connector = get_connector()
-
-    if connector.type not in ('sql', 'api'):
-        return None
-
-    retries = 0
-    connected, chaining_status = False, None
-    while retries < max_retries:
-        if debug:
-            dprint(f"Trying to connect to '{connector}'...")
-            dprint(f"Attempt ({retries + 1} / {max_retries})")
-
-        if connector.type == 'sql':
-
-            def _connect(_connector):
-                ### Test queries like `SELECT 1`.
-                connect_query = test_queries.get(connector.flavor, test_queries['default'])
-                if _connector.exec(connect_query) is None:
-                    raise Exception("Failed to connect.")
-
-            try:
-                _connect(connector)
-                connected = True
-            except Exception as e:
-                print(e) if warn else None
-                connected = False
-
-        elif connector.type == 'api':
-            ### If the remote instance does not allow chaining, don't even try logging in.
-            if not isinstance(chaining_status, bool):
-                chaining_status = connector.get_chaining_status(debug=debug)
-                if chaining_status is None:
-                    connected = None
-                elif chaining_status is False:
-                    if enforce_chaining:
-                        if warn:
-                            _warn(
-                                f"Meerschaum instance '{connector}' does not allow chaining " +
-                                "and cannot be used as the parent for this instance.",
-                                stack = False
-                            )
-                        return False
-                    else:
-                        ### Allow is the option to ignore chaining status.
-                        chaining_status = True
-            if chaining_status:
-                connected = connector.login(warn=warn, debug=debug)[0]
-                if not connected and warn:
-                    _warn(f"Unable to login to '{connector}'!", stack=False)
-
-        if connected:
-            if debug:
-                dprint("Connection established!")
-            return True
-
-        if warn:
-            _warn(
-                f"Connection failed. Press [Enter] to retry or wait {retry_wait} seconds.",
-                stack = False
-            )
-            info(
-                f"To quit, press CTRL-C, then 'q' + Enter for each worker" +
-                (f" ({workers})." if workers is not None else ".")
-            )
-        try:
-            if retry_wait > 0:
-                text = timed_input(retry_wait)
-                if text in ('q', 'quit', 'pass', 'exit', 'stop'):
-                    return None
-        except KeyboardInterrupt:
-            return None
-        retries += 1
-
-    return False
 
 
 def df_from_literal(

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -161,15 +161,20 @@ def verify_venv(
     """
     Verify that the virtual environment matches the expected state.
     """
-    import pathlib, platform, os, shutil, subprocess
+    import pathlib, platform, os, shutil, subprocess, sys
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
     from meerschaum.utils.process import run_process
     venv_path = VIRTENV_RESOURCES_PATH / venv
     bin_path = venv_path / (
         'bin' if platform.system() != 'Windows' else "Scripts"
     )
-    if not bin_path.exists():
-        init_venv(venv, verify=False, debug=debug)
+    current_python_versioned_name = (
+        'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
+        + ('' if platform.system() != 'Windows' else '.exe')
+    )
+
+    if not bin_path.exists() or current_python_versioned_name not in os.listdir(bin_path):
+        init_venv(venv, verify=False, force=True, debug=debug)
 
     def get_python_version(python_path: pathlib.Path) -> Union[str, None]:
         """
@@ -202,8 +207,24 @@ def verify_venv(
             'python' + major_version + '.' + minor_version
             + ('' if platform.system() != 'Windows' else '.exe')
         )
+
+        ### E.g. python3.10 actually links to Python 3.10.
         if filename == python_versioned_name:
+            real_path = pathlib.Path(os.path.realpath(python_path))
+            if not real_path.exists():
+                #  print(f"Does not exist:\n{python_path}\n->\n{real_path}")
+                python_path.unlink()
+                init_venv(venv, verify=False, force=True, debug=debug)
+                if not python_path.exists():
+                    raise FileNotFoundError(f"Unable to verify Python symlink:\n{python_path}")
+
+            if python_path == real_path:
+                continue
+
+            python_path.unlink()
+            python_path.symlink_to(real_path)
             continue
+
         python_versioned_path = bin_path / python_versioned_name
         if python_versioned_path.exists():
             ### Avoid circular symlinks.
@@ -217,6 +238,7 @@ tried_virtualenv = False
 def init_venv(
         venv: str = 'mrsm',
         verify: bool = True,
+        force: bool = False,
         debug: bool = False,
     ) -> bool:
     """
@@ -230,13 +252,16 @@ def init_venv(
     verify: bool, default True
         If `True`, verify that the virtual environment is in the expected state.
 
+    force: bool, default False
+        If `True`, recreate the virtual environment, even if already initalized.
+
     Returns
     -------
     A `bool` indicating success.
     """
-    if venv in verified_venvs:
+    if not force and venv in verified_venvs:
         return True
-    if venv_exists(venv, debug=debug):
+    if not force and venv_exists(venv, debug=debug):
         if verify:
             verify_venv(venv, debug=debug)
             verified_venvs.add(venv)
@@ -282,7 +307,6 @@ def init_venv(
                 "Failed to import `venv` or `virtualenv`! "
                 + "Please install `virtualenv` via pip then restart Meerschaum."
             )
-            #  sys.exit(1)
             return False
 
         tried_virtualenv = True
@@ -307,8 +331,9 @@ def init_venv(
             import traceback
             traceback.print_exc()
             return False
-    verify_venv(venv, debug=debug)
-    verified_venvs.add(venv)
+    if verify:
+        verify_venv(venv, debug=debug)
+        verified_venvs.add(venv)
     return True
 
 
@@ -338,7 +363,7 @@ def venv_executable(venv: Optional[str] = 'mrsm') -> str:
 
 def venv_exec(
         code: str,
-        venv: str = 'mrsm',
+        venv: Optional[str] = 'mrsm',
         with_extras: bool = False,
         as_proc: bool = False,
         capture_output: bool = True,
@@ -427,7 +452,14 @@ def venv_target_path(
             ### Allow for dist-level paths (running as root).
             if not site_path.exists():
                 if platform.system() == 'Windows' or os.geteuid() == 0:
-                    return pathlib.Path(site.getsitepackages()[-1])
+                    for possible_dist in reversed(site.getsitepackages()):
+                        dist_path = pathlib.Path(possible_dist)
+                        if not dist_path.exists():
+                            continue
+                        return dist_path
+                    
+                    raise EnvironmentError("Could not determine the dist-packages directory.")
+
             return site_path
 
     venv_root_path = (

--- a/scripts/docker/image_setup.sh
+++ b/scripts/docker/image_setup.sh
@@ -9,7 +9,7 @@ groupadd -r $MRSM_USER \
   && chown -R $MRSM_USER $MRSM_ROOT_DIR \
   && chown -R $MRSM_USER $MRSM_WORK_DIR
 
-### We need doas to switch from root to the user.
+### We need sudo to switch from root to the user.
 apt-get update && apt-get install sudo -y --no-install-recommends
 
 ### Install user-level build tools.

--- a/scripts/drivers.sh
+++ b/scripts/drivers.sh
@@ -1,0 +1,75 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+. "$DIR"/config.sh
+cd "$PARENT"
+
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root.";
+  exit 1;
+fi
+
+if [ -z "$DISTRO" ]; then
+  DISTRO="$(lsb_release -si)";
+fi
+
+install_mssql_ubuntu(){
+  if ! [[ "18.04 20.04 22.04" == *"$(lsb_release -rs)"* ]]; then
+    echo "Ubuntu $(lsb_release -rs) is not currently supported for MSSQL ODBC.";
+    exit 1;
+  fi
+  curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+  curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list > /etc/apt/sources.list.d/mssql-release.list
+  apt-get update
+  ACCEPT_EULA=Y apt-get install -y msodbcsql18
+  apt-get install -y unixodbc-dev
+}
+
+
+install_mssql_fedora(){
+  curl https://packages.microsoft.com/config/rhel/8/prod.repo > /etc/yum.repos.d/mssql-release.repo
+  yum remove unixODBC-utf16 unixODBC-utf16-devel
+  ACCEPT_EULA=Y yum install -y msodbcsql18
+  yum install -y unixODBC-devel
+}
+
+
+install_oracle_ubuntu(){
+  add-apt-repository universe
+  apt-get update
+  apt-get install -y alien
+
+  if [ ! -f /tmp/_oracle.rpm ]; then
+    curl https://download.oracle.com/otn_software/linux/instantclient/217000/oracle-instantclient-basic-21.7.0.0.0-1.el8.x86_64.rpm \
+      -o /tmp/_oracle.rpm
+  fi
+  alien -i /tmp/_oracle.rpm
+}
+
+
+install_oracle_fedora(){
+  if [ ! -f /tmp/_oracle.rpm ]; then
+    curl https://download.oracle.com/otn_software/linux/instantclient/217000/oracle-instantclient-basic-21.7.0.0.0-1.el8.x86_64.rpm \
+      -o /tmp/_oracle.rpm
+  fi
+  yum install /tmp/_oracle.rpm
+}
+
+case $DISTRO in
+  Ubuntu)
+    install_mssql_ubuntu;
+    install_oracle_ubuntu;
+    ;;
+  Debian)
+    install_mssql_ubuntu;
+    install_oracle_ubuntu;
+    ;;
+  Fedora)
+    install_mssql_fedora;
+    install_oracle_fedora;
+    ;;
+  CentOS)
+    install_mssql_fedora;
+    install_oracle_fedora;
+    ;;
+esac

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,12 +7,13 @@ cd "$PARENT"
 ### Install python packages.
 
 reqs_file="/tmp/mrsm_dev_setup_reqs.txt"
-python -m pip install wheel
+python -m meerschaum install package wheel --venv None --debug
 python -m meerschaum show packages dev-tools --nopretty > "$reqs_file"
 python -m meerschaum show packages docs --nopretty >> "$reqs_file"
 python -m pip install --upgrade -r "$reqs_file" || exit 1
-### Install pdoc3 outside of the declared docs dependencies.
+### Install pdoc3 and docker-compose outside of the declared docs dependencies.
 python -m pip install pdoc3 || exit 1
+python -m pip install docker-compose || exit 1
 rm -f "$reqs_file"
 
 ### Install Meerschaum plugins.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,34 +7,52 @@ cd "$PARENT"
 test_root="$PARENT/test_root"
 mkdir -p "$test_root"
 test_port="8989"
+export MRSM_ROOT_DIR=$test_root
 
 ### Start the test databases.
 if [ "$1" == "db" ]; then
   cd tests/
   docker-compose up -d
-  echo "Sleeping for 15 seconds..."
-  sleep 15
   cd ../
 fi
 
 ### Install the `stress` plugin.
-MRSM_ROOT_DIR="$test_root" python -m meerschaum install plugin stress
+python -m meerschaum install plugin stress
 
 ### Start the test API.
 api_exists=$(MRSM_ROOT_DIR="$test_root" python -m meerschaum show jobs test_api --nopretty)
 if [ "$api_exists" != "test_api" ]; then
-  MRSM_ROOT_DIR="$test_root" python -m meerschaum start api \
+  python -m meerschaum start api \
     -w 1 -p $test_port --name test_api -y -d -i sql:memory
 else
-  MRSM_ROOT_DIR="$test_root" python -m meerschaum start jobs test_api -y
+  python -m meerschaum start jobs test_api -y
 fi
-MRSM_ROOT_DIR="$test_root" python -m meerschaum start jobs test_api -y
-echo "Sleeping for 4 seconds..."
-sleep 4
+python -m meerschaum start jobs test_api -y
+MRSM_API_TEST=http://user:pass@localhost:$test_port python -m meerschaum start connectors api:test
+python -m meerschaum start jobs test_api -y
 
+### This is necessary to trigger installations in a clean environment.
+python -c "
+from tests.connectors import conns
+[conn.URI for conn in conns.values()]
+"
+
+MRSM_CONNS=$(python -c "
+from tests.connectors import conns
+print(' '.join([str(c) for c in conns.values()]))")
+
+MRSM_URIS=$(python -c "
+from tests.connectors import conns
+print(' '.join([
+  'MRSM_' + c.type.upper() + '_' + c.label.upper() + '=' + c.URI
+  for c in conns.values()
+]))")
+export $MRSM_URIS
+
+python -m meerschaum start connectors $MRSM_CONNS
 
 ### Execute the pytest tests.
-MRSM_ROOT_DIR="$test_root" python -m pytest \
+python -m pytest \
   --durations=0 \
   --ignore=portable/ --ignore=test_root/ --ignore=tests/data/ --ignore=docs/; rc="$?"
 
@@ -43,7 +61,7 @@ if [ "$2" == "rm" ]; then
   cd tests/
   docker-compose down -v
   cd ../
-  MRSM_ROOT_DIR="$test_root" python -m meerschaum delete job test_api -f -y
+  python -m meerschaum delete job test_api -f -y
 fi
 
 exit "$rc"

--- a/tests/connectors.py
+++ b/tests/connectors.py
@@ -24,7 +24,7 @@ conns = {
     #  'cockroachdb': get_connector('sql', 'test_cockroachdb',
         #  flavor='cockroachdb', host='localhost', port=26259,
     #  ),
-    'oracle': get_connector('sql', 'oracle_test',
+    'oracle': get_connector('sql', 'test_oracle',
         flavor='oracle', host='localhost', database='xe', username='system', password='oracle',
         port=1529,
     ),
@@ -40,7 +40,7 @@ conns = {
         flavor='citus', username='test', password='test1234', database='testdb',
         port=5499, host='localhost',
     ),
-    'api': get_connector('api', 'test_timescaledb_api',
+    'api': get_connector('api', 'test_api',
         port=8989, username='test', password='test1234', host='localhost',
     ),
 }

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -3,7 +3,7 @@ volumes:
   timescaledb_volume:
   mssql_volume:
   mariadb_volume:
-  cockroachdb_volume:
+  # cockroachdb_volume:
   oracle_volume:
   citus_healthcheck_volume:
 services:
@@ -39,13 +39,13 @@ services:
       - 3309:3306
     volumes:
       - mariadb_volume:/var/lib/mysql:z
-  cockroachdb:
-    image: cockroachdb/cockroach:v21.1.2
-    ports:
-      - 26259:26257
-    command: start-single-node --insecure
-    volumes:
-      - cockroachdb_volume:/cockroach/cockroach-data:z
+  # cockroachdb:
+    # image: cockroachdb/cockroach:v21.1.2
+    # ports:
+      # - 26259:26257
+    # command: start-single-node --insecure
+    # volumes:
+      # - cockroachdb_volume:/cockroach/cockroach-data:z
   oracle:
     image: konnecteam/docker-oracle-12c:sequelize
     ports:


### PR DESCRIPTION
# v1.2.0

**Improvements**

- **Added the action `start connectors`.**  
  This command allows you to wait until all of the specified connectors are available and accepting connections. This feature is very handy when paired with the new `MRSM_SQL_X` URI environment variables.

- **Added `MRSM_PLUGINS_DIR`.**  
  This one's been on my to-do list for quite a bit! You can now place your plugins in a dedicated, version-controlled directory outside of your root directory.
  
  Like `MRSM_ROOT_DIR`, specify a path with the environment variable `MRSM_PLUGINS_DIR`:

  ```bash
  MRSM_PLUGINS_DIR=plugins \
    mrsm show plugins
  ```

- **Allow for symlinking in URI environment variables.**  
  You may now reference configuration keys within URI variables:

  ```bash
  MRSM_SQL_FOO=postgresql://user:MRSM{meerschaum:connectors:sql:main:password}@localhost:5432/db
  ```

- **Increased token expiration window to 12 hours.**  
  This should reduce the number of login requests needed.

- **Improved virtual environment verification.**  
  More edge cases have been addressed.

- **Symlink Meerschaum into `Plugin` virtual environments.**  
  If plugins do not specify `Meerschaum` in the `required` list, Meerschaum will be symlinked to the currently running package.

**Breaking changes**

- **API endpoints for registering and editing users changed.**  
  To comply with OAuth2 convention, the API endpoint for registering a user is now a url-encoded form submission to `/users/register` (`/user/edit` for editing).

    ***You must upgrade both the server and client to v1.2.0+ to login to your API instances.***

- **Replaced `meerschaum.utils.sql.update_query()` with `meerschaum.utils.sql.get_update_queries()`.**  
  The new function returns a list of query strings rather than a single query. These queries are executed within a single transaction.

**Bugfixes**

- **Removed version enforcement in `pip_install()`.**  
  This changed behavior allows for custom version constraints to be specified in Meerschaum plugins.

- **Backported `UPDATE FROM` query for older versions of SQLite.**  
  The current mutable data logic uses an `UPDATE FROM` query, but this syntax is only present in versions of SQLite greater than 3.33.0 (released 2020-08-14). This releases splits the same logic into `DELETE` and `INSERT` queries for older versions of SQLite.

- **Fixed missing suggestions for shell-only commands.**  
  Completions for commands like `instance` are now suggested.

- **Fixed an issue with killing background jobs.**  
  The signals were not being sent correctly, so this release includes better job process management.

- **Install from `requirements.txt` if `required` is not present.**
- **Fixed issue with custom actions with underscores on the Web UI.**