### PR TITLE
v1.3.0: Dynamic Columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,82 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.0
+### v1.3.0: Dynamic Columns
 
 **Improvements**
 
+  - **Syncing now handles dynamic columns.**  
+    Syncing a pipe with new columns will trigger an `ALTER TABLE` query to append the columns to your table:
+
+    ```python
+    import meerschaum as mrsm
+    pipe = mrsm.Pipe('foo', 'bar', instance='sql:memory')
+    
+    pipe.sync([{'a': 1}])
+    print(pipe.get_data())
+    #    a
+    # 0  1
+
+    pipe.sync([{'b': 1}])
+    print(pipe.get_data())
+    #       a     b
+    # 0     1  <NA>
+    # 1  <NA>     1
+    ```
+
+    If you've specified index columns, you can use this feature to fill in `NULL` values in your table:
+
+    ```python
+    import meerschaum as mrsm
+    pipe = mrsm.Pipe(
+        'foo', 'bar',
+        columns = {'id': 'id_col'},
+        instance = 'sql:memory',
+    )
+
+    pipe.sync([{'id_col': 1, 'a': 10.0}])
+    pipe.sync([{'id_col': 1, 'b': 20.0}])
+
+    print(pipe.get_data())
+    #    id_col     a     b
+    # 0       1  10.0  20.0
+    ```
+
+  - **Add as many indices as you like.**  
+    In addition to the special index column labels `datetime`, `id`, and `value`, the values of all keys within the `Pipe.columns` dictionary will be treated as indices when creating and updating tables:
+
+    ```python
+    import meerschaum as mrsm
+    indices = {'micro': 'station', 'macro': 'country'}
+    pipe = mrsm.Pipe('demo', 'weather', columns=indices, instance='sql:memory')
+
+    docs = [{'station': 1, 'country': 'USA', 'temp_f': 80.6}]
+    pipe.sync(docs)
+
+    docs = [{'station': 1, 'country': 'USA', 'temp_c': 27.0}]
+    pipe.sync(docs)
+
+    print(pipe.get_data())
+    #    station  country  temp_f  temp_c
+    # 0        1      USA    80.6    27.0
+    ```
+
   - **Added a default 60-second timeout for pipe attributes.**  
-    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the database every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the instance every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+
+  - **Added custom indices and Pandas data types to the Web UI.**
 
 **Breaking Changes**
   
   - **Removed `None` as default for uninitalized properties for pipes.**  
-    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a value, even if a pipe is not registered.
+    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a dictionary, even if a pipe is not registered.
   - **`Pipe.get_columns()` now sets `error` to `False` by default.**  
-    This fixes several breaking datetime checks, such as `Pipe.get_sync_time()`.
+    Pipes are now mostly index-agnostic, so these checks are no longer needed. This downgrades errors in several functions to just warnings, e.g. `Pipe.get_sync_time()`.
 
 **Bugfixes**
 
-  - 
+  - **Always quote tables that begin with underscores in Oracle.**
+  - **Always refresh the metadata when grabbing `sqlalchemy` tables for pipes to account for dynamic state.**
 
 ## 1.2.x Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,35 @@
 # 🪵 Changelog
 
+## 1.3.x Releases
+
+This is the current release cycle, so stay tuned for future releases!
+
+### v1.3.0
+
+**Improvements**
+
+  - **Added a default 60-second timeout for pipe attributes.**  
+    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the database every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+
+**Breaking Changes**
+  
+  - **Removed `None` as default for uninitalized properties for pipes.**  
+    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a value, even if a pipe is not registered.
+  - **`Pipe.get_columns()` now sets `error` to `False` by default.**  
+    This fixes several breaking datetime checks, such as `Pipe.get_sync_time()`.
+
+**Bugfixes**
+
+  - 
+
 ## 1.2.x Releases
 
-This is the current release cycle, so future features will be updated below.
+This series brought many industry-ready features, such as the `@make_connector` decorator, improvements to the virtual environment system, the environment variable `MRSM_PLUGINS_DIR`, and much more.
+
+### v1.2.9
+
+- **Added support for Windows junctions for virtual environments.**  
+  This included many changes to fix functionality on Windows. For example, the addition of the `MRSM_PLUGINS_DIR` environment variable broke Meerschaum on Windows, because Windows requires administrator rights to create symlinks.
 
 ### v1.2.8
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,23 +4,82 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.0
+### v1.3.0: Dynamic Columns
 
 **Improvements**
 
+  - **Syncing now handles dynamic columns.**  
+    Syncing a pipe with new columns will trigger an `ALTER TABLE` query to append the columns to your table:
+
+    ```python
+    import meerschaum as mrsm
+    pipe = mrsm.Pipe('foo', 'bar', instance='sql:memory')
+    
+    pipe.sync([{'a': 1}])
+    print(pipe.get_data())
+    #    a
+    # 0  1
+
+    pipe.sync([{'b': 1}])
+    print(pipe.get_data())
+    #       a     b
+    # 0     1  <NA>
+    # 1  <NA>     1
+    ```
+
+    If you've specified index columns, you can use this feature to fill in `NULL` values in your table:
+
+    ```python
+    import meerschaum as mrsm
+    pipe = mrsm.Pipe(
+        'foo', 'bar',
+        columns = {'id': 'id_col'},
+        instance = 'sql:memory',
+    )
+
+    pipe.sync([{'id_col': 1, 'a': 10.0}])
+    pipe.sync([{'id_col': 1, 'b': 20.0}])
+
+    print(pipe.get_data())
+    #    id_col     a     b
+    # 0       1  10.0  20.0
+    ```
+
+  - **Add as many indices as you like.**  
+    In addition to the special index column labels `datetime`, `id`, and `value`, the values of all keys within the `Pipe.columns` dictionary will be treated as indices when creating and updating tables:
+
+    ```python
+    import meerschaum as mrsm
+    indices = {'micro': 'station', 'macro': 'country'}
+    pipe = mrsm.Pipe('demo', 'weather', columns=indices, instance='sql:memory')
+
+    docs = [{'station': 1, 'country': 'USA', 'temp_f': 80.6}]
+    pipe.sync(docs)
+
+    docs = [{'station': 1, 'country': 'USA', 'temp_c': 27.0}]
+    pipe.sync(docs)
+
+    print(pipe.get_data())
+    #    station  country  temp_f  temp_c
+    # 0        1      USA    80.6    27.0
+    ```
+
   - **Added a default 60-second timeout for pipe attributes.**  
-    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the database every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the instance every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+
+  - **Added custom indices and Pandas data types to the Web UI.**
 
 **Breaking Changes**
   
   - **Removed `None` as default for uninitalized properties for pipes.**  
-    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a value, even if a pipe is not registered.
+    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a dictionary, even if a pipe is not registered.
   - **`Pipe.get_columns()` now sets `error` to `False` by default.**  
-    This fixes several breaking datetime checks, such as `Pipe.get_sync_time()`.
+    Pipes are now mostly index-agnostic, so these checks are no longer needed. This downgrades errors in several functions to just warnings, e.g. `Pipe.get_sync_time()`.
 
 **Bugfixes**
 
