### PR TITLE
v1.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.10 – v1.3.11
+### v1.3.13
+
+- **Fixed an issue when displaying backtrack data on the Web Console.**  
+  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to string before building the table.
+
+- **Added YAML and JSON support to editing parameters.**  
+  YAML is now the default, and toggle buttons have been added to switch the encoding.
+
+- **Removed the index column from the CSV downloader.**  
+  When the download button is clicked, the dataframe's index column will be omitted from the CSV file.
+
+- **Changed the download filename to `<target>.csv`.**  
+  The download process will now name the CSV file after the table rather than the pipe.
+
+### v1.3.10 – v1.3.12
 
 - **Fixed virtual environment issues when syncing.**  
   This one's a doozy. Before this patch, there would frequently be warnings and sometimes exceptions thrown when syncing a lot of pipes with a lot of threads. This kind of race condition can be hard to pin down, so this patch reworks the virtual environment resolution system by keeping track of which threads have activated the environments and refusing to deactivate if other threads still depend on the environment. To enforce this behavior, most manual ivocations of [`activate_venv()`](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.activate_venv) were replaced with the [`Venv` context manager](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.Venv). Finally, the last stage of each action is to clean up any stray virtual environments. *Note:* You may still run into the wrong version of a package being imported into your plugin if you're syncing a lot of plugins concurrently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This is the current release cycle, so stay tuned for future releases!
 - **Changed the download filename to `<target>.csv`.**  
   The download process will now name the CSV file after the table rather than the pipe.
 
+- **Web Console improvements.**  
+  The items in the actions builder now are presented with a monospace font. Actions and subactions will have underscores represented as spaces.
+
+- **Activating the virtual environment `None` will not override your current working directory.**  
+  This is especially useful when testing the API. Activating the virtual environment `None` will insert behind your current working directory or `''` in `sys.path`.
+
 ### v1.3.10 – v1.3.12
 
 - **Fixed virtual environment issues when syncing.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ This is the current release cycle, so stay tuned for future releases!
 ### v1.3.13
 
 - **Fixed an issue when displaying backtrack data on the Web Console.**  
-  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to string before building the table.
+  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to strings before building the table.
 
 - **Added YAML and JSON support to editing parameters.**  
-  YAML is now the default, and toggle buttons have been added to switch the encoding.
+  YAML is now the default, and toggle buttons have been added to switch the encoding. Line numbers have also been added to the editors.
 
 - **Removed the index column from the CSV downloader.**  
   When the download button is clicked, the dataframe's index column will be omitted from the CSV file.
@@ -23,6 +23,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Activating the virtual environment `None` will not override your current working directory.**  
   This is especially useful when testing the API. Activating the virtual environment `None` will insert behind your current working directory or `''` in `sys.path`.
+
+- **Added WebSocket Secure Support.**  
+  This has been coming a long time, so I'm proud to announce that the web console can now detect whether the client is connecting via HTTPS and (assuming the server has the appropriate [proxy configuration](http://nginx.org/en/docs/http/websocket.html)) will connect via WSS.
 
 ### v1.3.10 – v1.3.12
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.3.10 – v1.3.11
+### v1.3.13
+
+- **Fixed an issue when displaying backtrack data on the Web Console.**  
+  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to string before building the table.
+
+- **Added YAML and JSON support to editing parameters.**  
+  YAML is now the default, and toggle buttons have been added to switch the encoding.
+
+- **Removed the index column from the CSV downloader.**  
+  When the download button is clicked, the dataframe's index column will be omitted from the CSV file.
+
+- **Changed the download filename to `<target>.csv`.**  
+  The download process will now name the CSV file after the table rather than the pipe.
+
+### v1.3.10 – v1.3.12
 
 - **Fixed virtual environment issues when syncing.**  
   This one's a doozy. Before this patch, there would frequently be warnings and sometimes exceptions thrown when syncing a lot of pipes with a lot of threads. This kind of race condition can be hard to pin down, so this patch reworks the virtual environment resolution system by keeping track of which threads have activated the environments and refusing to deactivate if other threads still depend on the environment. To enforce this behavior, most manual ivocations of [`activate_venv()`](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.activate_venv) were replaced with the [`Venv` context manager](https://docs.meerschaum.io/utils/venv/index.html#meerschaum.utils.venv.Venv). Finally, the last stage of each action is to clean up any stray virtual environments. *Note:* You may still run into the wrong version of a package being imported into your plugin if you're syncing a lot of plugins concurrently.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -18,6 +18,12 @@ This is the current release cycle, so stay tuned for future releases!
 - **Changed the download filename to `<target>.csv`.**  
   The download process will now name the CSV file after the table rather than the pipe.
 
