### PR TITLE
🧵 v1.3.10 Improved virtual environment resolution with multithreading.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.6 – v1.3.7
+### v1.3.10
+
+- **Fixed virtual environment issues when syncing.**  
+  This one's a doozy. Before this patch, there would frequently be warnings and sometimes exceptions thrown when syncing a lot of pipes with a lot of threads. This kind of race condition can be hard to pin down, so this patch reworks the virtual environment resolution system by keeping track of which threads have activated the environments and refusing to deactivate if other threads still depend on the environment. To enforce this behavior, most manual ivocations of [`activate_venv()`](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.activate_venv) were replaced with the [`Venv` context manager](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.Venv). Finally, the last stage of each action is to clean up any stray virtual environments. *Note:* You may still run into the wrong version of a package being imported into your plugin if you're syncing a lot of plugins concurrently.
+
+- **Allow custom instance connectors to be selected on the web console.**  
+  Provided all of the appropriate interface methods are implemented, selecting a custom instance connector from the instance dropdown should no longer throw an error.
+
+- **Bugfixes and improvements to the virtual environment system.**  
+  This patch *should* resolve your virtual environment woes but at a somewhat significant performance penalty. Oh well, 'tis the price we must pay for correct and determinstic code!
+
+### v1.3.6 – v1.3.9
 
 - **Allow for syncing multiple data types per column.**  
   The highlight of this release is support for syncing multiple data types per column. When different data types are encountered, the underlying column will be converted to `TEXT`:
@@ -67,7 +78,7 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Syncing bugfixes.**
 
-### v1.3.2 – 1.3.3
+### v1.3.2 – v1.3.3
 
 - **Fixed a bug with `begin` and `end` bounds in `Pipe.get_data()`.**  
   A safety measure was incorrectly checking if the quoted version of a column was in `pipe.get_columns_types()`, not the unquoted version. This patch restores functionality for `pipe.get_data()`.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.6 – v1.3.7
+### v1.3.10
+
+- **Fixed virtual environment issues when syncing.**  
+  This one's a doozy. Before this patch, there would frequently be warnings and sometimes exceptions thrown when syncing a lot of pipes with a lot of threads. This kind of race condition can be hard to pin down, so this patch reworks the virtual environment resolution system by keeping track of which threads have activated the environments and refusing to deactivate if other threads still depend on the environment. To enforce this behavior, most manual ivocations of [`activate_venv()`](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.activate_venv) were replaced with the [`Venv` context manager](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.Venv). Finally, the last stage of each action is to clean up any stray virtual environments. *Note:* You may still run into the wrong version of a package being imported into your plugin if you're syncing a lot of plugins concurrently.
+
+- **Allow custom instance connectors to be selected on the web console.**  
+  Provided all of the appropriate interface methods are implemented, selecting a custom instance connector from the instance dropdown should no longer throw an error.
+
+- **Bugfixes and improvements to the virtual environment system.**  
+  This patch *should* resolve your virtual environment woes but at a somewhat significant performance penalty. Oh well, 'tis the price we must pay for correct and determinstic code!
+
+### v1.3.6 – v1.3.9
 
 - **Allow for syncing multiple data types per column.**  
   The highlight of this release is support for syncing multiple data types per column. When different data types are encountered, the underlying column will be converted to `TEXT`:
@@ -67,7 +78,7 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Syncing bugfixes.**
 
-### v1.3.2 – 1.3.3
+### v1.3.2 – v1.3.3
 
 - **Fixed a bug with `begin` and `end` bounds in `Pipe.get_data()`.**  
   A safety measure was incorrectly checking if the quoted version of a column was in `pipe.get_columns_types()`, not the unquoted version. This patch restores functionality for `pipe.get_data()`.

--- a/meerschaum/_internal/entry.py
+++ b/meerschaum/_internal/entry.py
@@ -46,7 +46,7 @@ def entry_with_args(
     from meerschaum.plugins import Plugin
     from meerschaum.actions import get_shell, get_action, get_main_action_name
     from meerschaum._internal.arguments import remove_leading_action
-    from meerschaum.utils.venv import Venv
+    from meerschaum.utils.venv import Venv, active_venvs, deactivate_venv
     if kw.get('trace', None):
         from meerschaum.utils.misc import debug_trace
         debug_trace()
@@ -90,6 +90,10 @@ def entry_with_args(
                     if not kw.get('debug', False) else ''
                 )
             )
+
+    ### Clean up stray virtual environments.
+    for venv in [venv for venv in active_venvs]:
+        deactivate_venv(venv, debug=kw.get('debug', False), force=True)
 
     return result
 

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -630,17 +630,18 @@ class Shell(cmd.Cmd):
     def complete_instance(self, text: str, line: str, begin_index: int, end_index: int):
         from meerschaum.utils.misc import get_connector_labels
         from meerschaum._internal.arguments._parse_arguments import parse_line