-  - **Fix tables that begin with underscores in Oracle.**
+  - **Always quote tables that begin with underscores in Oracle.**
+  - **Always refresh the metadata when grabbing `sqlalchemy` tables for pipes to account for dynamic state.**
 
 ## 1.2.x Releases
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -20,7 +20,7 @@ This is the current release cycle, so stay tuned for future releases!
 
 **Bugfixes**
 
-  - 
+  - **Fix tables that begin with underscores in Oracle.**
 
 ## 1.2.x Releases
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -1,8 +1,35 @@
 # 🪵 Changelog
 
+## 1.3.x Releases
+
+This is the current release cycle, so stay tuned for future releases!
+
+### v1.3.0
+
+**Improvements**
+
+  - **Added a default 60-second timeout for pipe attributes.**  
+    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the database every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.
+
+**Breaking Changes**
+  
+  - **Removed `None` as default for uninitalized properties for pipes.**  
+    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a value, even if a pipe is not registered.
+  - **`Pipe.get_columns()` now sets `error` to `False` by default.**  
+    This fixes several breaking datetime checks, such as `Pipe.get_sync_time()`.
+
+**Bugfixes**
+
+  - 
+
 ## 1.2.x Releases
 
-This is the current release cycle, so future features will be updated below.
+This series brought many industry-ready features, such as the `@make_connector` decorator, improvements to the virtual environment system, the environment variable `MRSM_PLUGINS_DIR`, and much more.
+
+### v1.2.9
+
+- **Added support for Windows junctions for virtual environments.**  
+  This included many changes to fix functionality on Windows. For example, the addition of the `MRSM_PLUGINS_DIR` environment variable broke Meerschaum on Windows, because Windows requires administrator rights to create symlinks.
 
 ### v1.2.8
 

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -119,6 +119,9 @@ default_pipes_config       = {
             'id'           : None,
         },
     },
