### PR TITLE
🐛 v1.3.1 Fix dtype enforcement issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.3.1
+
+- **Fixed data type enforcement issues.**  
+  A serious bug in data type enforcement has been patched.
+- **Allow `Pipe.dtypes` to be edited.**  
+  You can now set keys in `Pipe.dtypes` and persist them with `Pipe.edit()`.
+- **Added `Pipe.update()`.**  
+  `Pipe.update()` is an alias to `Pipe.edit(interactive=False)`.
+- **`Pipe.delete()` no longer deletes local attributes.**  
+  It still removes `Pipe.id`, but local attributes will now remain intact.
+- **Fixed dynamic columns on DuckDB.**  
+  DuckDB does not allow for altering tables when indices are created, so this patch will drop and rebuild indices when tables are altered.
+- **Replaced `CLOB` with `NVARCHAR(2000)` on Oracle SQL.**  
+  This may require migrating existing pipes to use the new data type.
+- **Enforce integers are of type `INTEGER` on Oracle SQL.**  
+  Lots of data type enforcement has been added for Oracle SQL.
+- **Removed datetime warnings when syncing pipes without a datetime column.**
+- **Removed grabbing the current time for the sync time if a sync time cannot be determined.**
+
 ### v1.3.0: Dynamic Columns
 
 **Improvements**

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.3.1
+
+- **Fixed data type enforcement issues.**  
+  A serious bug in data type enforcement has been patched.
+- **Allow `Pipe.dtypes` to be edited.**  
+  You can now set keys in `Pipe.dtypes` and persist them with `Pipe.edit()`.
+- **Added `Pipe.update()`.**  
+  `Pipe.update()` is an alias to `Pipe.edit(interactive=False)`.
+- **`Pipe.delete()` no longer deletes local attributes.**  
+  It still removes `Pipe.id`, but local attributes will now remain intact.
+- **Fixed dynamic columns on DuckDB.**  
+  DuckDB does not allow for altering tables when indices are created, so this patch will drop and rebuild indices when tables are altered.
+- **Replaced `CLOB` with `NVARCHAR(2000)` on Oracle SQL.**  
+  This may require migrating existing pipes to use the new data type.
+- **Enforce integers are of type `INTEGER` on Oracle SQL.**  
+  Lots of data type enforcement has been added for Oracle SQL.
+- **Removed datetime warnings when syncing pipes without a datetime column.**
+- **Removed grabbing the current time for the sync time if a sync time cannot be determined.**
+
 ### v1.3.0: Dynamic Columns
 
 **Improvements**

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -101,7 +101,7 @@ class Pipe:
         guess_datetime,
     )
     from ._show import show
-    from ._edit import edit, edit_definition
+    from ._edit import edit, edit_definition, update
     from ._sync import sync, get_sync_time, exists, filter_existing
     from ._delete import delete
     from ._drop import drop

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -109,7 +109,9 @@ def dtypes(self) -> Union[Dict[str, Any], None]:
     from meerschaum.config._patch import apply_patch_to_config
     configured_dtypes = self.parameters.get('dtypes', {})
     remote_dtypes = self.infer_dtypes(persist=False)
-    return apply_patch_to_config(remote_dtypes, configured_dtypes)
+    patched_dtypes = apply_patch_to_config(remote_dtypes, configured_dtypes)
+    self.parameters['dtypes'] = patched_dtypes
+    return self.parameters['dtypes']
 
 
 @dtypes.setter

--- a/meerschaum/core/Pipe/_delete.py
+++ b/meerschaum/core/Pipe/_delete.py
@@ -41,7 +41,7 @@ def delete(
     if not isinstance(result, tuple):
         return False, f"Received unexpected result from '{self.instance_connector}': {result}"
     if result[0]:
-        to_delete = ['_id', '_attributes', '_columns', '_tags', '_data']
+        to_delete = ['_id']
         for member in to_delete:
             if member in self.__dict__:
                 del self.__dict__[member]

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -76,7 +76,7 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
     for col, typ in common_diff_dtypes.items():
         if 'datetime' in typ and 'datetime' in common_dtypes[col]:
             df_dtypes[col] = typ
-            detected_dt_cols[col] = (common_dtypes[col], common_diff_dtypes[typ])
+            detected_dt_cols[col] = (common_dtypes[col], common_diff_dtypes[col])
     for col in detected_dt_cols:
         del common_diff_dtypes[col]
 

--- a/meerschaum/core/Pipe/_edit.py
+++ b/meerschaum/core/Pipe/_edit.py
@@ -9,6 +9,14 @@ Edit a Pipe's parameters here.
 from __future__ import annotations
 from meerschaum.utils.typing import Any, SuccessTuple
 
+def update(self, *args, **kw) -> SuccessTuple:
+    """
+    Update a pipe's parameters in its instance.
+    """
+    kw['interactive'] = False
+    return self.edit(*args, **kw)
+
+
 def edit(
         self,
         patch: bool = False,

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -52,10 +52,15 @@ export $MRSM_URIS
 python -m meerschaum show connectors
 python -m meerschaum start connectors $MRSM_CONNS
 
+export ff=""
+if [ "$2" == "--ff" ]; then
+  export ff="--ff"
+fi
+
 ### Execute the pytest tests.
 python -m pytest \
   --durations=0 \
-  --ignore=portable/ --ignore=test_root/ --ignore=tests/data/ --ignore=docs/; rc="$?"
+  --ignore=portable/ --ignore=test_root/ --ignore=tests/data/ --ignore=docs/ $ff; rc="$?"
 
 ### Cleanup
 if [ "$2" == "rm" ]; then


### PR DESCRIPTION
# v1.3.1

- **Fixed data type enforcement issues.**  
  A serious bug in data type enforcement has been patched.
- **Allow `Pipe.dtypes` to be edited.**  
  You can now set keys in `Pipe.dtypes` and persist them with `Pipe.edit()`.
- **Added `Pipe.update()`.**  
  `Pipe.update()` is an alias to `Pipe.edit(interactive=False)`.
- **`Pipe.delete()` no longer deletes local attributes.**  
  It still removes `Pipe.id`, but local attributes will now remain intact.
- **Fixed dynamic columns on DuckDB.**  
  DuckDB does not allow for altering tables when indices are created, so this patch will drop and rebuild indices when tables are altered.
- **Replaced `CLOB` with `NVARCHAR(2000)` on Oracle SQL.**  
  This may require migrating existing pipes to use the new data type.
- **Enforce integers are of type `INTEGER` on Oracle SQL.**  
  Lots of data type enforcement has been added for Oracle SQL.
- **Removed datetime warnings when syncing pipes without a datetime column.**
- **Removed grabbing the current time for the sync time if a sync time cannot be determined.**