### PR TITLE
v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.3.4
+
+- **Define environment connectors with JSON or URIs.**  
+  Connectors defined as environment variables may now have their attributes set as JSON in addition to a URI string.
+
+- **Custom Connectors may now be defined as environment variables.**  
+  You may now set environment variables for custom connectors defined via `@make_connector`, e.g.:
+
+  ```bash
+  MRSM_FOO_BAR='{"foo": "bar"}' mrsm show connectors
+  ```
+
+- **Allow for custom connectors to be instance connectors.**  
+  Add the property `IS_INSTANCE = True` your custom connector to add it to the official list of instance types:
+
+  ```python
+  from meerschaum.connectors import make_connector, Connector
+
+  @make_connector
+  class FooConnector(Connector):
+      IS_INSTANCE = True
+
+      def __init__(label: str, **kw):
+          super().__init__('foo', label, **kw)
+  ```
+
+- **Install packages for all plugins with `mrsm install required`.**  
+  The default behavior for `mrsm install required` with no plugins named is now to install dependencies for all plugins.
+
+- **Syncing bugfixes.**
+
 ### v1.3.2 – 1.3.3
 
 - **Fixed a bug with `begin` and `end` bounds in `Pipe.get_data()`.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,37 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.3.4
+
+- **Define environment connectors with JSON or URIs.**  
+  Connectors defined as environment variables may now have their attributes set as JSON in addition to a URI string.
+
+- **Custom Connectors may now be defined as environment variables.**  
+  You may now set environment variables for custom connectors defined via `@make_connector`, e.g.:
+
+  ```bash
+  MRSM_FOO_BAR='{"foo": "bar"}' mrsm show connectors
+  ```
+
+- **Allow for custom connectors to be instance connectors.**  
+  Add the property `IS_INSTANCE = True` your custom connector to add it to the official list of instance types:
+
+  ```python
+  from meerschaum.connectors import make_connector, Connector
+
+  @make_connector
+  class FooConnector(Connector):
+      IS_INSTANCE = True
+
+      def __init__(label: str, **kw):
+          super().__init__('foo', label, **kw)
+  ```
+
+- **Install packages for all plugins with `mrsm install required`.**  
+  The default behavior for `mrsm install required` with no plugins named is now to install dependencies for all plugins.
+
+- **Syncing bugfixes.**
+
 ### v1.3.2 – 1.3.3
 
 - **Fixed a bug with `begin` and `end` bounds in `Pipe.get_data()`.**  

--- a/meerschaum/__main__.py
+++ b/meerschaum/__main__.py
@@ -19,12 +19,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys, os
+import sys, os, copy
 
 def main(sysargs: list = None) -> None:
     """Main CLI entry point."""
     if sysargs is None:
-        sysargs = sys.argv[1:].copy()
+        sysargs = copy.deepcopy(sys.argv[1:])
     old_cwd = os.getcwd()
 
     ### Catch help flags.
@@ -63,12 +63,14 @@ def main(sysargs: list = None) -> None:
 
     return _exit(rc, old_cwd=old_cwd)
 
+
 def _exit(return_code: int = 0, old_cwd: str = None) -> None:
     _close_pools()
     ### Restore the previous working directory.
     if old_cwd is not None and old_cwd != os.getcwd():
         os.chdir(old_cwd)
     sys.exit(return_code)
+
 
 def _close_pools():
     """Close multiprocessing pools before exiting."""

--- a/meerschaum/_internal/gui/app/_windows.py
+++ b/meerschaum/_internal/gui/app/_windows.py
@@ -21,6 +21,7 @@ def get_windows(**kw) -> Dict[str, toga.window.Window]:
 def get_main_window(instance: Optional[str], debug: bool = False, **kw) -> toga.window.Window:
     from meerschaum.config.static import _static_config
     from meerschaum.utils.misc import get_connector_labels
+    from meerschaum.connectors import instance_types
     from meerschaum._internal.gui.app.pipes import build_pipes_tree
 
     main_window = toga.MainWindow(title=_static_config()['setup']['formal_name'], size=(1280, 720))