+    'attributes'           : {
+        'local_cache_timeout_seconds': 60,
+    },
 }
 default_plugins_config     = {}
 default_experimental_config = {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.0.dev1"
+__version__ = "1.3.0.dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.2.10.dev1"
+__version__ = "1.3.0.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.2.9"
+__version__ = "1.2.10.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.0.dev2"
+__version__ = "1.3.0"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -10,25 +10,15 @@ from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Union, Any, Optional, Mapping, List, Dict, Tuple
 
 def pipe_r_url(
-        pipe : 'meerschaum.Pipe'
+        pipe: 'meerschaum.Pipe'
     ) -> str:
-    """Generate a relative URL path from a Pipe's keys.
-
-    Parameters
-    ----------
-    pipe : 'meerschaum.Pipe' :
-        
-
-    Returns
-    -------
-
-    """
-    from meerschaum.config.static import _static_config
+    """Return a relative URL path from a Pipe's keys."""
+    from meerschaum.config.static import STATIC_CONFIG
     location_key = pipe.location_key
     if location_key is None:
         location_key = '[None]'
     return (
-        f"{_static_config()['api']['endpoints']['pipes']}/"
+        f"{STATIC_CONFIG['api']['endpoints']['pipes']}/"
         + f"{pipe.connector_keys}/{pipe.metric_key}/{location_key}"
     )
 
@@ -39,17 +29,6 @@ def register_pipe(
     ) -> SuccessTuple:
     """Submit a POST to the API to register a new Pipe object.
     Returns a tuple of (success_bool, response_dict).
-
-    Parameters
-    ----------
-    pipe: meerschaum.Pipe :
-        
-    debug: bool :
-         (Default value = False)
-
-    Returns
-    -------
-
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.config.static import _static_config
@@ -80,19 +59,6 @@ def edit_pipe(
     ) -> SuccessTuple:
     """Submit a PATCH to the API to edit an existing Pipe object.
     Returns a tuple of (success_bool, response_dict).
-
-    Parameters
-    ----------
-    pipe: meerschaum.Pipe :
-        
-    patch: bool :
-         (Default value = False)
-    debug: bool :
-         (Default value = False)
-
-    Returns
-    -------
-
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.config.static import _static_config
@@ -153,7 +119,6 @@ def fetch_pipes_keys(
     Returns
     -------
     A list of tuples containing pipes' keys.
-
     """
     from meerschaum.utils.warnings import error
     from meerschaum.config.static import _static_config
@@ -198,30 +163,6 @@ def sync_pipe(
     ) -> SuccessTuple:
     """Append a pandas DataFrame to a Pipe.
     If Pipe does not exist, it is registered with supplied metadata.
-        NOTE: columns['datetime'] must be set for new Pipes.
-
-    Parameters
-    ----------
-    pipe : Optional[meerschaum.Pipe] :
-         (Default value = None)
-    df : Optional[Union[pandas.DataFrame :
-        
-    Dict[Any :
-        
-    Any] :
-        
-    str]] :
-         (Default value = None)
-    chunksize : Optional[int] :
-         (Default value = -1)
-    debug : bool :
-         (Default value = False)
-    **kw : Any :
-        
-
-    Returns
-    -------
-
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn
@@ -334,19 +275,7 @@ def delete_pipe(
         pipe: Optional[meerschaum.Pipe] = None,
         debug: bool = None,        
     ) -> SuccessTuple:
-    """Delete a Pipe and drop its table.
-
-    Parameters
-    ----------
-    pipe: Optional[meerscahum.Pipe] :
-         (Default value = None)
-    debug: bool :
-         (Default value = None)
-
-    Returns
-    -------
-
-    """
+    """Delete a Pipe and drop its table."""
     from meerschaum.utils.warnings import error
     from meerschaum.utils.debug import dprint
     if pipe is None:
@@ -369,39 +298,15 @@ def delete_pipe(
 
 def get_pipe_data(
         self,
-        pipe : meerschaum.Pipe,
-        begin : Optional[datetime.datetime] = None,
-        end : Optional[datetime.datetime] = None,
-        params : Optional[Dict[str, Any]] = None,
-        as_chunks : bool = False,
-        debug : bool = False,
+        pipe: meerschaum.Pipe,
+        begin: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None,
+        params: Optional[Dict[str, Any]] = None,
+        as_chunks: bool = False,
+        debug: bool = False,
         **kw: Any
-    ) -> Optional[pandas.DataFrame]:
-    """Fetch data from the API.
-
-    Parameters
-    ----------
-    pipe : meerschaum.Pipe :
-        
-    begin : Optional[datetime.datetime] :
-         (Default value = None)
-    end : Optional[datetime.datetime] :
-         (Default value = None)
-    params : Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    as_chunks : bool :
-         (Default value = False)
-    debug : bool :
-         (Default value = False)
-    **kw: Any :
-        
-
-    Returns
-    -------
-
-    """
+    ) -> Union[pandas.DataFrame, None]:
+    """Fetch data from the API."""
     import json
     from meerschaum.utils.warnings import warn
     r_url = pipe_r_url(pipe)
@@ -431,38 +336,17 @@ def get_pipe_data(
     df = parse_df_datetimes(pd.read_json(response.text), debug=debug)
     return df
 
+
 def get_backtrack_data(
         self,
-        pipe : meerschaum.Pipe,
-        begin : datetime.datetime,
-        backtrack_minutes : int = 0,
+        pipe: meerschaum.Pipe,
+        begin: datetime.datetime,
+        backtrack_minutes: int = 0,
         params: Optional[Dict[str, Any]] = None,
-        debug : bool = False,
-        **kw : Any,
+        debug: bool = False,
+        **kw: Any,
     ) -> pandas.DataFrame:
-    """Get a Pipe's backtrack data from the API.
-
-    Parameters
-    ----------
-    pipe : meerschaum.Pipe :
-        
-    begin : datetime.datetime :
-        
-    backtrack_minutes : int :
-         (Default value = 0)
-    params: Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    debug : bool :
-         (Default value = False)
-    **kw : Any :
-        
-
-    Returns
-    -------
-
-    """
+    """Get a Pipe's backtrack data from the API."""
     import json
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn
@@ -495,22 +379,10 @@ def get_backtrack_data(
 
 def get_pipe_id(
         self,
-        pipe : meerschuam.Pipe,
-        debug : bool = False,
+        pipe: meerschuam.Pipe,
+        debug: bool = False,
     ) -> int:
-    """Get a Pipe's ID from the API
-
-    Parameters
-    ----------
-    pipe : meerschuam.Pipe :
-        
-    debug : bool :
-         (Default value = False)
-
-    Returns
-    -------
-
-    """
+    """Get a Pipe's ID from the API."""
     from meerschaum.utils.debug import dprint
     r_url = pipe_r_url(pipe)
     response = self.get(
@@ -524,23 +396,23 @@ def get_pipe_id(
     except Exception as e:
         return None
 
+
 def get_pipe_attributes(
         self,
-        pipe : meerschaum.Pipe,
-        debug : bool = False,
-    ) -> Mapping[str, Any]:
+        pipe: meerschaum.Pipe,
+        debug: bool = False,
+    ) -> Dict[str, Any]:
     """Get a Pipe's attributes from the API
 
     Parameters
     ----------
-    pipe : meerschaum.Pipe :
+    pipe: meerschaum.Pipe
+        The pipe whose attributes we are fetching.
         
-    debug : bool :
-         (Default value = False)
-
     Returns
     -------
-
+    A dictionary of a pipe's attributes.
+    If the pipe does not exist, return an empty dictionary.
     """
     r_url = pipe_r_url(pipe)
     response = self.get(r_url + '/attributes', debug=debug)
@@ -548,47 +420,38 @@ def get_pipe_attributes(
     try:
         return json.loads(response.text)
     except Exception as e:
-        return None
+        return {}
+
 
 def get_sync_time(
         self,
-        pipe : 'meerschaum.Pipe',
-        params : Optional[Dict[str, Any]] = None,
+        pipe: 'meerschaum.Pipe',
+        params: Optional[Dict[str, Any]] = None,
         newest: bool = True,
         round_down: bool = True,
-        debug : bool = False,
-    ) -> datetime.datetime:
+        debug: bool = False,
+    ) -> Union[datetime.datetime, None]:
     """Get a Pipe's most recent datetime value from the API.
 
     Parameters
     ----------
-    pipe :
+    pipe: meerschaum.Pipe
         The pipe to select from.
-    params :
+
+    params: Optional[Dict[str, Any]], default None
         Optional params dictionary to build the WHERE clause.
-    newest :
+
+    newest: bool, default True
         If `True`, get the most recent datetime (honoring `params`).
         If `False`, get the oldest datetime (ASC instead of DESC).
-        Defaults to `True`.
-    round_down :
+
+    round_down: bool, default True
         If `True`, round the resulting datetime value down to the nearest minute.
-        Defaults to `True`.
-    pipe : 'meerschaum.Pipe' :
-        
-    params : Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    newest: bool :
-         (Default value = True)
-    round_down: bool :
-         (Default value = True)
-    debug : bool :
-         (Default value = False)
 
     Returns
     -------
-
+    The most recent (or oldest if `newest` is `False`) datetime of a pipe,
+    rounded down to the closest minute.
     """
     import datetime, json
     r_url = pipe_r_url(pipe)
@@ -610,48 +473,44 @@ def get_sync_time(
             dt = None
     return dt
 
+
 def pipe_exists(
         self,
-        pipe : 'meerschaum.Pipe',
-        debug : bool = False
+        pipe: 'meerschaum.Pipe',
+        debug: bool = False
     ) -> bool:
-    """Consult the API to see if a Pipe exists
+    """Check the API to see if a Pipe exists.
 
     Parameters
     ----------
-    pipe : 'meerschaum.Pipe' :
+    pipe: 'meerschaum.Pipe'
+        The pipe which were are querying.
         
-    debug : bool :
-         (Default value = False)
-
     Returns
     -------
-
+    A bool indicating whether a pipe's underlying table exists.
     """
     from meerschaum.utils.debug import dprint
+    from meerschaum.utils.warnings import warn
     r_url = pipe_r_url(pipe)
     response = self.get(r_url + '/exists', debug=debug)
     if debug:
         dprint("Received response: " + str(response.text))
     j = response.json()
     if isinstance(j, dict) and 'detail' in j:
-        return False, j['detail']
+        warn(j['detail'])
     return j
+
 
 def create_metadata(
         self,
-        debug : bool = False
+        debug: bool = False
     ) -> bool:
-    """Create Pipe metadata tables
-
-    Parameters
-    ----------
-    debug : bool :
-         (Default value = False)
+    """Create metadata tables.
 
     Returns
     -------
-
+    A bool indicating success.
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.config.static import _static_config
@@ -666,37 +525,38 @@ def create_metadata(
         metadata_response = False
     return False
 
+
 def get_pipe_rowcount(
         self,
-        pipe : 'meerschaum.Pipe',
-        begin : 'datetime.datetime' = None,
-        end : 'datetime.datetime' = None,
-        params : Optional[Dict[str, Any]] = None,
-        remote : bool = False,
-        debug : bool = False,
-    ) -> Optional[int]:
-    """Get a pipe's row couunt from the API.
+        pipe: 'meerschaum.Pipe',
+        begin: Optional['datetime.datetime'] = None,
+        end: Optional['datetime.datetime'] = None,
+        params: Optional[Dict[str, Any]] = None,
+        remote: bool = False,
+        debug: bool = False,
+    ) -> int:
+    """Get a pipe's row count from the API.
 
     Parameters
     ----------
-    pipe : 'meerschaum.Pipe' :
+    pipe: 'meerschaum.Pipe':
+        The pipe whose row count we are counting.
         
-    begin : 'datetime.datetime' :
-         (Default value = None)
-    end : 'datetime.datetime' :
-         (Default value = None)
-    params : Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    remote : bool :
-         (Default value = False)
-    debug : bool :
-         (Default value = False)
+    begin: Optional[datetime.datetime], default None
+        If provided, bound the count by this datetime.
+
+    end: Optional[datetime.datetime]
+        If provided, bound the count by this datetime.
+
+    params: Optional[Dict[str, Any]], default None
+        If provided, bound the count by these parameters.
+
+    remote: bool, default False
 
     Returns
     -------
-
+    The number of rows in the pipe's table, bound the given parameters.
+    If the table does not exist, return 0.
     """
     import json
     r_url = pipe_r_url(pipe)
@@ -713,7 +573,7 @@ def get_pipe_rowcount(
     try:
         return int(json.loads(response.text))
     except Exception as e:
-        return None
+        return 0
 
 
 def drop_pipe(
@@ -721,18 +581,16 @@ def drop_pipe(
         pipe: meerschaum.Pipe,
         debug: bool = False
     ) -> SuccessTuple:
-    """Drop a pipe's tables but maintain its registration.
+    """Drop a pipe's table but maintain its registration.
 
     Parameters
     ----------
-    pipe: meerschaum.Pipe :
+    pipe: meerschaum.Pipe:
+        The pipe to be dropped.
         
-    debug: bool :
-         (Default value = False)
-
     Returns
     -------
-
+    A success tuple (bool, str).
     """
     return self.do_action(
         ['drop', 'pipes'],
@@ -747,31 +605,26 @@ def drop_pipe(
 def clear_pipe(
         self,
         pipe: meerschaum.Pipe,
-        force: bool = False,
         debug: bool = False,
         **kw
     ) -> SuccessTuple:
-    """Drop a pipe's tables but maintain its registration.
+    """
+    Delete rows in a pipe's table.
 
     Parameters
     ----------
-    pipe: meerschaum.Pipe :
+    pipe: meerschaum.Pipe
+        The pipe with rows to be deleted.
         
-    force: bool :
-         (Default value = False)
-    debug: bool :
-         (Default value = False)
-    **kw :
-        
-
     Returns
     -------
-
+    A success tuple.
     """
     kw.pop('metric_keys', None)
     kw.pop('connector_keys', None)
     kw.pop('location_keys', None)
     kw.pop('action', None)
+    kw.pop('force', None)
     return self.do_action(
         ['clear', 'pipes'],
         connector_keys = pipe.connector_keys,
@@ -785,32 +638,29 @@ def clear_pipe(
 
 def get_pipe_columns_types(
         self,
-        pipe : meerschaum.Pipe,
-        debug : bool = False,
-    ) -> Optional[Dict[str, str]]:
+        pipe: meerschaum.Pipe,
+        debug: bool = False,
+    ) -> Union[Dict[str, str], None]:
     """
+    Fetch the columns and types of the pipe's table.
 
     Parameters
     ----------
-    pipe : meerschaum.Pipe :
+    pipe: meerschaum.Pipe
+        The pipe whose columns to be queried.
         
-    debug : bool :
-         (Default value = False)
-
     Returns
     -------
-    type
-        E.g. An example dictionary for a small table.
-        
-        ```
+    A dictionary mapping column names to their database types.
 
+    Examples
+    --------
     >>> {
     ...   'dt': 'TIMESTAMP WITHOUT TIMEZONE',
     ...   'id': 'BIGINT',
     ...   'val': 'DOUBLE PRECISION',
     ... }
     >>>
-    ```
     """
     r_url = pipe_r_url(pipe) + '/columns/types'
     response = self.get(

--- a/meerschaum/connectors/parse.py
+++ b/meerschaum/connectors/parse.py
@@ -75,7 +75,7 @@ def parse_connector_keys(
         type_config = get_config('meerschaum', 'connectors', _type)
 
         ### Forgetting to add `copy()` caused THE MOST frustrating bug to investigate.
-        default_config = type_config.get('default', None).copy()
+        default_config = type_config.get('default', {}).copy()
         conn = type_config.get(_label, None)
         if default_config is not None and conn is not None:
             default_config.update(conn)

--- a/meerschaum/connectors/sql/SQLConnector.py
+++ b/meerschaum/connectors/sql/SQLConnector.py
@@ -23,13 +23,17 @@ class SQLConnector(Connector):
     """
 
     from ._create_engine import flavor_configs, create_engine
-    from ._sql import read, value, exec, execute, to_sql
+    from ._sql import read, value, exec, execute, to_sql, exec_queries
     from meerschaum.utils.sql import test_connection
     from ._fetch import fetch
     from ._cli import cli
     from ._pipes import (
         fetch_pipes_keys,
         create_indices,
+        drop_indices,
+        get_create_index_queries,
+        get_drop_index_queries,
+        get_add_columns_queries,
         delete_pipe,
         get_backtrack_data,
         get_pipe_data,

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -304,10 +304,81 @@ def fetch_pipes_keys(
 def create_indices(
         self,
         pipe: meerschaum.Pipe,
+        indices: Optional[List[str]] = None,
         debug: bool = False
     ) -> bool:
     """
-    Create indices for a Pipe's datetime and ID columns.
+    Create a pipe's indices.
+    """
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.debug import dprint
+    if debug:
+        dprint(f"Creating indices for {pipe}...")
+    if not pipe.columns:
+        warn(f"Unable to create indices for {pipe} without columns.", stack=False)
+        return False
+    ix_queries = {
+        ix: queries
+        for ix, queries in self.get_create_index_queries(pipe, debug=debug).items()
+        if indices is None or ix in indices
+    }
+    success = True
+    for ix, queries in ix_queries.items():
+        ix_success = all(self.exec_queries(queries, debug=debug, silent=True))
+        if not ix_success:
+            success = False
+            if debug:
+                dprint(f"Failed to create index on column: {ix}")
+    return success
+
+
+def drop_indices(
+        self,
+        pipe: meerschaum.Pipe,
+        indices: Optional[List[str]] = None,
+        debug: bool = False
+    ) -> bool:
+    """
+    Drop a pipe's indices.
+    """
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.debug import dprint
+    if debug:
+        dprint(f"Dropping indices for {pipe}...")
+    if not pipe.columns:
+        warn(f"Unable to drop indices for {pipe} without columns.", stack=False)
+        return False
+    ix_queries = {
+        ix: queries
+        for ix, queries in self.get_drop_index_queries(pipe, debug=debug).items()
+        if indices is None or ix in indices
+    }
+    success = True
+    for ix, queries in ix_queries.items():
+        ix_success = all(self.exec_queries(queries, debug=debug, silent=True))
+        if not ix_success:
+            success = False
+            if debug:
+                dprint(f"Failed to drop index on column: {ix}")
+    return success
+
+
+def get_create_index_queries(
+        self,
+        pipe: meerschaum.Pipe,
+        debug: bool = False,
+    ) -> Dict[str, List[str]]:
+    """
+    Return a dictionary mapping columns to a `CREATE INDEX` or equivalent query.
+
+    Parameters
+    ----------
+    pipe: meerschaum.Pipe
+        The pipe to which the queries will correspond.
+
+    Returns
+    -------
+    A dictionary of column names mapping to lists of queries.
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.sql import sql_item_name, get_distinct_col_count
@@ -315,28 +386,18 @@ def create_indices(
     from meerschaum.config import get_config
     index_queries = {}
 
-    if debug:
-        dprint(f"Creating indices for {pipe}...")
-    if (
-        pipe.columns is None or
-        pipe.columns.get('datetime', None) is None
-    ):
-        warn(f"Unable to create indices for {pipe} without columns.")
-        return False
+    indices = pipe.get_indices()
 
-    _cols_types = pipe.get_columns_types(debug=debug)
     _datetime = pipe.get_columns('datetime', error=False)
     _datetime_name = sql_item_name(_datetime, self.flavor) if _datetime is not None else None
     _datetime_index_name = (
-        sql_item_name(pipe.target + '_' + _datetime + '_index', self.flavor)
-        if _datetime is not None else None
+        sql_item_name(indices['datetime'], self.flavor) if indices.get('datetime', None)
+        else None
     )
     _id = pipe.get_columns('id', error=False)
     _id_name = sql_item_name(_id, self.flavor) if _id is not None else None
-    _id_index_name = (
-        sql_item_name(pipe.target + '_' + _id + '_index', self.flavor)
-        if _id is not None else None
-    )
+
+    _id_index_name = sql_item_name(indices['id'], self.flavor) if indices.get('id') else None
     _pipe_name = sql_item_name(pipe.target, self.flavor)
     _create_space_partition = get_config('system', 'experimental', 'space')
 
@@ -362,7 +423,7 @@ def create_indices(
                 + f"ON {_pipe_name} ({_datetime_name})"
             )
 
-        index_queries[_datetime] = dt_query
+        index_queries[_datetime] = [dt_query]
 
     ### create id index
     if _id_name is not None:
@@ -387,21 +448,79 @@ def create_indices(
             id_query = f"CREATE INDEX {_id_index_name} ON {_pipe_name} ({_id_name})"
 
         if id_query is not None:
-            index_queries[_id] = id_query
+            index_queries[_id] = [id_query]
 
-    failures = 0
-    for col, q in index_queries.items():
-        if debug:
-            dprint(f"Creating index on column '{col}' for {pipe}...")
-        queries = [q] if isinstance(q, str) else q
-        for q in queries:
-            try:
-                index_result = self.exec(q, debug=debug)
-            except Exception as e:
-                index_result = None
-            if index_result is None or index_result is False:
-                failures += 1
-    return failures == 0
+
+    ### Create indices for other label in `pipe.columns`.
+    other_indices = {
+        ix_key: ix_unquoted
+        for ix_key, ix_unquoted in pipe.get_indices().items()
+        if ix_key not in ('datetime', 'id')
+    }
+    for ix_key, ix_unquoted in other_indices.items():
+        ix_name = sql_item_name(ix_unquoted, self.flavor)
+        col = pipe.columns[ix_key]
+        col_name = sql_item_name(col, self.flavor)
+        index_queries[col] = [f"CREATE INDEX {ix_name} ON {_pipe_name} ({col_name})"]
+
+    return index_queries
+
+
+def get_drop_index_queries(
+        self,
+        pipe: meerschaum.Pipe,
+        debug: bool = False,
+    ) -> Dict[str, List[str]]:
+    """
+    Return a dictionary mapping columns to a `DROP INDEX` or equivalent query.
+
+    Parameters
+    ----------
+    pipe: meerschaum.Pipe
+        The pipe to which the queries will correspond.
+
+    Returns
+    -------
+    A dictionary of column names mapping to lists of queries.
+    """
+    if not pipe.exists(debug=debug):
+        return {}
+    from meerschaum.utils.sql import sql_item_name, table_exists, hypertable_queries
+    drop_queries = {}
+    indices = pipe.get_indices()
+    pipe_name = sql_item_name(pipe.target, self.flavor)
+
+    if self.flavor not in hypertable_queries:
+        is_hypertable = False
+    else:
+        is_hypertable_query = hypertable_queries[self.flavor].format(table_name=pipe_name)
+        is_hypertable = self.value(is_hypertable_query, silent=True, debug=debug) is not None
+
+    if is_hypertable:
+        nuke_queries = []
+        temp_table = '_' + pipe.target + '_temp_migration'
+        temp_table_name = sql_item_name(temp_table, self.flavor)
+
+        if table_exists(temp_table, self, debug=debug):
+            nuke_queries.append(f"DROP TABLE {temp_table_name}")
+        nuke_queries += [
+            f"SELECT * INTO {temp_table_name} FROM {pipe_name}",
+            f"DROP TABLE {pipe_name}",
+            f"ALTER TABLE {temp_table_name} RENAME TO {pipe_name}",
+        ]
+        nuke_ix_keys = ('datetime', 'id')
+        nuked = False
+        for ix_key in nuke_ix_keys:
+            if ix_key in indices and not nuked:
+                drop_queries[ix_key] = nuke_queries
+                nuked = True
+
+    drop_queries.update({
+        ix_key: ["DROP INDEX " + sql_item_name(ix_unquoted, self.flavor)]
+        for ix_key, ix_unquoted in indices.items()
+        if ix_key not in drop_queries
+    })
+    return drop_queries
 
 
 def delete_pipe(
@@ -436,6 +555,7 @@ def delete_pipe(
 
     return True, "Success"
 
+
 def get_backtrack_data(
         self,
         pipe: Optional[meerschaum.Pipe] = None,
@@ -444,7 +564,7 @@ def get_backtrack_data(
         params: Optional[Dict[str, Any]] = None,
         chunksize: Optional[int] = -1,
         debug: bool = False
-    ) -> Optional[pandas.DataFrame]:
+    ) -> Union[pandas.DataFrame, None]:
     """
     Get the most recent backtrack_minutes' worth of data from a Pipe.
 
@@ -491,7 +611,7 @@ def get_backtrack_data(
 
     from meerschaum.utils.sql import sql_item_name, build_where
     table = sql_item_name(pipe.target, self.flavor)
-    if not pipe.columns or 'datetime' not in pipe.columns:
+    if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
         dt = sql_item_name(_dt, self.flavor) if _dt else None
         is_guess = True
@@ -562,7 +682,7 @@ def get_pipe_data(
     query = f"SELECT * FROM {sql_item_name(pipe.target, self.flavor)}"
     where = ""
 
-    if not pipe.columns or 'datetime' not in pipe.columns:
+    if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
         dt = sql_item_name(_dt, self.flavor) if _dt else None
         is_guess = True
@@ -584,7 +704,7 @@ def get_pipe_data(
                 warn(
                     f"A datetime wasn't specified for {pipe}.\n"
                     + f"    Using column \"{_dt}\" for datetime bounds...",
-                    stack = False
+                    stack = False,
                 )
 
 
@@ -622,7 +742,7 @@ def get_pipe_data(
         dprint(f"Getting pipe data with begin = '{begin}' and end = '{end}'")
     kw['dtype'] = pipe.dtypes
     if self.flavor == 'sqlite':
-        if 'datetime' not in kw['dtype'].get(_dt, 'object'):
+        if _dt and 'datetime' not in kw['dtype'].get(_dt, 'object'):
             kw['dtype'][_dt] = 'datetime64[ns]'
     df = self.read(
         query,
@@ -636,6 +756,7 @@ def get_pipe_data(
             [parse_df_datetimes(c, debug=debug) for c in df]
         )
     return df
+
 
 def get_pipe_id(
         self,
@@ -772,7 +893,7 @@ def sync_pipe(
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.packages import import_pandas
     from meerschaum.utils.misc import parse_df_datetimes
-    from meerschaum.utils.sql import get_update_queries, sql_item_name, get_add_columns_query
+    from meerschaum.utils.sql import get_update_queries, sql_item_name
     from meerschaum import Pipe
     import time
     if df is None:
@@ -813,9 +934,9 @@ def sync_pipe(
         is_new = True
     else:
         ### Check for new columns.
-        add_cols_query = get_add_columns_query(pipe.target, df, self, debug=debug)
-        if add_cols_query:
-            if not self.exec(add_cols_query, debug=debug):
+        add_cols_queries = self.get_add_columns_queries(pipe, df, debug=debug)
+        if add_cols_queries:
+            if not self.exec_queries(add_cols_queries, debug=debug):
                 warn(f"Failed to add new columns to {pipe}.")
 
     if not isinstance(df, pd.DataFrame):
@@ -849,31 +970,19 @@ def sync_pipe(
             target = temp_target,
         )
 
-        join_cols = []
-        if 'datetime' in pipe.columns:
-            join_cols.append(pipe.columns['datetime'])
-        if 'id' in pipe.columns:
-            join_cols.append(pipe.columns['id'])
+        join_cols = [col for col_key, col in pipe.columns.items() if col_key != 'value']
 
-        with self.engine.begin() as connection:
-            for update_query in get_update_queries(
-                pipe.target,
-                temp_target,
-                self,
-                join_cols,
-                debug = debug
-            ):
-                if debug:
-                    dprint(update_query)
-                success = connection.execute(update_query) is not None
-                if not success:
-                    warn(f"Failed to update {pipe}!")
-                    break
-
-        if success:
-            temp_pipe.drop(debug=debug)
-        else:
-            warn(f"Failed to apply changes to {pipe}.", stack=False)
+        queries = get_update_queries(
+            pipe.target,
+            temp_target,
+            self,
+            join_cols,
+            debug = debug
+        )
+        success = all(self.exec_queries(queries, break_on_error=True, debug=debug))
+        if not success:
+            return False, f"Failed to apply update to {pipe}."
+        temp_pipe.drop(debug=debug)
 
     if_exists = kw.get('if_exists', 'append')
     if 'if_exists' in kw:
@@ -948,7 +1057,7 @@ def get_sync_time(
     import datetime
     table = sql_item_name(pipe.target, self.flavor)
 
-    if not pipe.columns or 'datetime' not in pipe.columns:
+    if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
         dt = sql_item_name(_dt, self.flavor) if _dt else None
         is_guess = True
@@ -958,7 +1067,7 @@ def get_sync_time(
         is_guess = False
 
     if _dt is None:
-        warn(f"Unable to determine the column for the sync time of {pipe}!", stack=False)
+        warn(f"Unable to determine the column for the sync time of {pipe}.", stack=False)
         return None
 
     ASC_or_DESC = "DESC" if newest else "ASC"
@@ -1091,7 +1200,7 @@ def get_pipe_rowcount(
 
     _pipe_name = sql_item_name(pipe.target, self.flavor)
 
-    if not pipe.columns or 'datetime' not in pipe.columns:
+    if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
         dt = sql_item_name(_dt, self.flavor) if _dt else None
         is_guess = True
@@ -1106,12 +1215,14 @@ def get_pipe_rowcount(
                 warn(
                     f"No datetime could be determined for {pipe}."
                     + "\n    Ignoring begin and end...",
+                    stack = False,
                 )
                 begin, end = None, None
             else:
                 warn(
                     f"A datetime wasn't specified for {pipe}.\n"
                     + f"    Using column \"{_dt}\" for datetime bounds...",
+                    stack = False,
                 )
 
 
@@ -1233,7 +1344,7 @@ def clear_pipe(
     from meerschaum.utils.warnings import warn
     pipe_name = sql_item_name(pipe.target, self.flavor)
 
-    if not pipe.columns or 'datetime' not in pipe.columns:
+    if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
         dt_name = sql_item_name(_dt, self.flavor) if _dt else None
         is_guess = True
@@ -1247,13 +1358,15 @@ def clear_pipe(
             if _dt is None:
                 warn(
                     f"No datetime could be determined for {pipe}."
-                    + "    Ignore datetime bounds..."
+                    + "\n    Ignoring datetime bounds...",
+                    stack = False,
                 )
                 begin, end = None, None
             else:
                 warn(
                     f"A datetime wasn't specified for {pipe}.\n"
                     + f"    Using column \"{_dt}\" for datetime bounds...",
+                    stack = False,
                 )
 
 
@@ -1293,7 +1406,8 @@ def get_pipe_table(
 
     """
     from meerschaum.utils.sql import get_sqlalchemy_table
-    return get_sqlalchemy_table(pipe.target, connector=self, debug=debug)
+    return get_sqlalchemy_table(pipe.target, connector=self, debug=debug, refresh=True)
+
 
 def get_pipe_columns_types(
         self,
@@ -1335,3 +1449,53 @@ def get_pipe_columns_types(
         table_columns = None
 
     return table_columns
+
+
+def get_add_columns_queries(
+        self,
+        pipe: mrsm.Pipe,
+        df: pd.DataFrame,
+        debug: bool = False,
+    ) -> List[str]:
+    """
+    Add new null columns of the correct type to a table from a dataframe.
+
+    Parameters
+    ----------
+    pipe: mrsm.Pipe
+        The pipe to be altered.
+
+    df: pd.DataFrame
+        The pandas DataFrame which contains new columns.
+
+    connector: mrsm.connectors.SQLConnector
+        The connector to the database on which the table resides.
+
+    Returns
+    -------
+    A list of the `ALTER TABLE` SQL query or queries to be executed on the provided connector.
+    """
+    if not pipe.exists(debug=debug):
+        return []
+    from meerschaum.utils.sql import get_pd_type, get_db_type, sql_item_name
+    table_obj = self.get_pipe_table(pipe, debug=debug)
+    df_cols_types = {col: str(typ) for col, typ in df.dtypes.items()}
+    db_cols_types = {col: get_pd_type(str(typ)) for col, typ in table_obj.columns.items()}
+    new_cols = set(df_cols_types) - set(db_cols_types)
+    if not new_cols:
+        return []
+
+    new_cols_types = {
+        col: get_db_type(
+            df_cols_types[col],
+            self.flavor
+        ) for col in new_cols
+    }
+
+    query = "ALTER TABLE " + sql_item_name(pipe.target, self.flavor)
+    for col, typ in new_cols_types.items():
+        query += "\nADD " + sql_item_name(col, self.flavor) + " " + typ + ","
+    query = query[:-1]
+    if self.flavor != 'duckdb':
+        return [query]
+    return [query] + [q for ix, q in self.get_create_index_queries(pipe, debug=debug)]

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -197,29 +197,36 @@ class Pipe:
         self.metric_key = metric
         self.location_key = location
 
+        self._attributes = {
+            'connector_keys': self.connector_keys,
+            'metric_key': self.metric_key,
+            'location_key': self.location_key,
+            'parameters': {},
+        }
+
         ### only set parameters if values are provided
         if isinstance(parameters, dict):
-            self.parameters = parameters
+            self._attributes['parameters'] = parameters
         elif parameters is not None:
             warn(f"The provided parameters are of invalid type '{type(parameters)}'.")
 
         if isinstance(columns, dict):
-            self.columns = columns
+            self._attributes['parameters']['columns'] = columns
         elif columns is not None:
             warn(f"The provided columns are of invalid type '{type(columns)}'.")
 
         if isinstance(tags, (list, tuple)):
-            self.tags = tags
+            self._attributes['parameters']['tags'] = tags
         elif tags is not None:
             warn(f"The provided tags are of invalid type '{type(tags)}'.")
 
         if isinstance(target, str):
-            self.target = target
+            self._attributes['parameters']['target'] = target
         elif target is not None:
             warn(f"The provided target is of invalid type '{type(target)}'.")
 
         if isinstance(dtypes, dict):
-            self.dtypes = dtypes
+            self._attributes['parameters']['dtypes'] = dtypes
         elif dtypes is not None:
             warn(f"The provided dtypes are of invalid type '{type(dtypes)}'.")
 
@@ -230,6 +237,7 @@ class Pipe:
         _mrsm_instance = mrsm_instance if mrsm_instance is not None else instance
         if _mrsm_instance is None:
             _mrsm_instance = get_config('meerschaum', 'instance', patch=True)
+
         if not isinstance(_mrsm_instance, str):
             self._instance_connector = _mrsm_instance
             self.instance_keys = str(_mrsm_instance)

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -90,6 +90,7 @@ class Pipe:
         dtypes,
         get_columns,
         get_columns_types,
+        get_indices,
         tags,
         get_id,
         id,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -73,7 +73,7 @@ def columns(self, columns: Dict[str, str]) -> None:
     Override the columns dictionary of the in-memory pipe.
     Call `meerschaum.Pipe.edit()` to persist changes.
     """
-    self._parameters['columns'] = columns
+    self.parameters['columns'] = columns
 
 
 @property

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -62,23 +62,23 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
 
     common_dtypes = {}
     common_diff_dtypes = {}
-    for d, t in self.dtypes.items():
-        if d in df_dtypes:
-            common_dtypes[d] = t
-            if t != df_dtypes[d]:
-                common_diff_dtypes[d] = df_dtypes[d]
+    for col, typ in self.dtypes.items():
+        if col in df_dtypes:
+            common_dtypes[col] = typ
+            if typ != df_dtypes[col]:
+                common_diff_dtypes[col] = df_dtypes[col]
 
     if debug:
         dprint(f"Common columns with different dtypes:")
         pprint(common_diff_dtypes)
 
     detected_dt_cols = {}
-    for d, t in common_diff_dtypes.items():
-        if 'datetime' in t and 'datetime' in common_dtypes[d]:
-            df_dtypes[d] = t
-            detected_dt_cols[d] = (common_dtypes[d], common_diff_dtypes[d])
-    for d in detected_dt_cols:
-        del common_diff_dtypes[d]
+    for col, typ in common_diff_dtypes.items():
+        if 'datetime' in typ and 'datetime' in common_dtypes[col]:
+            df_dtypes[col] = typ
+            detected_dt_cols[col] = (common_dtypes[col], common_diff_dtypes[typ])
+    for col in detected_dt_cols:
+        del common_diff_dtypes[col]
 
     if debug:
         dprint(f"Common columns with different dtypes (after dates):")
@@ -94,7 +94,7 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
             pprint(detected_dt_cols)
         return df
 
-    if len(common_dtypes) == len(df_dtypes):
+    if set(common_dtypes) == set(df_dtypes):
         min_ratio = STATIC_CONFIG['pipes']['dtypes']['min_ratio_columns_changed_for_full_astype']
         if (
             len(common_diff_dtypes) >= int(len(common_dtypes) * min_ratio)
@@ -102,7 +102,13 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
             if debug:
                 dprint(f"Enforcing data types for {self} on incoming DataFrame...")
             try:
-                return df[list(common_dtypes.keys())].astype(self.dtypes)
+                return df[
+                    list(common_dtypes.keys())
+                ].astype({
+                    col: typ
+                    for col, typ in self.dtypes.items()
+                    if col in common_dtypes
+                })
             except Exception as e:
                 warn(f"Encountered an error when enforcing data types for {self}:\n{e}")
                 return df
@@ -137,7 +143,7 @@ def infer_dtypes(self, persist: bool=False, debug: bool=False) -> Dict[str, Any]
         dtypes = {}
         if not self.columns:
             return {}
-        if 'datetime' in self.columns:
+        if self.columns.get('datetime', None) is not None:
             dtypes[self.columns['datetime']] = 'datetime64[ns]'
         return dtypes
     from meerschaum.utils.sql import get_pd_type

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -351,7 +351,7 @@ def get_sync_time(
 
     """
     from meerschaum.utils.warnings import error, warn
-    if self.columns is None:
+    if not self.columns:
         warn(
             f"No columns found in parameters for {self}.",
             stack = False,

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -831,6 +831,54 @@ def df_from_literal(
     return pd.DataFrame({dt_name : [now], val_name : [val]})
 
 
+def add_missing_cols_to_df(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
+    """
+    Add columns from the dtypes dictionary as null columns to a new DataFrame.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The dataframe we should copy and add null columns.
+
+    dtypes:
+        The data types dictionary which may contain keys not present in `df.columns`.
+
+    Returns
+    -------
+    A new `DataFrame` with the keys from `dtypes` added as null columns.
+    If `df.dtypes` is the same as `dtypes`, then return a reference to `df`.
+    NOTE: This will not ensure that dtypes are enforced!
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame([{'a': 1}])
+    >>> dtypes = {'b': 'Int64'}
+    >>> add_missing_cols_to_df(df, dtypes)
+       a     b
+       0  1  <NA>
+    >>> add_missing_cols_to_df(df, dtypes).dtypes
+    a    int64
+    b    Int64
+    dtype: object
+    >>> add_missing_cols_to_df(df, {'a': 'object'}).dtypes
+    a    int64
+    dtype: object
+    >>> 
+    """
+    if set(df.columns) == set(dtypes):
+        return df
+    
+    df = df.copy()
+    for col, typ in dtypes.items():
+        if col in df.columns:
+            continue
+        df[col] = None
+        df[col] = df[col].astype(typ)
+    
+    return df
+
+
 def filter_unseen_df(
         old_df: 'pd.DataFrame',
         new_df: 'pd.DataFrame',
@@ -876,35 +924,43 @@ def filter_unseen_df(
     ```
 
     """
-    if old_df is None:
+    if old_df is None or len(old_df) == 0:
         return new_df
+
     from meerschaum.utils.packages import import_pandas
     pd = import_pandas(debug=debug)
+
+    new_df_dtypes = dict(new_df.dtypes)
+    old_df_dtypes = dict(old_df.dtypes)
+
     same_cols = set(new_df.columns) == set(old_df.columns)
-    if same_cols:
-        try:
-            ### Order matters when checking equality.
-            new_df = new_df[old_df.columns]
-        except Exception as e:
-            from meerschaum.utils.warnings import warn
-            warn(
-                "Was not able to cast old columns onto new DataFrame. " +
-                f"Are both DataFrames the same shape? Error:\n{e}"
-            )
-        #  return None
+    if not same_cols:
+        new_df = add_missing_cols_to_df(new_df, old_df_dtypes)
+        old_df = add_missing_cols_to_df(old_df, new_df_dtypes)
+
+    try:
+        ### Order matters when checking equality.
+        new_df = new_df[old_df.columns]
+    except Exception as e:
+        from meerschaum.utils.warnings import warn
+        warn(
+            "Was not able to cast old columns onto new DataFrame. " +
+            f"Are both DataFrames the same shape? Error:\n{e}",
+            stacklevel = 3,
+        )
+        return new_df[list(new_df_dtypes.keys())]
 
     ### assume the old_df knows what it's doing, even if it's technically wrong.
     if dtypes is None:
         dtypes = dict(old_df.dtypes)
     cast_cols = True
-    if set(new_df.columns) == set(old_df.columns):
-        try:
-            new_df = new_df.astype(dtypes)
-            cast_cols = False
-        except Exception as e:
-            warn(
-                f"Was not able to cast the new DataFrame to the given dtypes.\n{e}"
-            )
+    try:
+        new_df = new_df.astype(dtypes)
+        cast_cols = False
+    except Exception as e:
+        warn(
+            f"Was not able to cast the new DataFrame to the given dtypes.\n{e}"
+        )
     if cast_cols:
         for col, dtype in dtypes.items():
             if col in new_df.columns:
@@ -913,12 +969,9 @@ def filter_unseen_df(
                 except Exception as e:
                     warn(f"Was not able to cast column '{col}' to dtype '{dtype}'.\n{e}")
 
-    if len(old_df) == 0:
-        return new_df
-
     return new_df[
         ~new_df.fillna(pd.NA).apply(tuple, 1).isin(old_df.fillna(pd.NA).apply(tuple, 1))
-    ].reset_index(drop=True)
+    ].reset_index(drop=True)[list(new_df_dtypes.keys())]
 
 
 def replace_pipes_in_dict(

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -186,7 +186,6 @@ def verify_venv(
     )
 
     if not (bin_path / current_python_versioned_name).exists():
-        print(f'DNE: {bin_path / current_python_versioned_name}')
         init_venv(venv, verify=False, force=True, debug=debug)
         current_python_in_venv_path = pathlib.Path(venv_executable(venv=venv))
         current_python_in_sys_path = pathlib.Path(venv_executable(venv=None))

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -158,3 +158,19 @@ def test_target_mutable(flavor: str):
     result = conn.read(target, silent=True)
     assert result is None
 
+
+@pytest.mark.parametrize("flavor", list(remote_pipes.keys()))
+def test_sync_new_columns(flavor: str):
+    conn = conns[flavor]
+    pipe = Pipe('foo', 'bar', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
+    pipe.drop(debug=debug)
+    docs = [
+        {'dt': '2022-01-01', 'id': 1, 'a': 10},
+    ]
+    pipe.sync(docs, debug=debug)
+    assert len(pipe.get_data().columns) == 3
+
+    docs = [
+        {'dt': '2022-01-01', 'id': 1, 'b': 20},
+    ]
+    assert len(pipe.get_data().columns == 4)

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -161,6 +161,9 @@ def test_target_mutable(flavor: str):
 
 @pytest.mark.parametrize("flavor", list(remote_pipes.keys()))
 def test_sync_new_columns(flavor: str):
+    """
+    Test that new columns are added.
+    """
     conn = conns[flavor]
     pipe = Pipe('foo', 'bar', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
     pipe.drop(debug=debug)
@@ -173,4 +176,7 @@ def test_sync_new_columns(flavor: str):
     docs = [
         {'dt': '2022-01-01', 'id': 1, 'b': 20},
     ]
-    assert len(pipe.get_data().columns == 4)
+    pipe.sync(docs, debug=debug)
+    df = pipe.get_data()
+    assert len(df.columns) == 4
+    assert len(df) == 1


### PR DESCRIPTION
# v1.3.0: Dynamic Columns

**Improvements**

  - **Syncing now handles dynamic columns.**  
    Syncing a pipe with new columns will trigger an `ALTER TABLE` query to append the columns to your table:

    ```python
    import meerschaum as mrsm
    pipe = mrsm.Pipe('foo', 'bar', instance='sql:memory')
    
    pipe.sync([{'a': 1}])
    print(pipe.get_data())
    #    a
    # 0  1

    pipe.sync([{'b': 1}])
    print(pipe.get_data())
    #       a     b
    # 0     1  <NA>
    # 1  <NA>     1
    ```

    If you've specified index columns, you can use this feature to fill in `NULL` values in your table:

    ```python
    import meerschaum as mrsm
    pipe = mrsm.Pipe(
        'foo', 'bar',
        columns = {'id': 'id_col'},
        instance = 'sql:memory',
    )

    pipe.sync([{'id_col': 1, 'a': 10.0}])
    pipe.sync([{'id_col': 1, 'b': 20.0}])

    print(pipe.get_data())
    #    id_col     a     b
    # 0       1  10.0  20.0
    ```

  - **Add as many indices as you like.**  
    In addition to the special index column labels `datetime`, `id`, and `value`, the values of all keys within the `Pipe.columns` dictionary will be treated as indices when creating and updating tables:

    ```python
    import meerschaum as mrsm
    indices = {'micro': 'station', 'macro': 'country'}
    pipe = mrsm.Pipe('demo', 'weather', columns=indices, instance='sql:memory')

    docs = [{'station': 1, 'country': 'USA', 'temp_f': 80.6}]
    pipe.sync(docs)

    docs = [{'station': 1, 'country': 'USA', 'temp_c': 27.0}]
    pipe.sync(docs)

    print(pipe.get_data())
    #    station  country  temp_f  temp_c
    # 0        1      USA    80.6    27.0
    ```

  - **Added a default 60-second timeout for pipe attributes.**  
    All parameter properties (e.g. `Pipe.columns`, `Pipe.target`, `Pipe.dtypes`, etc.) will sync with the instance every 60 seconds. The in-memory attributes will be patched on top of the database values, so your unsaved state won't be lost (persist your state with `Pipe.edit()`). You can change the timeout duration with `mrsm edit config pipes` under the keys `attributes:local_cache_timeout_seconds`. To disable this caching behavior, set the value to `null`.

  - **Added custom indices and Pandas data types to the Web UI.**

**Breaking Changes**
  
  - **Removed `None` as default for uninitalized properties for pipes.**  
    Parameter properties like `Pipe.columns`, `Pipe.parameters`, etc. will now always return a dictionary, even if a pipe is not registered.
  - **`Pipe.get_columns()` now sets `error` to `False` by default.**  
    Pipes are now mostly index-agnostic, so these checks are no longer needed. This downgrades errors in several functions to just warnings, e.g. `Pipe.get_sync_time()`.

**Bugfixes**

  - **Always quote tables that begin with underscores in Oracle.**
  - **Always refresh the metadata when grabbing `sqlalchemy` tables for pipes to account for dynamic state.**