### PR TITLE
🔖 v1.2.1 Added `@make_connector` and allow for omitting datetime columns.

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ on:
       - staging
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@
 
 This is the current release cycle, so future features will be updated below.
 
+### v1.2.1
+
+- **Added the `@make_connector` decorator.**  
+  Plugins may now extend the base `Connector` class to provide custom connectors. For most cases, the built-in `plugin` connector should work fine. This addition opens up the internal connector system so that plugin authors may now add new types. See below for a minimal example of a new connector class:
+
+  ```python
+  # ~/.config/meerschaum/plugins/example.py
+
+  from meerschaum.connectors import make_connector, Connector
+
+  REQUIRED_ATTRIBUTES = {'username', 'password'}
+
+  @make_connector
+  class FooConnector(Connector):
+      
+      def __init__(self, label: str, **kw):
+          """
+          Instantiate the base class and verify the required attributes are present.
+          """
+          kw['label'] = label
+          super().__init__('foo', **kw)
+          self.verify_attributes(REQUIRED_ATTRIBUTES)
+
+      
+      def fetch(self, pipe, **kw):
+          """
+          Return a dataframe (or list of dicts / dict of lists).
+          The same as you would in a regular fetch plugin, except that now
+          we can store configuration within the connector itself.
+          """
+          return [{self.username: '2020-01-01'}]
+  ```
+
+- **Allow for omitting `datetime` column index.**  
+  The `datetime` column name is still highly recommended, but recent changes have allowed pipes to be synced without a dedicated datetime axis. Plenty of warnings will be thrown if you sync your pipes without specifying a datetime index. If a datetime column can be found, it will be used as the index.
+
+  ```python
+  import meerschaum as mrsm
+  ### This will work but throw warnings.
+  mrsm.Pipe('foo', 'bar').sync([{'a': 1}])
+  ```
+
 ### v1.2.0
 
 **Improvements**

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,48 @@
 
 This is the current release cycle, so future features will be updated below.
 
+### v1.2.1
+
+- **Added the `@make_connector` decorator.**  
+  Plugins may now extend the base `Connector` class to provide custom connectors. For most cases, the built-in `plugin` connector should work fine. This addition opens up the internal connector system so that plugin authors may now add new types. See below for a minimal example of a new connector class:
+
+  ```python
+  # ~/.config/meerschaum/plugins/example.py
+
+  from meerschaum.connectors import make_connector, Connector
+
+  REQUIRED_ATTRIBUTES = {'username', 'password'}
+
+  @make_connector
+  class FooConnector(Connector):
+      
+      def __init__(self, label: str, **kw):
+          """
+          Instantiate the base class and verify the required attributes are present.
+          """
+          kw['label'] = label
+          super().__init__('foo', **kw)
+          self.verify_attributes(REQUIRED_ATTRIBUTES)
+
+      
+      def fetch(self, pipe, **kw):
+          """
+          Return a dataframe (or list of dicts / dict of lists).
+          The same as you would in a regular fetch plugin, except that now
+          we can store configuration within the connector itself.
+          """
+          return [{self.username: '2020-01-01'}]
+  ```
+
+- **Allow for omitting `datetime` column index.**  
+  The `datetime` column name is still highly recommended, but recent changes have allowed pipes to be synced without a dedicated datetime axis. Plenty of warnings will be thrown if you sync your pipes without specifying a datetime index. If a datetime column can be found, it will be used as the index.
+
+  ```python
+  import meerschaum as mrsm
+  ### This will work but throw warnings.
+  mrsm.Pipe('foo', 'bar').sync([{'a': 1}])
+  ```
+
 ### v1.2.0
 
 **Improvements**