@@ -29,7 +30,7 @@ def get_main_window(instance: Optional[str], debug: bool = False, **kw) -> toga.
 
     left_box = toga.Box(children=[
         toga.Box(children=[
-            toga.Selection(items=get_connector_labels('sql', 'api'), style=toga.style.Pack(flex=1)),
+            toga.Selection(items=get_connector_labels(*instance_types), style=toga.style.Pack(flex=1)),
             tree,
             toga.Button('Hello, world!', style=toga.style.Pack(flex=1, padding=10), on_press=show_test_window),
         ], style=toga.style.Pack(flex=1, padding=10, direction='column', width=200))

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -7,6 +7,7 @@ This module is the entry point for the interactive shell.
 
 from __future__ import annotations
 import os
+from copy import deepcopy
 from meerschaum.utils.typing import Union, SuccessTuple, Any, Callable, Optional, List, Dict
 from meerschaum.utils.packages import attempt_import
 from meerschaum.config import __doc__, __version__ as version, get_config
@@ -412,8 +413,7 @@ class Shell(cmd.Cmd):
         old_cwd = os.getcwd()
 
         ### make a backup of line for later
-        import copy
-        original_line = copy.deepcopy(line)
+        original_line = deepcopy(line)
 
         ### cmd2 support: check if command exists
         try:
@@ -832,9 +832,6 @@ def input_with_sigint(_input, session, shell: Optional[Shell] = None):
             colored(shell.repo_keys, 'on ' + get_config('shell', 'ansi', 'repo', 'rich', 'style'))
             if ANSI else colored(shell.repo_keys, 'on white')
         )
-        #  connected = (
-            #  is_connected(shell.instance_keys) if shell._update_bottom_toolbar else last_connected
-        #  )
         try:
             typ, label = shell.instance_keys.split(':')
             connected = typ in connectors and label in connectors[typ]

--- a/meerschaum/actions/api.py
+++ b/meerschaum/actions/api.py
@@ -142,6 +142,7 @@ def _api_start(
     from meerschaum.utils.pool import get_pool
     import shutil
     import os
+    from copy import deepcopy
 
     if action is None:
         action = []
@@ -156,7 +157,7 @@ def _api_start(
     uvicorn_config_path = API_UVICORN_RESOURCES_PATH / SERVER_ID / 'config.json'
     uvicorn_env_path = API_UVICORN_RESOURCES_PATH / SERVER_ID / 'uvicorn.env'
 
-    api_config = get_config('system', 'api').copy()
+    api_config = deepcopy(get_config('system', 'api'))
     cf = _config()
     uvicorn_config = api_config['uvicorn']
     if port is None:

--- a/meerschaum/actions/arguments/_parser.py
+++ b/meerschaum/actions/arguments/_parser.py
@@ -53,13 +53,14 @@ def parse_help(sysargs : Union[List[str], Dict[str, Any]]) -> None:
     from meerschaum.actions.arguments._parse_arguments import parse_arguments, parse_line
     from meerschaum.actions import actions, get_subactions
     import importlib, inspect, textwrap
+    from copy import deepcopy
     if isinstance(sysargs, list):
         args = parse_arguments(sysargs)
     elif isinstance(sysargs, dict):
         args = sysargs
     elif isinstance(sysargs, str):
         args = parse_line(sysargs)
-    _args = args.copy()
+    _args = deepcopy(args)
     del _args['action']
     if len(args['action']) == 0:
         return actions['show'](['help'], **_args)

--- a/meerschaum/actions/install.py
+++ b/meerschaum/actions/install.py
@@ -196,19 +196,23 @@ def _install_required(
         `install required noaa covid`
     """
     from meerschaum.core import Plugin
-    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.warnings import warn, info
     from meerschaum.connectors.parse import parse_repo_keys
     from meerschaum.utils.formatting import print_tuple
+    from meerschaum.plugins import get_plugins_names
     repo_connector = parse_repo_keys(repository)
+
+    plugins_names = action or get_plugins_names()
 
     success_count = 0
     fail_count = 0
 
-    for plugin_name in action:
+    for plugin_name in plugins_names:
         plugin = Plugin(plugin_name, repo_connector=repo_connector)
         if not plugin.is_installed():
             warn(f"Plugin '{plugin}' is not installed. Skipping...", stack=False)
             continue
+        info(f"Installing required packages for plugin '{plugin}'...")
         success = plugin.install_dependencies(force=force, debug=debug)
         if not success:
             warn(f"Failed to install required packages for plugin '{plugin}'.", stack=False)

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -62,7 +62,7 @@ def _pipes_lap(
     import queue
     import multiprocessing
     import contextlib
-    import time, os
+    import time, os, copy
     from meerschaum.utils.packages import venv_exec
     from meerschaum.utils.process import poll_process
     import json
@@ -72,7 +72,7 @@ def _pipes_lap(
     rich_table, rich_text, rich_box = attempt_import(
         'rich.table', 'rich.text', 'rich.box',
     )
-    all_kw = kw.copy()
+    all_kw = copy.deepcopy(kw)
     all_kw.update({'workers': workers, 'debug': debug, 'unblock': unblock, 'force': force,
         'min_seconds': min_seconds, 'timeout_seconds': timeout_seconds,
         'mrsm_instance': mrsm_instance,})

--- a/meerschaum/api/dash/actions.py
+++ b/meerschaum/api/dash/actions.py
@@ -7,7 +7,7 @@ Execute actions via the web interface.
 """
 
 from __future__ import annotations
-import platform, sys, io, os, shlex, time
+import platform, sys, io, os, shlex, time, copy
 from dash.exceptions import PreventUpdate
 from meerschaum.utils.threading import Thread
 from meerschaum.utils.typing import SuccessTuple, Tuple, Dict, Any, WebState
@@ -200,7 +200,7 @@ def execute_action(state: WebState):
             ### Don't forget to pass the existing environment
             ### in case MRSM_CONFIG and MRSM_PATCH are set.
             try:
-                _env = os.environ.copy()
+                _env = copy.deepcopy(os.environ)
             except Exception as e:
                 _env = {}
             _env.update({'LINES': '120', 'COLUMNS': '100'})

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -15,6 +15,7 @@ from meerschaum.config.static import _static_config
 from meerschaum.utils.misc import remove_ansi
 from meerschaum.actions import get_shell
 from meerschaum.api import endpoints, CHECK_UPDATE
+from meerschaum.connectors import instance_types
 from meerschaum.utils.misc import get_connector_labels
 from meerschaum.config import __doc__ as doc
 dbc = attempt_import('dash_bootstrap_components', lazy=False, check_update=CHECK_UPDATE)
@@ -92,7 +93,7 @@ instance_select = dbc.Select(
     size = 'sm',
     options = [
         {'label': i, 'value': i}
-        for i in get_connector_labels('sql', 'api')
+        for i in get_connector_labels(*instance_types)
     ],
     class_name = 'dbc_dark custom-select custom-select-sm',
 )
@@ -102,20 +103,40 @@ navbar = dbc.Navbar(
     [
         dbc.Row(
             [
-                dbc.Col(html.Img(src=endpoints['dash'] + "/assets/logo_48x48.png", style = {'padding': '0.5em', 'padding-left': '2em'}), width='auto', align='start'),
-                dbc.Col(dbc.NavbarBrand("Meerschaum Web Console", class_name='ms-2', style={'margin-top': '10px', 'display': 'inline-block'}), align='start', width=2),
+                dbc.Col(
+                    html.Img(
+                        src = endpoints['dash'] + "/assets/logo_48x48.png",
+                        style = {'padding': '0.5em', 'padding-left': '2em'}
+                    ),
+                    width = 'auto', 
+                    align = 'start'
+                ),
+                dbc.Col(
+                    dbc.NavbarBrand(
+                        "Meerschaum Web Console",
+                        class_name = 'ms-2',
+                        style = {'margin-top': '10px', 'display': 'inline-block'}
+                    ), align='start', width=2
+                ),
                 dbc.Col(md=True, lg=True, sm=False),
-                dbc.Col(html.Center(instance_select), sm=2, md=2, lg=1, align='end', class_name='d-flex justify-content-center text-center'),
+                dbc.Col(
+                    html.Center(
+                        instance_select
+                    ),
+                    sm = 2,
+                    md = 2,
+                    lg = 1,
+                    align = 'end',
+                    class_name = 'd-flex justify-content-center text-center'
+                ),
                 dbc.Col(html.Pre(html.A(doc, href='/docs')), width='auto', align='end'),
             ],
-            #  align = 'center',
             style = {'width': '100%'},
             justify = 'around',
         ),
     ],
     color = 'dark', dark=True
 )
-
 
 
 def alert_from_success_tuple(success: SuccessTuple) -> dbc.Alert:
@@ -132,6 +153,7 @@ def alert_from_success_tuple(success: SuccessTuple) -> dbc.Alert:
             color = 'success' if success[0] else 'danger',
         )
     )
+
 
 def build_cards_grid(cards: List[dbc.Card], num_columns: int = 3) -> html.Div:
     """
@@ -152,4 +174,3 @@ def build_cards_grid(cards: List[dbc.Card], num_columns: int = 3) -> html.Div:
         rows.append(r)
         rows.append(html.Br())
     return html.Div(rows)
-

--- a/meerschaum/api/dash/pages/dashboard.py
+++ b/meerschaum/api/dash/pages/dashboard.py
@@ -64,13 +64,8 @@ layout = html.Div(
                             ),
                             html.Br(),
                             bottom_buttons_content,
-                            #  action_row,
                             test_button,
-                            #  go_button,
-                            #  show_pipes_button,
-                            #  get_items_menu,
                             html.Div(id='ws-div'),
-                            #  search_parameters_editor,
                         ],
                         id = 'content-col-left',
                         md=12, lg=6,
@@ -78,7 +73,6 @@ layout = html.Div(
                     dbc.Col(
                         children = [
                             dbc.Col([
-                                ### Place alert divs here.
                                     html.Div(id='success-alert-div'),
                                     html.Div(id='instance-alert-div')
                                 ],

--- a/meerschaum/config/__init__.py
+++ b/meerschaum/config/__init__.py
@@ -9,7 +9,7 @@ and if interactive, print the welcome message.
 
 from __future__ import annotations
 
-import os, shutil, sys, pathlib
+import os, shutil, sys, pathlib, copy
 from meerschaum.utils.typing import Any, Dict, Optional, Union
 from meerschaum.utils.threading import RLock
 from meerschaum.utils.warnings import warn
@@ -196,7 +196,7 @@ def get_config(
             in_default = True
             patched_default_config = (
                 search_and_substitute_config(default_config)
-                if substitute else default_config.copy()
+                if substitute else copy.deepcopy(default_config)
             )
             _c = patched_default_config
             for k in keys:

--- a/meerschaum/config/_patch.py
+++ b/meerschaum/config/_patch.py
@@ -7,7 +7,7 @@ Functions for patching the configuration dictionary
 """
 
 import sys
-from copy import deepcopy
+import copy
 from meerschaum.utils.typing import Dict, Any
 
 def apply_patch_to_config(
@@ -15,7 +15,7 @@ def apply_patch_to_config(
         patch: Dict[str, Any],
     ):
     """Patch the config dict with a new dict (cascade patching)."""
-    _base = deepcopy(config) if isinstance(config, dict) else {}
+    _base = copy.deepcopy(config) if isinstance(config, dict) else {}
     if not isinstance(patch, dict):
         return config
 

--- a/meerschaum/config/_patch.py
+++ b/meerschaum/config/_patch.py
@@ -7,6 +7,7 @@ Functions for patching the configuration dictionary
 """
 
 import sys
+from copy import deepcopy
 from meerschaum.utils.typing import Dict, Any
 
 def apply_patch_to_config(
@@ -14,7 +15,9 @@ def apply_patch_to_config(
         patch: Dict[str, Any],
     ):
     """Patch the config dict with a new dict (cascade patching)."""
-    _base = config.copy()
+    _base = deepcopy(config) if isinstance(config, dict) else {}
+    if not isinstance(patch, dict):
+        return config
 
     def update_dict(base, patch):
         for key, value in patch.items():

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -43,7 +43,7 @@ STATIC_CONFIG = {
         'plugins': 'MRSM_PLUGINS_DIR',
         'runtime': 'MRSM_RUNTIME',
         'id': 'MRSM_SERVER_ID',
-        'uri_regex': r'MRSM_(SQL|API)_(\d*[a-zA-Z][a-zA-Z0-9-_+]*$)',
+        'uri_regex': 'MRSM_({TYPES})_(\d*[a-zA-Z][a-zA-Z0-9-_+]*$)',
         'prefix': 'MRSM_',
     },
     'config': {

--- a/meerschaum/connectors/Connector.py
+++ b/meerschaum/connectors/Connector.py
@@ -10,14 +10,18 @@ PluginConnector for further details.
 
 from __future__ import annotations
 import abc
-from meerschaum.utils.typing import Iterable, Optional, Any, Union
+import copy
+from meerschaum.utils.typing import Iterable, Optional, Any, Union, List, Dict
 
 class Connector(metaclass=abc.ABCMeta):
+    """
+    The base connector class to hold connection attributes,
+    """
     def __init__(
             self,
-            type : Optional[str] = None,
-            label : Optional[str] = None,
-            **kw : Any
+            type: Optional[str] = None,
+            label: Optional[str] = None,
+            **kw: Any
         ):
         """
         Parameters
@@ -45,7 +49,7 @@ class Connector(metaclass=abc.ABCMeta):
         ```
 
         """
-        self._original_dict = self.__dict__.copy()
+        self._original_dict = copy.deepcopy(self.__dict__)
         self._set_attributes(type=type, label=label, **kw)
 
     def _reset_attributes(self):
@@ -65,14 +69,14 @@ class Connector(metaclass=abc.ABCMeta):
         self.type, self.label = type, label
 
         from meerschaum.config import get_config
-        conn_configs = get_config('meerschaum', 'connectors').copy()
-        connector_config = get_config('system', 'connectors').copy()
+        conn_configs = copy.deepcopy(get_config('meerschaum', 'connectors'))
+        connector_config = copy.deepcopy(get_config('system', 'connectors'))
 
         ### inherit attributes from 'default' if exists
         if inherit_default:
             inherit_from = 'default'
             if self.type in conn_configs and inherit_from in conn_configs[self.type]:
-                _inherit_dict = conn_configs[self.type][inherit_from].copy()
+                _inherit_dict = copy.deepcopy(conn_configs[self.type][inherit_from])
                 self.__dict__.update(_inherit_dict)
 
         ### load user config into self.__dict__
@@ -82,11 +86,11 @@ class Connector(metaclass=abc.ABCMeta):
         ### load system config into self.sys_config
         ### (deep copy so future Connectors don't inherit changes)
         if self.type in connector_config:
-            from copy import deepcopy
-            self.sys_config = deepcopy(connector_config[self.type])
+            self.sys_config = copy.deepcopy(connector_config[self.type])
 
         ### add additional arguments or override configuration
         self.__dict__.update(kw)
+
 
     def verify_attributes(
             self,
@@ -117,6 +121,7 @@ class Connector(metaclass=abc.ABCMeta):
         """
         from meerschaum.utils.warnings import error, warn
         from meerschaum.utils.debug import dprint
+        from meerschaum.utils.misc import items_str
         if required_attributes is None:
             required_attributes = ['label']
         missing_attributes = set()
@@ -125,29 +130,17 @@ class Connector(metaclass=abc.ABCMeta):
                 missing_attributes.add(a)
         if len(missing_attributes) > 0:
             error(
-                f"Please provide connection configuration for connector '{self.type}:{self.label}' "
-                f"in the configuration file (open with `mrsm edit config`) or as arguments for the Connector.\n\n"
-                f"Missing attributes: {missing_attributes}",
+                (
+                    "Please provide connection configuration for connector "
+                    + f"'{self.type}:{self.label}' "
+                    + "in the configuration file (open with `mrsm edit config`) or as arguments "
+                    + "for the Connector.\n\n"
+                    + f"Missing {items_str(list(missing_attributes))}."
+                ),
                 silent = True,
                 stack = False
             )
 
-    def fetch(
-            self,
-            instructions: dict
-        ) -> 'pd.DataFrame':
-        """
-        Abstract method for all Connectors.
-        In addition to specialized functionality, all Connectors must be able to fetch data
-        based on criteria provided in the instructions dictionary.
-        
-        Returns
-        -------
-        A pandas (or pandas derivative) DataFrame.
-
-        """
-        from meerschaum.utils.warnings import error
-        error("fetch() must be implemented in children classes", NotImplementedError)
 
     def __str__(self):
         return f"{self.type}:{self.label}"

--- a/meerschaum/connectors/api/_fetch.py
+++ b/meerschaum/connectors/api/_fetch.py
@@ -7,8 +7,9 @@ Fetch Pipe data via the API connector
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import Any, Optional, Dict
 import datetime
+import copy
+from meerschaum.utils.typing import Any, Optional, Dict
 
 def fetch(
         self,
@@ -43,7 +44,7 @@ def fetch(
     if begin is None:
         begin = pipe.sync_time
 
-    _params = params.copy() if params is not None else {}
+    _params = copy.deepcopy(params) if params is not None else {}
     _params = apply_patch_to_config(_params, instructions.get('params', {}))
 
     from meerschaum import Pipe

--- a/meerschaum/connectors/parse.py
+++ b/meerschaum/connectors/parse.py
@@ -50,6 +50,7 @@ def parse_connector_keys(
     A connector or dictionary of attributes. If `as_tuple`, also return the connector's keys.
 
     """
+    import copy
     from meerschaum.connectors import get_connector
     from meerschaum.config import get_config
     from meerschaum.config.static import _static_config
@@ -74,8 +75,7 @@ def parse_connector_keys(
             return None
         type_config = get_config('meerschaum', 'connectors', _type)
 
-        ### Forgetting to add `copy()` caused THE MOST frustrating bug to investigate.
-        default_config = type_config.get('default', {}).copy()
+        default_config = copy.deepcopy(type_config.get('default', {}))
         conn = type_config.get(_label, None)
         if default_config is not None and conn is not None:
             default_config.update(conn)

--- a/meerschaum/connectors/parse.py
+++ b/meerschaum/connectors/parse.py
@@ -106,6 +106,7 @@ def parse_instance_keys(
     
     return parse_connector_keys(keys, construct=construct, as_tuple=as_tuple, **kw)
 
+
 def parse_repo_keys(keys: Optional[str] = None, **kw):
     """Parse the Meerschaum repository value into an APIConnector."""
     from meerschaum.config import get_config
@@ -117,8 +118,9 @@ def parse_repo_keys(keys: Optional[str] = None, **kw):
 
     return parse_connector_keys(keys, **kw)
 
+
 def is_valid_connector_keys(
-        keys : str
+        keys: str
     ) -> bool:
     """Verify a connector_keys string references a valid connector.
     """

--- a/meerschaum/connectors/poll.py
+++ b/meerschaum/connectors/poll.py
@@ -134,6 +134,7 @@ def _wrap_retry_connect(
     """
     from meerschaum.utils.warnings import warn as _warn, error, info
     from meerschaum.utils.debug import dprint
+    from meerschaum.connectors import instance_types
     from meerschaum.connectors.parse import parse_instance_keys
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.sql import test_queries
@@ -142,7 +143,7 @@ def _wrap_retry_connect(
     import time
 
     connector = parse_instance_keys(connector_keys)
-    if connector.type not in ('sql', 'api'):
+    if connector.type not in instance_types:
         return None
 
     retries = 0

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -175,6 +175,7 @@ def create_engine(
     from meerschaum.utils.warnings import error, warn
     sqlalchemy = attempt_import('sqlalchemy')
     import urllib
+    import copy
     ### Install and patch required drivers.
     if self.flavor in install_flavor_drivers:
         attempt_import(*install_flavor_drivers[self.flavor], debug=debug, lazy=False, warn=False)
@@ -242,7 +243,7 @@ def create_engine(
             ) + '\n' + f"{self.sys_config.get('create_engine', {}).get('connect_args', {})}"
         )
 
-    _kw_copy = kw.copy()
+    _kw_copy = copy.deepcopy(kw)
 
     ### NOTE: Order of inheritance:
     ###       1. Defaults

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -170,6 +170,7 @@ def fetch_pipes_keys(
     from meerschaum.config.static import _static_config
     sqlalchemy = attempt_import('sqlalchemy')
     import json
+    from copy import deepcopy
 
     if connector_keys is None:
         connector_keys = []
@@ -197,7 +198,7 @@ def fetch_pipes_keys(
     }
 
     ### Make deep copy so we don't mutate this somewhere else.
-    parameters = params.copy()
+    parameters = deepcopy(params)
     for col, vals in cols.items():
         ### Allow for IS NULL to be declared as a single-item list ([None]).
         if vals == [None]:

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -702,7 +702,7 @@ def get_pipe_data(
     quoted_indices = {
         key: sql_item_name(val, self.flavor)
         for key, val in pipe.columns.items()
-        if val
+        if val in existing_cols
     }
 
     if begin is not None or end is not None:

--- a/meerschaum/connectors/sql/tables/__init__.py
+++ b/meerschaum/connectors/sql/tables/__init__.py
@@ -70,6 +70,10 @@ def get_tables(
             return conn.create_metadata(debug=debug)
         return {}
 
+    ### Skip if the connector is not a SQL connector.
+    if getattr(conn, 'type', None) != 'sql':
+        return {}
+
     if conn not in connector_tables:
         if debug:
             dprint(f"Creating tables for connector '{conn}'.")

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -51,6 +51,7 @@ with correct credentials, as well as a network connection and valid permissions.
 """
 
 from __future__ import annotations
+import copy
 from meerschaum.utils.typing import Optional, Dict, Any, Union, InstanceConnector, List
 from meerschaum.utils.formatting._pipes import pipe_repr
 from meerschaum.config import get_config
@@ -208,8 +209,10 @@ class Pipe:
         ### only set parameters if values are provided
         if isinstance(parameters, dict):
             self._attributes['parameters'] = parameters
-        elif parameters is not None:
-            warn(f"The provided parameters are of invalid type '{type(parameters)}'.")
+        else:
+            if parameters is not None:
+                warn(f"The provided parameters are of invalid type '{type(parameters)}'.")
+            self._attributes['parameters'] = {}
 
         if isinstance(columns, dict):
             self._attributes['parameters']['columns'] = columns
@@ -332,7 +335,7 @@ class Pipe:
         if '_cache_pipe' not in self.__dict__:
             from meerschaum.config._patch import apply_patch_to_config
             from meerschaum.utils.sql import sql_item_name
-            _parameters = self.parameters.copy()
+            _parameters = copy.deepcopy(self.parameters)
             _fetch_patch = {
                 'fetch': ({
                     'definition': (
@@ -355,6 +358,7 @@ class Pipe:
             )
 
         return self._cache_pipe
+
 
     @property
     def sync_time(self) -> Union['datetime.datetime', None]:

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -8,6 +8,7 @@ Fetch and manipulate Pipes' attributes
 
 from __future__ import annotations
 from meerschaum.utils.typing import Tuple, Dict, SuccessTuple, Any, Union, Optional, List
+from meerschaum.utils.warnings import warn
 
 @property
 def attributes(self) -> Dict[str, Any]:
@@ -64,7 +65,11 @@ def columns(self) -> Union[Dict[str, str], None]:
     """
     if 'columns' not in self.parameters:
         self.parameters['columns'] = {}
-    return self.parameters['columns']
+    cols = self.parameters['columns']
+    if not isinstance(cols, dict):
+        cols = {}
+        self.parameters['columns'] = cols
+    return cols
 
 
 @columns.setter
@@ -73,6 +78,9 @@ def columns(self, columns: Dict[str, str]) -> None:
     Override the columns dictionary of the in-memory pipe.
     Call `meerschaum.Pipe.edit()` to persist changes.
     """
+    if not isinstance(columns, dict):
+        warn(f"{self}.columns must be a dictionary, received {type(columns)}")
+        return
     self.parameters['columns'] = columns
 
 

--- a/meerschaum/core/Pipe/_edit.py
+++ b/meerschaum/core/Pipe/_edit.py
@@ -87,6 +87,7 @@ def edit(
 
     return self.instance_connector.edit_pipe(self, patch=patch, debug=debug, **kw)
 
+
 def edit_definition(
         self,
         yes: bool = False,
@@ -104,7 +105,8 @@ def edit_definition(
     A `SuccessTuple` of success, message.
 
     """
-    if (self.connector is None) or self.connector.type not in ('sql', 'api'):
+    from meerschaum.connectors import instance_types
+    if (self.connector is None) or self.connector.type not in instance_types:
         return self.edit(interactive=True, debug=debug, **kw)
 
     import json

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -313,10 +313,6 @@ def _determine_begin(
     ### Datetime has already been provided.
     if begin is not None:
         return begin
-    ### Only manipulate the datetime for SQL or API pipes.
-    if not pipe.instance_connector.type in ('sql', 'api'):
-        return begin
-
     return pipe.get_sync_time(debug=debug)
 
 

--- a/meerschaum/utils/formatting/_pprint.py
+++ b/meerschaum/utils/formatting/_pprint.py
@@ -71,7 +71,7 @@ def pprint(
         c = a
         ### convert OrderedDict into dict
         if isinstance(a, OrderedDict) or issubclass(type(a), OrderedDict):
-            c = dict_from_od(c.copy())
+            c = dict_from_od(copy.deepcopy(c))
         _args.append(c)
     args = _args
 
@@ -81,7 +81,7 @@ def pprint(
         for a in args:
             c = a
             if isinstance(c, dict):
-                c = replace_password(c.copy())
+                c = replace_password(copy.deepcopy(c))
             if nopretty:
                 try:
                     c = json.dumps(c)

--- a/meerschaum/utils/interactive.py
+++ b/meerschaum/utils/interactive.py
@@ -36,11 +36,12 @@ def select_pipes(
     from meerschaum.config import get_config
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.misc import flatten_pipes_dict
+    from meerschaum.connectors import instance_types
     clear_screen(debug=debug)
     while True:
         instance = choose(
             "On which instance are the pipes stored?",
-            get_connector_labels('sql', 'api'),
+            get_connector_labels(*instance_types),
             numeric = True,
             default = get_config('meerschaum', 'instance'),
         )

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1015,6 +1015,7 @@ def replace_pipes_in_dict(
     A dictionary where every pipe is replaced with the output of a function.
 
     """
+    import copy
     def change_dict(d : Dict[Any, Any], func : 'function') -> None:
         for k, v in d.items():
             if isinstance(v, dict):
@@ -1026,7 +1027,7 @@ def replace_pipes_in_dict(
         from meerschaum import get_pipes
         pipes = get_pipes(debug=debug, **kw)
 
-    result = pipes.copy()
+    result = copy.deepcopy(pipes)
     change_dict(result, func)
     return result
 
@@ -1144,6 +1145,7 @@ def _pyinstaller_traverse_dir(
             paths.append((path, _path))
     return paths
 
+
 def replace_password(d: Dict[str, Any], replace_with: str = '*') -> Dict[str, Any]:
     """
     Recursively replace passwords in a dictionary.
@@ -1173,7 +1175,8 @@ def replace_password(d: Dict[str, Any], replace_with: str = '*') -> Dict[str, An
     {'password': '!!!'}
 
     """
-    _d = d.copy()
+    import copy
+    _d = copy.deepcopy(d)
     for k, v in d.items():
         if isinstance(v, dict):
             _d[k] = replace_password(v)
@@ -1196,6 +1199,7 @@ def replace_password(d: Dict[str, Any], replace_with: str = '*') -> Dict[str, An
                 )
             )
     return _d
+
 
 def filter_keywords(
         func: Callable[[Any], Any],

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -194,7 +194,7 @@ def string_to_dict(
         return json.loads(params_string)
 
     import ast
-    params_dict = dict()
+    params_dict = {}
     for param in params_string.split(","):
         _keys = param.split(":")
         keys = _keys[:-1]
@@ -217,13 +217,14 @@ def string_to_dict(
 
     return params_dict
 
+
 def parse_config_substitution(
         value: str,
         leading_key: str = 'MRSM',
         begin_key: str = '{',
         end_key: str = '}',
         delimeter: str = ':'
-    ):
+    ) -> List[Any]:
     """
     Parse Meerschaum substitution syntax
     E.g. MRSM{value1:value2} => ['value1', 'value2']
@@ -278,6 +279,7 @@ def edit_file(
         rc = run_python_package('pyvim', [path], venv=package_venv(pyvim), debug=debug)
     return rc == 0
 
+
 def is_pipe_registered(
         pipe: 'meerschaum.Pipe',
         pipes: PipesDict,
@@ -308,6 +310,7 @@ def is_pipe_registered(
         dprint(f'{pipe}, {pipes}')
     return ck in pipes and mk in pipes[ck] and lk in pipes[ck][mk]
 
+
 def _get_subaction_names(action : str, globs : dict = None) -> List[str]:
     """NOTE: Don't use this function. You should use `meerschaum.actions.get_subactions()` instead.
     This only exists for internal use.
@@ -321,6 +324,7 @@ def _get_subaction_names(action : str, globs : dict = None) -> List[str]:
         if f'_{action}' in item and 'complete' not in item.lstrip('_'):
             subactions.append(globs[item])
     return subactions
+
 
 def choices_docstring(action: str, globs : Optional[Dict[str, Any]] = None) -> str:
     """
@@ -831,7 +835,7 @@ def df_from_literal(
     return pd.DataFrame({dt_name : [now], val_name : [val]})
 
 
-def add_missing_cols_to_df(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
+def add_missing_cols_to_df(df: 'pd.DataFrame', dtypes: Dict[str, Any]) -> pd.DataFrame:
     """
     Add columns from the dtypes dictionary as null columns to a new DataFrame.
 
@@ -876,9 +880,9 @@ def add_missing_cols_to_df(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataF
     for col, typ in dtypes.items():
         if col in df.columns:
             continue
+        if typ == 'int64':
+            typ = 'Int64'
         df[col] = pd.Series([None] * len(df), dtype=typ)
-        #  df[col] = None
-        #  df[col] = df[col].astype(typ)
     
     return df
 
@@ -956,8 +960,13 @@ def filter_unseen_df(
 
     ### assume the old_df knows what it's doing, even if it's technically wrong.
     if dtypes is None:
-        dtypes = dict(old_df.dtypes)
-    dtypes = {col: typ for col, typ in old_df.dtypes.items()}
+        dtypes = {col: str(typ) for col, typ in old_df.dtypes.items()}
+    dtypes = {
+        col: (
+            str(typ) if str(typ) != 'int64' else 'Int64'
+        ) for col, typ in new_df.dtypes.items()
+    }
+
     cast_cols = True
     try:
         new_df = new_df.astype(dtypes)
@@ -1263,6 +1272,7 @@ def remove_ansi(s : str) -> str:
     """
     import re
     return re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])').sub('', s)
+
 
 def get_connector_labels(
         *types: str,
@@ -1763,3 +1773,16 @@ def is_symlink(path: pathlib.Path) -> bool:
         return bool(os.readlink(path))
     except OSError:
         return False
+
+
+def parametrized(dec):
+    """
+    A meta-decorator for allowing other decorator functions to have parameters.
+
+    https://stackoverflow.com/a/26151604/9699829
+    """
+    def layer(*args, **kwargs):
+        def repl(f):
+            return dec(f, *args, **kwargs)
+        return repl
+    return layer

--- a/meerschaum/utils/venv/_Venv.py
+++ b/meerschaum/utils/venv/_Venv.py
@@ -8,6 +8,7 @@ Define a context manager for virtual environments.
 
 from __future__ import annotations
 
+import copy
 import pathlib
 from meerschaum.utils.typing import Union
 
@@ -50,7 +51,7 @@ class Venv:
             self._kwargs = {'venv': venv}
         self._debug = debug
         ### In case someone calls `deactivate()` before `activate()`.
-        self._kwargs['previously_active_venvs'] = active_venvs.copy()
+        self._kwargs['previously_active_venvs'] = copy.deepcopy(active_venvs)
 
 
     def activate(self, debug: bool = False) -> bool:
@@ -60,7 +61,7 @@ class Venv:
         will also be activated.
         """
         from meerschaum.utils.venv import active_venvs
-        self._kwargs['previously_active_venvs'] = active_venvs.copy()
+        self._kwargs['previously_active_venvs'] = copy.deepcopy(active_venvs)
         return self._activate(debug=(debug or self._debug), **self._kwargs)
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -6,15 +6,18 @@
 Test SQL utility functions.
 """
 
+import datetime
 import pytest
 from tests.connectors import conns
 from meerschaum.connectors.sql import SQLConnector
 from meerschaum.connectors.sql.tools import dateadd_str, table_exists, sql_item_name
-import datetime
 import dateutil.parser
 
 @pytest.mark.parametrize("flavor", list(conns.keys()))
 def test_dateadd_str(flavor: str):
+    """
+    Verify that the DATEADD function works for all flavors.
+    """
     conn = conns[flavor]
     if conn.type != 'sql':
         return
@@ -94,4 +97,7 @@ def test_exists(flavor: str):
     ],
 )
 def test_parse_uri(uri: str, expected_attributes):
+    """
+    Text that parsing a URI string returns the expected dictionary.
+    """
     assert SQLConnector.parse_uri(uri) == expected_attributes

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,7 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Test utility functions.
+"""

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Test functions from `meerschaum.utils.misc`.
+"""
+
+import datetime
+import pytest
+from meerschaum.utils.packages import import_pandas
+DEBUG: bool = True
+pd = import_pandas(debug=DEBUG)
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        'object', 'bool', 'float64', 'datetime64[ns]',
+        'Int64', 'int64', 'datetime64[ns, UTC]'
+    ]
+)
+def test_add_missing_cols_to_df(dtype: str):
+    """
+    Test that new columns are successfully added to a dataframe.
+    """
+    from meerschaum.utils.misc import add_missing_cols_to_df
+    df = pd.DataFrame([{'foo': 'bar'}])
+    new_df = add_missing_cols_to_df(df, {'baz': dtype})
+    assert len(df.columns) == 1
+    assert len(new_df.columns) == 2
+    assert str(new_df.dtypes['baz']).lower() == dtype.lower()
+
+
+@pytest.mark.parametrize(
+    'old_docs,new_docs,expected_docs',
+    [
+        (
+            [
+                {'a': 1, 'b': 1},
+            ], [
+                {'a': 1},
+            ], [
+                {'a': 1},
+            ]
+        ),
+        (
+            [
+                {'a': 1,},
+            ], [
+                {'a': 1},
+            ], []
+        ),
+        (
+            [
+                {'a': datetime.datetime(2022, 1, 1), 'b': 100.0},
+            ], [
+                {'a': datetime.datetime(2022, 1, 1), 'b': 100.0},
+            ], []
+        ),
+        (
+            [
+                {'a': 1, 'b': 1},
+            ], [], []
+        ),
+        (
+            [
+                {'a': 'foo', 'b': 'bar'},
+            ], [
+                {'a': 'foo', 'b': 'bar'},
+            ], []
+        ),
+        (
+            [
+                {'a': False, 'b': 'bar'},
+            ], [
+                {'a': False, 'b': 'bar'},
+            ], []
+        ),
+        (
+            [], [], []
+        ),
+        (
+            [{'a': None}], [{'a': None}], []
+        ),
+    ]
+)
+def test_filter_unseen_df(old_docs, new_docs, expected_docs):
+    """
+    Test that duplicate rows are removed.
+    """
+    from meerschaum.utils.misc import filter_unseen_df
+    old_df = pd.DataFrame(old_docs)
+    new_df = pd.DataFrame(new_docs)
+    delta_df = filter_unseen_df(old_df, new_df)
+    assert delta_df.to_dict(orient='records') == expected_docs


### PR DESCRIPTION
# v1.3.4

- **Define environment connectors with JSON or URIs.**  
  Connectors defined as environment variables may now have their attributes set as JSON in addition to a URI string.

- **Custom Connectors may now be defined as environment variables.**  
  You may now set environment variables for custom connectors defined via `@make_connector`, e.g.:

  ```bash
  MRSM_FOO_BAR='{"foo": "bar"}' mrsm show connectors
  ```

- **Allow for custom connectors to be instance connectors.**  
  Add the property `IS_INSTANCE = True` your custom connector to add it to the official list of instance types:

  ```python
  from meerschaum.connectors import make_connector, Connector

  @make_connector
  class FooConnector(Connector):
      IS_INSTANCE = True

      def __init__(label: str, **kw):
          super().__init__('foo', label, **kw)
  ```

- **Install packages for all plugins with `mrsm install required`.**  
  The default behavior for `mrsm install required` with no plugins named is now to install dependencies for all plugins.

- **Syncing bugfixes.**