### PR TITLE
v1.3.2

### DIFF
--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -247,6 +247,8 @@ def search_and_substitute_config(
     def _find_symlinks(d, _keys: Optional[List[str]] = None):
         if _keys is None:
             _keys = []
+        if not isinstance(d, dict):
+            return
         for k, v in d.items():
             if isinstance(v, dict):
                 _find_symlinks(v, _keys + [k])

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -245,6 +245,8 @@ def search_and_substitute_config(
 
     _links = []
     def _find_symlinks(d, _keys: Optional[List[str]] = None):
+        if _keys is None:
+            _keys = []
         for k, v in d.items():
             if isinstance(v, dict):
                 _find_symlinks(v, _keys + [k])

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -349,7 +349,7 @@ def search_and_substitute_config(
             haystack = haystack.replace(pattern, str(value))
 
     ### parse back into dict
-    parsed_config = json.loads(haystack)
+    parsed_config = json.loads(haystack) or {}
 
     symlinks = {}
     if keep_symlinks:

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -244,7 +244,7 @@ def search_and_substitute_config(
     """
 
     _links = []
-    def _find_symlinks(d, _keys: List[str] = []):
+    def _find_symlinks(d, _keys: Optional[List[str]] = None):
         for k, v in d.items():
             if isinstance(v, dict):
                 _find_symlinks(v, _keys + [k])

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.2.dev1"
+__version__ = "1.3.2"


### PR DESCRIPTION
This release addresses an environment issue in Ubuntu 18.04 on Python 3.8. The patch fixes a mutable default argument and ensures substituted configuration is always parsed as a dictionary.