+        from meerschaum.connectors import instance_types
         args = parse_line(line)
         action = args['action']
         _text = action[1] if len(action) > 1 else ""
-        return get_connector_labels('api', 'sql', search_term=_text, ignore_exact_match=True)
+        return get_connector_labels(*instance_types, search_term=_text, ignore_exact_match=True)
 
 
     def do_repo(
             self,
-            action : Optional[List[str]] = None,
-            debug : bool = False,
-            **kw : Any
+            action: Optional[List[str]] = None,
+            debug: bool = False,
+            **kw: Any
         ) -> SuccessTuple:
         """
         Temporarily set a default Meerschaum repository for the duration of the shell.

--- a/meerschaum/actions/register.py
+++ b/meerschaum/actions/register.py
@@ -48,6 +48,7 @@ def _complete_register(
     from meerschaum._internal.shell import default_action_completer
     return default_action_completer(action=(['register'] + action), **kw)
 
+
 def _register_pipes(
         connector_keys: Optional[List[str]] = None,
         metric_keys: Optional[List[str]] = None,
@@ -66,6 +67,7 @@ def _register_pipes(
     from meerschaum import get_pipes, get_connector
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn, info
+    from meerschaum.utils.misc import items_str
 
     if connector_keys is None:
         connector_keys = []
@@ -100,6 +102,8 @@ def _register_pipes(
 
     success, message = True, "Success"
     failed_message = ""
+    failed_pipes = []
+    success_pipes = []
     for p in pipes:
         if debug:
             dprint(f"Registering {p}...")
@@ -107,12 +111,27 @@ def _register_pipes(
         if not ss:
             warn(f"{msg}", stack=False)
             success = False
-            failed_message += f"{p}, "
+            failed_pipes.append(p)
+        else:
+            success_pipes.append(p)
 
-    if len(failed_message) > 0:
-        message = "Failed to register pipes: " + failed_message[:(-1 * len(', '))]
+    message = ""
+    if success_pipes:
+        message += (
+            f"Successfully registered {len(success_pipes)} pipe"
+            + ('s' if len(success_pipes) != 1 else '') + "."
+        )
+        if failed_pipes:
+            message += "\n"
 
-    return success, message
+    if failed_pipes:
+        message += (
+            f"Failed to register {len(failed_pipes)} pipe"
+            + ('s' if len(failed_pipes) != 1 else '') + "."
+        )
+
+    return len(success_pipes) > 0, message
+
 
 def _register_plugins(
         action: Optional[List[str]] = None,

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -80,6 +80,7 @@ def _complete_show(
     from meerschaum._internal.shell import default_action_completer
     return default_action_completer(action=(['show'] + action), **kw)
 
+
 def _show_actions(**kw: Any) -> SuccessTuple:
     """
     Show available actions.
@@ -91,13 +92,15 @@ def _show_actions(**kw: Any) -> SuccessTuple:
     print_options(options=_actions, name='actions', actions=False, **kw)
     return True, "Success"
 
+
 def _show_help(**kw: Any) -> SuccessTuple:
     """
     Print the --help menu from `argparse`.
     """
-    from meerschaum.actions.arguments._parser import parser
+    from meerschaum._internal.arguments._parser import parser
     print(parser.format_help())
     return True, "Success"
