### PR TITLE
✨ v1.4.0 In-place syncing, `--params` improvements, and more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,55 @@
 # 🪵 Changelog
 
-## 1.3.x Releases
+## 1.4.x Releases
 
 This is the current release cycle, so stay tuned for future releases!
+
+### v1.4.0
+
+- **Added in-place syncing for SQL pipes.**  
+  This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.
+
+  ```python
+  import meerschaum as mrsm
+  import pandas as pd
+
+  conn = mrsm.get_connector('sql', 'local')
+  conn.to_sql(pd.DataFrame([{'a': 1}]), 'foo')
+  
+  pipe = mrsm.Pipe(
+      "sql:local", "foo",
+      instance = "sql:local",
+      parameters = {
+          "query": "SELECT * FROM foo"
+      },
+  )
+  ### This will no longer load table data into memory.
+  pipe.sync()
+  ```
+
+  To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.
+
+- **Added negation to `--params`.**  
+  The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):
+
+  ```bash
+  ### Show recent data, excluding where `id` equals `2`.
+  mrsm show data --params id:_2
+  ```
+
+- **Added `--params` to SQL pipes' queries.**  
+  Specifying parameters when syncing SQL pipes will add those constraints to the fetch stage.
+
+- **Skip invalid parameters in `--params`.**  
+  If a column does not exist in a pipe's table, the value will be ignored in `--params`.
+
+- **Fixed environment issue when starting the Web API with `gunicorn`.**
+- **Added an emoji to the SQL Query option of the web console.**
+- **Fixed an edge case with data type enforcement.**
+
+## 1.3.x Releases
+
+The 1.3.x series brought a tremendous amount of new features and stability improvements. Read below to see everything that was introduced!
 
 ### v1.3.13
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -1,8 +1,55 @@
 # 🪵 Changelog
 
-## 1.3.x Releases
+## 1.4.x Releases
 
 This is the current release cycle, so stay tuned for future releases!
+
+### v1.4.0
+
+- **Added in-place syncing for SQL pipes.**  
+  This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.
+
+  ```python
+  import meerschaum as mrsm
+  import pandas as pd
+
+  conn = mrsm.get_connector('sql', 'local')
+  conn.to_sql(pd.DataFrame([{'a': 1}]), 'foo')
+  
+  pipe = mrsm.Pipe(
+      "sql:local", "foo",
+      instance = "sql:local",
+      parameters = {
+          "query": "SELECT * FROM foo"
+      },
+  )
+  ### This will no longer load table data into memory.
+  pipe.sync()
+  ```
+
+  To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.
+
+- **Added negation to `--params`.**  
+  The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):
+
+  ```bash
+  ### Show recent data, excluding where `id` equals `2`.
+  mrsm show data --params id:_2
+  ```
+
+- **Added `--params` to SQL pipes' queries.**  
+  Specifying parameters when syncing SQL pipes will add those constraints to the fetch stage.
+
+- **Skip invalid parameters in `--params`.**  
+  If a column does not exist in a pipe's table, the value will be ignored in `--params`.
+
+- **Fixed environment issue when starting the Web API with `gunicorn`.**
+- **Added an emoji to the SQL Query option of the web console.**
+- **Fixed an edge case with data type enforcement.**
+
+## 1.3.x Releases
+
+The 1.3.x series brought a tremendous amount of new features and stability improvements. Read below to see everything that was introduced!
 
 ### v1.3.13
 

--- a/meerschaum/actions/api.py
+++ b/meerschaum/actions/api.py
@@ -137,7 +137,7 @@ def _api_start(
     )
     from meerschaum.config._patch import apply_patch_to_config
     from meerschaum.config._environment import get_env_vars
-    from meerschaum.config.static import _static_config, SERVER_ID
+    from meerschaum.config.static import STATIC_CONFIG, SERVER_ID
     from meerschaum.connectors.parse import parse_instance_keys
     from meerschaum.utils.pool import get_pool
     import shutil