--- a/meerschaum/actions/clear.py
+++ b/meerschaum/actions/clear.py
@@ -93,6 +93,31 @@ def _ask_with_rowcounts(
     """
     from meerschaum.utils.prompt import yes_no
     from meerschaum.utils.misc import print_options
+    from meerschaum.utils.warnings import warn
+    for pipe in pipes:
+        if not pipe.columns or 'datetime' not in pipe.columns:
+            _dt = pipe.guess_datetime()
+            is_guess = True
+        else:
+            _dt = pipe.get_columns('datetime')
+            is_guess = False
+
+        if begin is not None or end is not None:
+            if is_guess:
+                if _dt is None:
+                    warn(
+                        f"No datetime could be determined for {pipe}!\n"
+                        + "    THIS WILL DELETE THE ENTIRE TABLE!",
+                        stack = False
+                    )
+                else:
+                    warn(
+                        f"A datetime wasn't specified for {pipe}.\n"
+                        + f"    Using column \"{_dt}\" for datetime bounds...",
+                        stack = False
+                    )
+
+
     pipes_rowcounts = {p: p.get_rowcount(begin=begin, end=end, debug=debug) for p in pipes} 
     print_options(
         [str(p) + f'\n{rc}\n' for p, rc in pipes_rowcounts.items()],

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -97,6 +97,7 @@ class Pipe:
         parents,
         target,
         _target_legacy,
+        guess_datetime,
     )
     from ._show import show
     from ._edit import edit, edit_definition

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -110,7 +110,7 @@ def dtypes(self) -> Union[Dict[str, Any], None]:
     If defined, return the `dtypes` dictionary defined in `meerschaum.Pipe.parameters`.
     """
     if self.parameters is None or self.parameters.get('dtypes', None) is None:
-        if '_dtypes' in self.__dict__:
+        if self.__dict__.get('_dtypes', None):
             return self._dtypes
         self._dtypes = self.infer_dtypes(persist=False)
         return self._dtypes
@@ -130,21 +130,21 @@ def dtypes(self, _dtypes: Dict[str, Any]) -> None:
         self._parameters['dtypes'] = _dtypes
 
 
-def get_columns(self, *args: str, error : bool = True) -> Tuple[str]:
+def get_columns(self, *args: str, error: bool = True) -> Union[str, Tuple[str]]:
     """
     Check if the requested columns are defined.
 
     Parameters
     ----------
-    *args : str :
+    *args: str
         The column names to be retrieved.
         
-    error : bool, default True:
+    error: bool, default True
         If `True`, raise an `Exception` if the specified column is not defined.
 
     Returns
     -------
-    A tuple of the same size of `args`.
+    A tuple of the same size of `args` or a `str` if `args` is a single argument.
 
     Examples
     --------
@@ -180,7 +180,7 @@ def get_columns_types(self, debug: bool = False) -> Union[Dict[str, str], None]:
 
     Parameters
     ----------
-    debug : bool, default False:
+    debug: bool, default False:
         Verbosity toggle.
 
     Returns
@@ -363,3 +363,14 @@ def target(self, _target: str) -> None:
         self._parameters['target'] = _target
 
 
+def guess_datetime(self) -> Union[str, None]:
+    """
+    Try to determine a pipe's datetime column.
+    """
+    dt_cols = [
+        col for col, typ in self.dtypes.items()
+        if typ.startswith('datetime')
+    ]
+    if not dt_cols:
+        return None
+    return dt_cols[0]    

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -10,6 +10,7 @@ from meerschaum.utils.typing import (
     Union, Mapping, Any, Callable, Optional, List, Dict, SuccessTuple, Iterable, PipesDict, Tuple,
     InstanceConnector,
 )
+import meerschaum as mrsm
 
 def add_method_to_class(
         func: Callable[[Any], Any],
@@ -1611,8 +1612,8 @@ def separate_negation_values(
         If `None`, use the system default (`_`).
     """
     if negation_prefix is None:
-        from meerschaum.config.static import _static_config
-        negation_prefix = _static_config()['system']['fetch_pipes_keys']['negation_prefix']
+        from meerschaum.config.static import STATIC_CONFIG
+        negation_prefix = STATIC_CONFIG['system']['fetch_pipes_keys']['negation_prefix']
     _in_vals, _ex_vals = [], []
     for v in vals:
         if str(v).startswith(negation_prefix):
@@ -1632,4 +1633,3 @@ def flatten_list(list_: List[Any]) -> List[Any]:
             yield from flatten_list(item)
         else:
             yield item
-

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -407,7 +407,7 @@ def determine_version(
         try:
             os.chdir(module_parent_dir)
             _version = importlib_metadata.metadata(import_name)['Version']
-        except KeyError:
+        except Exception as e:
             _version = None
         finally:
             os.chdir(old_cwd)

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -119,6 +119,7 @@ packages: Dict[str, Dict[str, str]] = {
         'pandasgui'                  : 'pandasgui>=0.2.9',      
         'modin'                      : 'modin[ray]>=0.8.3',
         'nanoid'                     : 'nanoid>=2.0.0',
+        'importlib_metadata'         : 'importlib-metadata>=4.12.0',
     },
 }
 packages['sql'] = {

--- a/meerschaum/utils/pool.py
+++ b/meerschaum/utils/pool.py
@@ -29,22 +29,23 @@ def get_pool(
     """If the requested pool does not exist, instantiate it here.
     Pools are joined and closed on exit."""
     global pools
-    if pools is None:
-        with _locks['pools']:
+    with _locks['pools']:
+        if pools is None:
             pools = {}
 
     def build_pool(workers):
         from meerschaum.utils.warnings import warn
         from meerschaum.utils.packages import attempt_import
+        import importlib
         try:
             Pool = getattr(
-                attempt_import('multiprocessing.pool', warn=False, venv=None, lazy=False),
+                importlib.import_module('multiprocessing.pool'),
                 pool_class_name
             )
         except Exception as e:
             warn(e, stacklevel=3)
             Pool = getattr(
-                attempt_import('multiprocessing.pool', warn=False, venv=None, lazy=False),
+                importlib.import_module('multiprocessing.pool'),
                 'ThreadPool'
             )
 

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -176,8 +176,9 @@ def verify_venv(
     if not bin_path.exists() or current_python_versioned_name not in os.listdir(bin_path):
         init_venv(venv, verify=False, force=True, debug=debug)
         current_python_in_venv_path = pathlib.Path(venv_executable(venv=venv))
-        current_python_in_sys = pathlib.Path(venv_executable(venv=None))
-        current_python_in_sys.symlink_to(current_python_in_venv_path)
+        current_python_in_sys_path = pathlib.Path(venv_executable(venv=None))
+        if not current_python_in_venv_path.exists():
+            current_python_in_venv_path.symlink_to(current_python_in_sys_path)
 
     def get_python_version(python_path: pathlib.Path) -> Union[str, None]:
         """

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -175,6 +175,9 @@ def verify_venv(
 
     if not bin_path.exists() or current_python_versioned_name not in os.listdir(bin_path):
         init_venv(venv, verify=False, force=True, debug=debug)
+        current_python_in_venv_path = pathlib.Path(venv_executable(venv=venv))
+        current_python_in_sys = pathlib.Path(venv_executable(venv=None))
+        current_python_in_sys.symlink_to(current_python_in_venv_path)
 
     def get_python_version(python_path: pathlib.Path) -> Union[str, None]:
         """

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_kw_args = {
     'author_email'                  : setup_cf['author_email'],
     'maintainer_email'              : setup_cf['maintainer_email'],
     'license'                       : setup_cf['license'],
-    'packages'                      : setuptools.find_packages(exclude=['*tests*']),
+    'packages'                      : ['meerschaum'],
     'install_requires'              : extras['required'],
     'extras_require'                : extras,
     'entry_points'                  : {

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_kw_args = {
     'author_email'                  : setup_cf['author_email'],
     'maintainer_email'              : setup_cf['maintainer_email'],
     'license'                       : setup_cf['license'],
-    'packages'                      : ['meerschaum'],
+    'packages'                      : setuptools.find_packages(exclude=['*test*']),
     'install_requires'              : extras['required'],
     'extras_require'                : extras,
     'entry_points'                  : {


### PR DESCRIPTION
# v1.2.1

- **Added the `@make_connector` decorator.**  
  Plugins may now extend the base `Connector` class to provide custom connectors. For most cases, the built-in `plugin` connector should work fine. This addition opens up the internal connector system so that plugin authors may now add new types. See below for a minimal example of a new connector class:

  ```python
  # ~/.config/meerschaum/plugins/example.py

  from meerschaum.connectors import make_connector, Connector

  REQUIRED_ATTRIBUTES = {'username', 'password'}

  @make_connector
  class FooConnector(Connector):
      
      def __init__(self, label: str, **kw):
          """
          Instantiate the base class and verify the required attributes are present.
          """
          kw['label'] = label
          super().__init__('foo', **kw)
          self.verify_attributes(REQUIRED_ATTRIBUTES)

      
      def fetch(self, pipe, **kw):
          """
          Return a dataframe (or list of dicts / dict of lists).
          The same as you would in a regular fetch plugin, except that now
          we can store configuration within the connector itself.
          """
          return [{self.username: '2020-01-01'}]
  ```

- **Allow for omitting `datetime` column index.**  
  The `datetime` column name is still highly recommended, but recent changes have allowed pipes to be synced without a dedicated datetime axis. Plenty of warnings will be thrown if you sync your pipes without specifying a datetime index. If a datetime column can be found, it will be used as the index.

  ```python
  import meerschaum as mrsm
  ### This will work but throw warnings.
  mrsm.Pipe('foo', 'bar').sync([{'a': 1}])
  ```