+- **Web Console improvements.**  
+  The items in the actions builder now are presented with a monospace font. Actions and subactions will have underscores represented as spaces.
+
+- **Activating the virtual environment `None` will not override your current working directory.**  
+  This is especially useful when testing the API. Activating the virtual environment `None` will insert behind your current working directory or `''` in `sys.path`.
+
 ### v1.3.10 – v1.3.12
 
 - **Fixed virtual environment issues when syncing.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -7,10 +7,10 @@ This is the current release cycle, so stay tuned for future releases!
 ### v1.3.13
 
 - **Fixed an issue when displaying backtrack data on the Web Console.**  
-  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to string before building the table.
+  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to strings before building the table.
 
 - **Added YAML and JSON support to editing parameters.**  
-  YAML is now the default, and toggle buttons have been added to switch the encoding.
+  YAML is now the default, and toggle buttons have been added to switch the encoding. Line numbers have also been added to the editors.
 
 - **Removed the index column from the CSV downloader.**  
   When the download button is clicked, the dataframe's index column will be omitted from the CSV file.
@@ -23,6 +23,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Activating the virtual environment `None` will not override your current working directory.**  
   This is especially useful when testing the API. Activating the virtual environment `None` will insert behind your current working directory or `''` in `sys.path`.
+
+- **Added WebSocket Secure Support.**  
+  This has been coming a long time, so I'm proud to announce that the web console can now detect whether the client is connecting via HTTPS and (assuming the server has the appropriate [proxy configuration](http://nginx.org/en/docs/http/websocket.html)) will connect via WSS.
 
 ### v1.3.10 – v1.3.12
 