@@ -239,25 +239,24 @@ def _api_start(
             pprint(uvicorn_config, stream=sys.stderr, nopretty=nopretty)
         json.dump(uvicorn_config, f)
 
-    MRSM_SERVER_ID = _static_config()['environment']['id']
-    MRSM_CONFIG = _static_config()['environment']['config']
-    MRSM_RUNTIME = _static_config()['environment']['runtime']
-    MRSM_PATCH = _static_config()['environment']['patch']
-    MRSM_ROOT_DIR = _static_config()['environment']['root']
+    MRSM_SERVER_ID = STATIC_CONFIG['environment']['id']
+    MRSM_CONFIG = STATIC_CONFIG['environment']['config']
+    MRSM_RUNTIME = STATIC_CONFIG['environment']['runtime']
+    MRSM_PATCH = STATIC_CONFIG['environment']['patch']
+    MRSM_ROOT_DIR = STATIC_CONFIG['environment']['root']
     env_dict = {
         MRSM_SERVER_ID: SERVER_ID,
         MRSM_RUNTIME: 'api',
-        MRSM_CONFIG: apply_patch_to_config(
-            get_config('system'),
-            {'system': {'api': {'uvicorn': uvicorn_config}}},
-        ),
     }
-    if MRSM_PATCH in os.environ:
-        env_dict[MRSM_PATCH] = os.environ[MRSM_PATCH]
     for env_var in get_env_vars():
         if env_var in env_dict:
             continue
         env_dict[env_var] = os.environ[env_var]
+
+    env_dict[MRSM_CONFIG] = apply_patch_to_config(
+        env_dict.get(MRSM_CONFIG, {}),
+        {'system': {'api': {'uvicorn': uvicorn_config}}},
+    )
 
     env_text = ''
     for key, val in env_dict.items():

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -173,7 +173,7 @@ def accordion_items_from_pipe(
         '📔 Parameters': 'parameters',
     }
     if pipe.connector_keys.startswith('sql:'):
-        items_titles['SQL Query'] = 'sql'
+        items_titles['📃 SQL Query'] = 'sql'
     items_titles.update({
         '🗃️ Recent Data': 'recent-data',
         '📝 Sync Documents': 'sync-data',
@@ -278,14 +278,14 @@ def accordion_items_from_pipe(
             id = {'type': 'parameters-as-yaml-button', 'index': json.dumps(pipe.meta)},
             color = 'link',
             size = 'sm',
-            style = {'text-decoration': 'none', 'margin-left': '10px'},
+            style = {'text-decoration': 'none'},
         )
         as_json_button = dbc.Button(
             "JSON",
             id = {'type': 'parameters-as-json-button', 'index': json.dumps(pipe.meta)},
             color = 'link',
             size = 'sm',
-            style = {'text-decoration': 'none'},
+            style = {'text-decoration': 'none', 'margin-left': '10px'},
         )
         items_bodies['parameters'] = html.Div([
             parameters_editor,

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -110,6 +110,7 @@ default_system_config = {
         'cache': True,
         'space': False,
         'join_fetch': False,
+        'inplace_sync': True,
     },
 }
 default_pipes_config       = {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.3.13"
+__version__ = "1.4.0"

--- a/meerschaum/connectors/sql/SQLConnector.py
+++ b/meerschaum/connectors/sql/SQLConnector.py
@@ -27,7 +27,7 @@ class SQLConnector(Connector):
     from ._create_engine import flavor_configs, create_engine
     from ._sql import read, value, exec, execute, to_sql, exec_queries
     from meerschaum.utils.sql import test_connection
-    from ._fetch import fetch
+    from ._fetch import fetch, get_pipe_metadef
     from ._cli import cli
     from ._pipes import (
         fetch_pipes_keys,
@@ -40,11 +40,13 @@ class SQLConnector(Connector):
         delete_pipe,
         get_backtrack_data,
         get_pipe_data,
+        get_pipe_data_query,
         register_pipe,
         edit_pipe,
         get_pipe_id,
         get_pipe_attributes,
         sync_pipe,
+        sync_pipe_inplace,
         get_sync_time,
         pipe_exists,
         get_pipe_rowcount,

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -60,6 +60,7 @@ flavor_configs = {
         'engine'       : 'mssql+pyodbc',
         'create_engine' : {
             'fast_executemany': True,
+            'isolation_level': 'AUTOCOMMIT',
         },
         'omit_create_engine': {'method',},
         'to_sql': {
@@ -280,8 +281,6 @@ def create_engine(
             **_create_engine_args
         )
     except Exception as e:
-        #  import traceback
-        #  traceback.print_exc(e)
         warn(e)
         warn(f"Failed to create connector '{self}'.", stack=False)
         engine = None

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -47,7 +47,7 @@ def enforce_dtypes(self, df: 'pd.DataFrame', debug: bool=False) -> 'pd.DataFrame
             )
         return df
 
-    df_dtypes = {c: t.name for c, t in dict(df.dtypes).items()}
+    df_dtypes = {c: str(t) for c, t in df.dtypes.items()}
     if len(df_dtypes) == 0:
         if debug:
             dprint("Incoming DataFrame has no columns. Skipping enforcement...")

--- a/tests/pipes.py
+++ b/tests/pipes.py
@@ -32,8 +32,6 @@ for _label, instance in conns.items():
     all_pipes[_label].append(stress_pipe)
     stress_pipes[_label].append(stress_pipe)
     for __label, conn in conns.items():
-        if _label == __label:
-            continue
         remote_pipe = Pipe(
             str(conn), 'test', None,
             mrsm_instance=instance,


### PR DESCRIPTION
# v1.4.0

- **Added in-place syncing for SQL pipes.**  
  This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.

  ```python
  import meerschaum as mrsm
  import pandas as pd

  conn = mrsm.get_connector('sql', 'local')
  conn.to_sql(pd.DataFrame([{'a': 1}]), 'foo')
  
  pipe = mrsm.Pipe(
      "sql:local", "foo",
      instance = "sql:local",
      parameters = {
          "query": "SELECT * FROM foo"
      },
  )
  ### This will no longer load table data into memory.
  pipe.sync()
  ```

  To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.

- **Added negation to `--params`.**  
  The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):

  ```bash
  ### Show recent data, excluding where `id` equals `2`.
  mrsm show data --params id:_2
  ```

- **Added `--params` to SQL pipes' queries.**  
  Specifying parameters when syncing SQL pipes will add those constraints to the fetch stage.

- **Skip invalid parameters in `--params`.**  
  If a column does not exist in a pipe's table, the value will be ignored in `--params`.

- **Fixed environment issue when starting the Web API with `gunicorn`.**
- **Added an emoji to the SQL Query option of the web console.**
- **Fixed an edge case with data type enforcement.**