+
 
 def _show_config(
         action: Optional[List[str]] = None,
@@ -130,6 +133,7 @@ def _show_config(
         pprint(config)
     return (True, "Success")
 
+
 def _complete_show_config(action: Optional[List[str]] = None, **kw : Any):
     from meerschaum.config._read_config import get_possible_keys
     keys = get_possible_keys()
@@ -141,6 +145,7 @@ def _complete_show_config(action: Optional[List[str]] = None, **kw : Any):
             possibilities.append(key)
     return possibilities
 
+
 def _show_modules(**kw: Any) -> SuccessTuple:
     """
     Show the currently imported modules.
@@ -149,6 +154,7 @@ def _show_modules(**kw: Any) -> SuccessTuple:
     from meerschaum.utils.formatting import pprint
     pprint(list(sys.modules.keys()), **kw)
     return (True, "Success")
+
 
 def _show_pipes(
         nopretty: bool = False,
@@ -180,6 +186,7 @@ def _show_pipes(
 
     return (True, "Success")
 
+
 def _show_version(nopretty: bool = False, **kw : Any) -> SuccessTuple:
     """
     Show the Meerschaum doc string.
@@ -198,6 +205,7 @@ def _show_version(nopretty: bool = False, **kw : Any) -> SuccessTuple:
         _print = info
     _print(msg)
     return (True, "Success")
+
 
 def _show_connectors(
         action: Optional[List[str]] = None,
@@ -254,6 +262,7 @@ def _show_arguments(
     from meerschaum.utils.formatting import pprint
     pprint(kw)
     return True, "Success"
+
 
 def _show_data(
         action: Optional[List[str]] = None,
@@ -356,6 +365,7 @@ def _show_data(
                 df.plot()
     return True, "Success"
 
+
 def _show_columns(
         action: Optional[List[str]] = None,
         debug: bool = False,
@@ -372,6 +382,7 @@ def _show_columns(
         pprint_pipe_columns(p, nopretty=nopretty, debug=debug)
 
     return True, "Success"
+
 
 def _show_rowcounts(
         action: Optional[List[str]] = None,

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -32,6 +32,7 @@ def stack(
     import io
     import os
     import sys
+    import pathlib
     import meerschaum.config.stack
     from meerschaum.config.stack import NECESSARY_FILES, write_stack
     from meerschaum.config._paths import STACK_COMPOSE_PATH
@@ -128,12 +129,24 @@ def stack(
 
     stdout = None if not _capture_output else subprocess.PIPE
     stderr = stdout
+
+    has_binary_compose = pathlib.Path('/usr/bin/docker-compose').exists()
     proc = subprocess.Popen(
-        ['docker', 'compose'] + cmd_list, cwd=STACK_COMPOSE_PATH.parent,
-        stdout=stdout, stderr=stderr, env=os.environ,
-    ) if has_builtin_compose else run_python_package(
-        'compose', args=cmd_list, cwd=STACK_COMPOSE_PATH.parent, venv=_compose_venv,
-        capture_output=_capture_output, as_proc=True,
+        (
+            ['docker', 'compose'] if has_builtin_compose
+            else ['docker-compose']
+        ) + cmd_list,
+        cwd = STACK_COMPOSE_PATH.parent,
+        stdout = stdout,
+        stderr = stderr,
+        env = os.environ,
+    ) if (has_builtin_compose or has_binary_compose) else run_python_package(
+        'compose',
+        args = cmd_list,
+        cwd = STACK_COMPOSE_PATH.parent,
+        venv = _compose_venv,
+        capture_output = _capture_output,
+        as_proc = True,
     )
     try:
         rc = proc.wait() if proc is not None else 1

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"

--- a/meerschaum/connectors/plugin/PluginConnector.py
+++ b/meerschaum/connectors/plugin/PluginConnector.py
@@ -32,30 +32,33 @@ class PluginConnector(Connector):
         import os, pathlib, sys
         from meerschaum.core import Plugin
         from meerschaum.utils.warnings import error, warn
+        from meerschaum.utils.venv import Venv
+
         self._plugin = Plugin(self.label)
-        if self._plugin.module is None:
-            error(f"Plugin '{self.label}' cannot be found. Is it installed?")
+        with Venv(self._plugin):
+            if self._plugin.module is None:
+                error(f"Plugin '{self.label}' cannot be found. Is it installed?")
 
-        ### Attempt to import a `fetch()` method.
-        self.fetch = None
-        try:
-            self.fetch = self._plugin.module.fetch
-        except Exception as e:
-            pass
+            ### Attempt to import a `fetch()` method.
+            self.fetch = None
+            try:
+                self.fetch = self._plugin.module.fetch
+            except Exception as e:
+                pass
 
-        ### Attempt to import a `sync()` method.
-        self.sync = None
-        try:
-            self.sync = self._plugin.module.sync
-        except Exception as e:
-            pass
+            ### Attempt to import a `sync()` method.
+            self.sync = None
+            try:
+                self.sync = self._plugin.module.sync
+            except Exception as e:
+                pass
 
-        ### Attempt to import a `register()` method.
-        self.register = None
-        try:
-            self.register = self._plugin.module.register
-        except Exception as e:
-            pass
+            ### Attempt to import a `register()` method.
+            self.register = None
+            try:
+                self.register = self._plugin.module.register
+            except Exception as e:
+                pass
 
-        if self.fetch is None and self.sync is None:
-            error(f"Could not import `fetch()` or `sync()` methods for plugin '{self.label}'.")
+            if self.fetch is None and self.sync is None:
+                error(f"Could not import `fetch()` or `sync()` methods for plugin '{self.label}'.")

--- a/meerschaum/connectors/poll.py
+++ b/meerschaum/connectors/poll.py
@@ -146,6 +146,9 @@ def _wrap_retry_connect(
     if connector.type not in instance_types:
         return None
 
+    if not hasattr(connector, 'test_connection'):
+        return True
+
     retries = 0
     connected, chaining_status = False, None
     while retries < max_retries:

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -33,11 +33,6 @@ def fetch(
         If `True` and the pipe's connector is of type `'sql'`, begin syncing chunks while fetching
         loads chunks into memory.
 
-    deactivate_plugin_venv: bool, default True
-        If `True` and the pipe's connector is of type `'plugin'`, deactivate the plugin's
-        virtual environment after retrieving the dataframe.
-        Not intended for general use.
-
     debug: bool, default False
         Verbosity toggle.
 
@@ -84,7 +79,7 @@ def fetch(
         self.connector.type == 'plugin'
         or
         self.connector.type in custom_types
-    ) and deactivate_plugin_venv:
+    ):
         connector_plugin.deactivate_venv(debug=debug)
     ### Return True if we're syncing in parallel, else continue as usual.
     if sync_chunks:

--- a/meerschaum/core/Pipe/_register.py
+++ b/meerschaum/core/Pipe/_register.py
@@ -27,6 +27,7 @@ def register(
     """
     from meerschaum.connectors import custom_types
     from meerschaum.utils.formatting import get_console
+    from meerschaum.utils.venv import Venv
     import warnings
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
@@ -42,8 +43,13 @@ def register(
         and
         getattr(_conn, 'register', None) is not None
     ):
+        if _conn.type == 'plugin':
+            venv = _conn._plugin
+        elif _conn.__module__.startswith('plugins'):
+            venv = _conn.__module__[len('plugins:'):].split('.')[0]
         try:
-            params = self.connector.register(self)
+            with Venv(venv, debug=debug):
+                params = self.connector.register(self)
         except Exception as e:
             get_console().print_exception()
             params = None

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -21,7 +21,7 @@ def pprint_pipes(pipes: PipesDict) -> None:
     rich = import_rich('rich', warn=False)
     Text = None
     if rich is not None:
-        rich_text = attempt_import('rich.text')
+        rich_text = attempt_import('rich.text', lazy=False)
         Text = rich_text.Text
 
     icons = get_config('formatting', 'pipes', CHARSET, 'icons')

--- a/meerschaum/utils/get_pipes.py
+++ b/meerschaum/utils/get_pipes.py
@@ -141,10 +141,10 @@ def get_pipes(
         from meerschaum.connectors.parse import parse_instance_keys
         connector = parse_instance_keys(keys=mrsm_instance, wait=wait, debug=debug)
     else: ### NOTE: mrsm_instance MUST be a SQL or API connector for this to work
-        from meerschaum.connectors import Connector
+        from meerschaum.connectors import instance_types
         valid_connector = False
-        if issubclass(type(mrsm_instance), Connector):
-            if mrsm_instance.type in ('api', 'sql'):
+        if hasattr(mrsm_instance, 'type'):
+            if mrsm_instance.type in instance_types:
                 valid_connector = True
         if not valid_connector:
             error(f"Invalid instance connector: {mrsm_instance}")

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -699,6 +699,7 @@ def table_exists(
     exists = connector.exec(q, debug=debug, silent=True) is not None
     return exists
 
+
 def get_sqlalchemy_table(
         table: str,
         connector: Optional[meerschaum.connectors.sql.SQLConnector] = None,

--- a/meerschaum/utils/threading.py
+++ b/meerschaum/utils/threading.py
@@ -14,6 +14,7 @@ Lock = threading.Lock
 RLock = threading.RLock
 Event = threading.Event
 Timer = threading.Timer
+get_ident = threading.get_ident
 
 class Thread(threading.Thread):
     """Wrapper for threading.Thread with optional callback and error_callback functions."""

--- a/meerschaum/utils/venv/_Venv.py
+++ b/meerschaum/utils/venv/_Venv.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import copy
 import pathlib
 from meerschaum.utils.typing import Union
+from meerschaum.utils.threading import RLock
+
 
 class Venv:
     """


### PR DESCRIPTION
# v1.3.10

- **Fixed virtual environment issues when syncing.**  
  This one's a doozy. Before this patch, there would frequently be warnings and sometimes exceptions thrown when syncing a lot of pipes with a lot of threads. This kind of race condition can be hard to pin down, so this patch reworks the virtual environment resolution system by keeping track of which threads have activated the environments and refusing to deactivate if other threads still depend on the environment. To enforce this behavior, most manual ivocations of [`activate_venv()`](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.activate_venv) were replaced with the [`Venv` context manager](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.Venv). Finally, the last stage of each action is to clean up any stray virtual environments. *Note:* You may still run into the wrong version of a package being imported into your plugin if you're syncing a lot of plugins concurrently.

- **Allow custom instance connectors to be selected on the web console.**  
  Provided all of the appropriate interface methods are implemented, selecting a custom instance connector from the instance dropdown should no longer throw an error.

- **Bugfixes and improvements to the virtual environment system.**  
  This patch *should* resolve your virtual environment woes but at a somewhat significant performance penalty. Oh well, 'tis the price we must pay for correct and determinstic code!