--- a/meerschaum/api/dash/__init__.py
+++ b/meerschaum/api/dash/__init__.py
@@ -68,7 +68,8 @@ dash_app = enrich.DashProxy(
 dash_app.layout = html.Div([
     location,
     dcc.Store(id='session-store', storage_type='session', data={}),
-    html.Div([], id='page-layout-div')
+    html.Div([], id='page-layout-div'),
+    html.Div(id='websocket-div'),
 ])
 
 import meerschaum.api.dash.pages as pages

--- a/meerschaum/api/dash/__init__.py
+++ b/meerschaum/api/dash/__init__.py
@@ -69,7 +69,6 @@ dash_app.layout = html.Div([
     location,
     dcc.Store(id='session-store', storage_type='session', data={}),
     html.Div([], id='page-layout-div'),
-    html.Div(id='websocket-div'),
 ])
 
 import meerschaum.api.dash.pages as pages

--- a/meerschaum/api/dash/actions.py
+++ b/meerschaum/api/dash/actions.py
@@ -162,7 +162,7 @@ def execute_action(state: WebState):
     def use_process():
         from meerschaum.utils.packages import run_python_package
         from meerschaum._internal.arguments._parse_arguments import parse_dict_to_sysargs
-        max_buffer_size = 30000
+        max_buffer_size = 10000
         line_buffer = ''
         def send_line(line: str):
             nonlocal line_buffer

--- a/meerschaum/api/dash/actions.py
+++ b/meerschaum/api/dash/actions.py
@@ -162,7 +162,7 @@ def execute_action(state: WebState):
     def use_process():
         from meerschaum.utils.packages import run_python_package
         from meerschaum._internal.arguments._parse_arguments import parse_dict_to_sysargs
-        max_buffer_size = 10000
+        max_buffer_size = 30000
         line_buffer = ''
         def send_line(line: str):
             nonlocal line_buffer
@@ -170,6 +170,7 @@ def execute_action(state: WebState):
             buff_start_idx = max(len(line_buffer) - max_buffer_size, 0)
             line_buffer = line_buffer[buff_start_idx:]
             ws_send(line_buffer, session_id)
+
         def do_process():
             keywords['action'] = [action] + subactions
             _sysargs = parse_dict_to_sysargs(keywords)

--- a/meerschaum/api/dash/callbacks/dashboard.py
+++ b/meerschaum/api/dash/callbacks/dashboard.py
@@ -32,6 +32,7 @@ from meerschaum.utils.packages import attempt_import, import_html, import_dcc
 from meerschaum.utils.misc import (
     string_to_dict, get_connector_labels, json_serialize_datetime, filter_keywords
 )
+from meerschaum.utils.yaml import yaml
 from meerschaum.actions import get_subactions, actions
 from meerschaum._internal.arguments._parser import get_arguments_triggers, parser
 from meerschaum.connectors.sql._fetch import set_pipe_query
@@ -176,14 +177,14 @@ def update_content(*args):
 
     ### NOTE: functions MUST return a list of content and a list of alerts
     triggers = {
-        'go-button' : execute_action,
-        'cancel-button' : stop_action,
-        'get-pipes-button' : get_pipes_cards,
-        'get-jobs-button' : get_jobs_cards,
-        'get-plugins-button' : get_plugins_cards,
-        'get-users-button' : get_users_cards,
-        'get-graphs-button' : get_graphs_cards,
-        'check-input-interval' : check_input_interval,
+        'go-button': execute_action,
+        'cancel-button': stop_action,
+        'get-pipes-button': get_pipes_cards,
+        'get-jobs-button': get_jobs_cards,
+        'get-plugins-button': get_plugins_cards,
+        'get-users-button': get_users_cards,
+        'get-graphs-button': get_graphs_cards,
+        'check-input-interval': check_input_interval,
     }
     ### Defaults to 3 if not in dict.
     trigger_num_cols = {
@@ -223,7 +224,7 @@ def update_content(*args):
     Input('action-dropdown', 'value'),
     Input('subaction-dropdown', 'value'),
 )
-def update_actions(action : str, subaction : str):
+def update_actions(action: str, subaction: str):
     """
     Update the subactions dropdown to reflect options for the primary action.
     """
@@ -232,16 +233,15 @@ def update_actions(action : str, subaction : str):
         trigger = None
     _actions_options = sorted([
         {
-            'label' : a,
+            'label' : a.replace('_', ' '),
             'value' : a,
             'title' : (textwrap.dedent(f.__doc__).lstrip() if f.__doc__ else 'No help available.'),
         }
         for a, f in actions.items() if a not in omit_actions
     ], key=lambda k: k['label'])
-    _actions = [o['label'] for o in _actions_options]
     _subactions_options = sorted([
         {
-            'label' : sa,
+            'label' : sa.replace('_', ' '),
             'value' : sa,
             'title' : (textwrap.dedent(f.__doc__).lstrip() if f.__doc__ else 'No help available.'),
         }
@@ -522,13 +522,13 @@ def download_pipe_csv(n_clicks):
     pipe = pipe_from_ctx(ctx, 'n_clicks')
     if pipe is None:
         raise PreventUpdate
-    filename = str(pipe) + '.csv'
+    filename = str(pipe.target) + '.csv'
     try:
         df = pipe.get_data(debug=debug)
     except Exception as e:
         df = None
     if df is not None:
-        return dcc.send_data_frame(df.to_csv, filename)
+        return dcc.send_data_frame(df.to_csv, filename, index=False)
     raise PreventUpdate
 
 
@@ -570,11 +570,16 @@ def update_pipe_parameters_click(n_clicks, parameters_editor_text):
         success, msg = False, f"Unable to update parameters for {pipe}."
     else:
         try:
-            params = json.loads(parameters_editor_text)
+            text_format = 'JSON' if parameters_editor_text.lstrip().startswith('{') else 'YAML'
+            params = (
+                json.loads(parameters_editor_text)
+                if text_format == 'JSON'
+                else yaml.load(parameters_editor_text)
+            )
             pipe.parameters = params
             success, msg = pipe.edit(debug=debug)
         except Exception as e:
-            success, msg = False, f"Invalid JSON:\n{e}"
+            success, msg = False, f"Invalid {text_format}:\n{e}"
 
     return alert_from_success_tuple((success, msg))
 
@@ -687,3 +692,34 @@ def sign_out_button_click(
     if session_id and session_id in active_sessions:
         del active_sessions[session_id]
     return endpoints['dash'], {}
+
+
+@dash_app.callback(
+    Output({'type': 'parameters-editor', 'index': MATCH}, 'value'),
+    Input({'type': 'parameters-as-yaml-button', 'index': MATCH}, 'n_clicks'),
+    Input({'type': 'parameters-as-json-button', 'index': MATCH}, 'n_clicks'),
+    prevent_initial_callback = True,
+)
+def parameters_as_yaml_or_json_click(
+        yaml_n_clicks: Optional[int],
+        json_n_clicks: Optional[int],
+        prevent_initial_callback = True,
+    ):
+    """
+    When the `YAML` button is clicked under the parameters editor, switch the content to YAML.
+    """
+    if not yaml_n_clicks and not json_n_clicks:
+        raise PreventUpdate
+
+    ctx = dash.callback_context
+    triggered = dash.callback_context.triggered
+    if triggered[0]['value'] is None:
+        raise PreventUpdate
+    as_yaml = 'yaml' in triggered[0]['prop_id']
+    pipe = pipe_from_ctx(triggered, 'n_clicks')
+    if pipe is None:
+        raise PreventUpdate
+
+    if as_yaml:
+        return yaml.dump(pipe.parameters)
+    return json.dumps(pipe.parameters, indent=4, separators=(',', ': '), sort_keys=True)

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -59,7 +59,7 @@ bottom_buttons_content = dbc.Card(
 console_div = html.Div(id='console-div', children=[html.Pre(get_shell().intro, id='console-pre')])
 
 location = dcc.Location(id='location', refresh=False)
-websocket = dex.WebSocket(id='ws', url='')
+websocket = dex.WebSocket(id='ws', url='', protocols=['ws', 'wss'])
 
 search_parameters_editor = dash_ace.DashAceEditor(
     id = 'search-parameters-editor',

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -7,7 +7,6 @@ Custom components are defined here.
 """
 
 from __future__ import annotations
-from dash.dependencies import Input, Output, State
 from meerschaum.utils.venv import Venv
 from meerschaum.utils.packages import attempt_import, import_dcc, import_html
 from meerschaum.utils.typing import SuccessTuple, List

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -59,7 +59,6 @@ bottom_buttons_content = dbc.Card(
 console_div = html.Div(id='console-div', children=[html.Pre(get_shell().intro, id='console-pre')])
 
 location = dcc.Location(id='location', refresh=False)
-websocket = dex.WebSocket(id='ws', url='', protocols=['ws', 'wss'])
 
 search_parameters_editor = dash_ace.DashAceEditor(
     id = 'search-parameters-editor',

--- a/meerschaum/api/dash/keys.py
+++ b/meerschaum/api/dash/keys.py
@@ -58,7 +58,7 @@ action_dropdown_row = html.Div(
                         dbc.Select(
                             id = 'action-dropdown',
                             options = [],
-                            className = 'custom-select'
+                            className = 'custom-select input-text'
                             #  clearable = False,
                             #  style = {'height' : '150px'},
                         ),
@@ -72,10 +72,10 @@ action_dropdown_row = html.Div(
                         dbc.Select(
                             id = 'subaction-dropdown',
                             options = [],
-                            className = 'custom-select'
+                            className = 'custom-select input-text'
                         ),
                         id = 'subaction-dropdown-div',
-                        className = 'dbc_dark'
+                        className = 'dbc_dark input-text'
                     ),
                     width = widths['subaction']
                 ),
@@ -83,18 +83,17 @@ action_dropdown_row = html.Div(
                     html.Div(
                         dbc.InputGroup(
                             children = [
-                                #  dbc.InputGroupAddon(
-                                    dbc.Button(
-                                        'Clear',
-                                        color = 'link',
-                                        id = 'clear-subaction-dropdown-text-button',
-                                        size = 'sm',
-                                    ),
-                                    #  addon_type = 'prepend',
-                                #  ),
+                                dbc.Button(
+                                    'Clear',
+                                    color = 'link',
+                                    id = 'clear-subaction-dropdown-text-button',
+                                    size = 'sm',
+                                    style = {'text-decoration': 'none'},
+                                ),
                                 dbc.Input(
                                     id = 'subaction-dropdown-text',
                                     placeholder = 'Action arguments',
+                                    className = 'input-text',
                                 ),
                             ],
                         ),
@@ -118,50 +117,73 @@ action_dropdown_row = html.Div(
                             value = ['yes'],
                         ),
                         id = 'flags-dropdown-div',
-                        className = 'dbc_dark',
+                        className = 'dbc_dark input-text',
                     ),
-                    width = widths['flags'],      
+                    width = widths['flags'],
                 ),
             ],
         ),
         html.Br(),
-        dbc.Row(
-            children = [
-                dbc.Col(
-                    children = [
-                        html.Div(
-                            children = [
-                                dbc.Button(
-                                    'Additional parameters',
-                                    id = 'show-arguments-collapse-button',
-                                    color = 'link',
-                                    size = 'md',
-                                    outline = True,
-                                    style = {'display': 'none'},
-                                ),
-                                #  html.Br(),
-                                dbc.Collapse(
-                                    children = [
-                                        dbc.Button(
-                                            'Clear',
-                                            id = 'clear-begin-end-datepicker-button',
-                                            color = 'link',
-                                            size = 'sm',
-                                        ),
-                                        dcc.DatePickerRange(
-                                            id = 'begin-end-datepicker',
-                                        ),
-                                    ],
-                                    id = 'arguments-collapse',
-                                ),
-                            ], ### end of div children
-                        ),
-                    ], ### end of col children
-                    width = widths['arguments'],
-                ),
-            ], ### end of row children
-        ),
-    ] ### end of parent div children
+        #  dbc.Row(
+            #  [
+                #  dbc.Col(
+                    #  html.Div(
+                        #  dcc.Dropdown(
+                            #  id = {'type': 'input-flags-dropdown', 'index': 0},
+                            #  multi = False,
+                            #  placeholder = 'Optional flags',
+                            #  options = [],
+                            #  value = ['yes'],
+                        #  ),
+                        #  id = 'flags-dropdown-div',
+                        #  className = 'dbc_dark input-text',
+                    #  ),
+                    #  width = widths['flags'],
+                    #  id = 'input-flags-left-col',
+                #  ),
+                #  dbc.Col(),
+            #  ],
+            #  id = 'input-flags-row',
+            #  className = 'input-text',
+        #  ),
+        #  dbc.Row(
+            #  children = [
+                #  dbc.Col(
+                    #  children = [
+                        #  html.Div(
+                            #  children = [
+                                #  dbc.Button(
+                                    #  'Additional parameters',
+                                    #  id = 'show-arguments-collapse-button',
+                                    #  color = 'link',
+                                    #  size = 'md',
+                                    #  outline = True,
+                                    #  style = {'display': 'none'},
+                                #  ),
+                                #  #  html.Br(),
+                                #  dbc.Collapse(
+                                    #  children = [
+                                        #  dbc.Button(
+                                            #  'Clear',
+                                            #  id = 'clear-begin-end-datepicker-button',
+                                            #  color = 'link',
+                                            #  size = 'sm',
+                                        #  ),
+                                        #  dcc.DatePickerRange(
+                                            #  id = 'begin-end-datepicker',
+                                        #  ),
+                                    #  ],
+                                    #  id = 'arguments-collapse',
+                                #  ),
+                            #  ], ### end of div children
+                        #  ),
+                    #  ], ### end of col children
+                    #  width = widths['arguments'],
+                #  ),
+            #  ], ### end of row children
+        #  ),
+    ], ### end of parent div children
+    id = 'action-div',
 )
 
 

--- a/meerschaum/api/dash/pages/dashboard.py
+++ b/meerschaum/api/dash/pages/dashboard.py
@@ -19,7 +19,7 @@ px = attempt_import('plotly.express', warn=False, check_update=CHECK_UPDATE)
 daq = attempt_import('dash_daq', warn=False, check_update=CHECK_UPDATE)
 
 from meerschaum.api.dash.components import (
-    go_button, search_parameters_editor, websocket, test_button,
+    go_button, search_parameters_editor, test_button,
     get_items_menu, bottom_buttons_content, console_div, download_dataframe, navbar,
 )
 from meerschaum.api.dash.keys import (
@@ -29,7 +29,6 @@ from meerschaum.api.dash.keys import (
 layout = html.Div(
     id = 'main-div',
     children = [
-        websocket,
         keys_lists_content,
         download_dataframe,
         dcc.Interval(

--- a/meerschaum/api/dash/pages/dashboard.py
+++ b/meerschaum/api/dash/pages/dashboard.py
@@ -29,6 +29,7 @@ from meerschaum.api.dash.keys import (
 layout = html.Div(
     id = 'main-div',
     children = [
+        html.Div(id='websocket-div'),
         keys_lists_content,
         download_dataframe,
         dcc.Interval(

--- a/meerschaum/api/dash/websockets.py
+++ b/meerschaum/api/dash/websockets.py
@@ -15,8 +15,7 @@ def ws_url_from_href(href: str) -> str:
     Generate the websocket URL from the webpage href.
     """
     http_protocol = href.split('://')[0]
-    #  ws_protocol = 'wss' if http_protocol == 'https' else 'ws'
-    ws_protocol = 'ws'
+    ws_protocol = 'wss' if http_protocol == 'https' else 'ws'
     host_and_port = href.replace(http_protocol + '://', '').split('/')[0]
     return (
         ws_protocol + '://' +

--- a/meerschaum/api/dash/websockets.py
+++ b/meerschaum/api/dash/websockets.py
@@ -8,19 +8,20 @@ Functions for interacting via WebSockets.
 
 import asyncio, sys
 from meerschaum.api._websockets import websockets
-from meerschaum.config.static import _static_config
+from meerschaum.config.static import STATIC_CONFIG
 
-def ws_url_from_href(href : str) -> str:
+def ws_url_from_href(href: str) -> str:
     """
     Generate the websocket URL from the webpage href.
     """
     http_protocol = href.split('://')[0]
-    ws_protocol = 'wss' if http_protocol == 'https' else 'ws'
+    #  ws_protocol = 'wss' if http_protocol == 'https' else 'ws'
+    ws_protocol = 'ws'
     host_and_port = href.replace(http_protocol + '://', '').split('/')[0]
     return (
         ws_protocol + '://' +
         host_and_port +
-        _static_config()['api']['endpoints']['websocket']
+        STATIC_CONFIG['api']['endpoints']['websocket']
     )
 
 def ws_send(msg: str, session_id: str) -> None:

--- a/meerschaum/api/resources/static/css/dash.css
+++ b/meerschaum/api/resources/static/css/dash.css
@@ -62,3 +62,6 @@ a {
   color: white;
   margin-top: 5px;
 }
+.input-text {
+  font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif !important;
+}

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.13.dev4"
+__version__ = "1.3.13"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.13.dev3"
+__version__ = "1.3.13.dev4"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.12"
+__version__ = "1.3.13.dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.13.dev2"
+__version__ = "1.3.13.dev3"

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -83,7 +83,13 @@ def activate_venv(
         if target in active_venvs_order:
             sys.path.remove(target)
             active_venvs_order.remove(target)
-        sys.path.insert(0, target)
+        if venv is not None:
+            sys.path.insert(0, target)
+        else:
+            if sys.path and sys.path[0] in (os.getcwd(), ''):
+                sys.path.insert(1, target)
+            else:
+                sys.path.insert(0, target)
         active_venvs_order.insert(0, target)
 
     return True


### PR DESCRIPTION
# v1.3.13

- **Fixed an issue when displaying backtrack data on the Web Console.**  
  Certain values like `pd.NA` would break the Recent Data view on the Web Console. Now the values are cast to strings before building the table.

- **Added YAML and JSON support to editing parameters.**  
  YAML is now the default, and toggle buttons have been added to switch the encoding. Line numbers have also been added to the editors.

- **Removed the index column from the CSV downloader.**  
  When the download button is clicked, the dataframe's index column will be omitted from the CSV file.

- **Changed the download filename to `<target>.csv`.**  
  The download process will now name the CSV file after the table rather than the pipe.

- **Web Console improvements.**  
  The items in the actions builder now are presented with a monospace font. Actions and subactions will have underscores represented as spaces.

- **Activating the virtual environment `None` will not override your current working directory.**  
  This is especially useful when testing the API. Activating the virtual environment `None` will insert behind your current working directory or `''` in `sys.path`.

- **Added WebSocket Secure Support.**  
  This has been coming a long time, so I'm proud to announce that the web console can now detect whether the client is connecting via HTTPS and (assuming the server has the appropriate [proxy configuration](http://nginx.org/en/docs/http/websocket.html)) will connect via WSS.