### PR TITLE
v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.4.1
+### v1.4.0 – v1.4.4
 
 - **Added in-place syncing for SQL pipes.**  
   This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.
@@ -27,7 +27,9 @@ This is the current release cycle, so stay tuned for future releases!
   pipe.sync()
   ```
 
-  To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.
+  This applies even when the source table's schema changes, just like the dynamic columns feature added in v1.3.0.
+
+  > *To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.*
 
 - **Added negation to `--params`.**  
   The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):
@@ -46,6 +48,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fixed environment issue when starting the Web API with `gunicorn`.**
 - **Added an emoji to the SQL Query option of the web console.**
 - **Fixed an edge case with data type enforcement.**
+- **Other bugfixes**
 
 ## 1.3.x Releases
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.4.1
+### v1.4.0 – v1.4.4
 
 - **Added in-place syncing for SQL pipes.**  
   This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.
@@ -27,7 +27,9 @@ This is the current release cycle, so stay tuned for future releases!
   pipe.sync()
   ```
 
-  To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.
+  This applies even when the source table's schema changes, just like the dynamic columns feature added in v1.3.0.
+
+  > *To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.*
 
 - **Added negation to `--params`.**  
   The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):
@@ -46,6 +48,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fixed environment issue when starting the Web API with `gunicorn`.**
 - **Added an emoji to the SQL Query option of the web console.**
 - **Fixed an edge case with data type enforcement.**
+- **Other bugfixes**
 
 ## 1.3.x Releases
 

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -332,8 +332,8 @@ def get_pipe_data(
         connector_keys: str,
         metric_key: str,
         location_key: str,
-        begin: datetime.datetime = None,
-        end: datetime.datetime = None,
+        begin: str = None,
+        end: str = None,
         params: Optional[str] = None,
         orient: str = 'records',
         curr_user = (

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -110,7 +110,7 @@ default_system_config = {
         'cache': True,
         'space': False,
         'join_fetch': False,
-        'inplace_sync': False,
+        'inplace_sync': True,
     },
 }
 default_pipes_config       = {

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -110,7 +110,7 @@ default_system_config = {
         'cache': True,
         'space': False,
         'join_fetch': False,
-        'inplace_sync': True,
+        'inplace_sync': False,
     },
 }
 default_pipes_config       = {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.4.3"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"

--- a/meerschaum/config/stack/grafana/__init__.py
+++ b/meerschaum/config/stack/grafana/__init__.py
@@ -10,36 +10,36 @@ import os
 from meerschaum.config.stack import db_host, db_user, db_pass, db_port, db_base
 
 default_datasource = {
-    'apiVersion' : 1,
-    'datasources' : [
+    'apiVersion': 1,
+    'datasources': [
         {
-            'name' : 'Meerschaum Main',
-            'type' : 'postgres',
-            'jsonData' : {
-                'sslmode' : 'disable',
-                'postgresVersion' : 1400,
-                'timescaledb' : True,
+            'name': 'Meerschaum Main',
+            'type': 'postgres',
+            'jsonData': {
+                'sslmode': 'disable',
+                'postgresVersion': 1400,
+                'timescaledb': True,
             },
-            'user' : db_user,
-            'secureJsonData' : {
-                'password' : db_pass,
+            'user': db_user,
+            'secureJsonData': {
+                'password': db_pass,
             },
-            'database' : db_base,
-            'url' : db_host + ':' + str(db_port),
-            'isDefault' : True,
-            'editable' : True,
+            'database': db_base,
+            'url': db_host + ':5432',
+            'isDefault': True,
+            'editable': True,
         }
     ],
 }
 
 default_dashboard = {
-    'apiVersion' : 1,
-    'providers' : [
+    'apiVersion': 1,
+    'providers': [
         {
-            'name' : 'Default',
-            'folder' : 'Meerschaum Dashboards',
-            'options' : {
-                'path' : '/etc/grafana/provisioning/dashboards',
+            'name': 'Default',
+            'folder': 'Meerschaum Dashboards',
+            'options': {
+                'path': '/etc/grafana/provisioning/dashboards',
             },
         }
     ],
@@ -70,4 +70,3 @@ def edit_grafana(
         'dashboard.yaml' : GRAFANA_DASHBOARD_PATH,
     }
     return general_edit_config(action=action, files=files, default='datasource', debug=debug)
-

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -225,7 +225,7 @@ def sync_pipe(
 
     for i, c in enumerate(chunks):
         if debug:
-            dprint(f"Posting chunk ({i + 1} / {_chunksize}) to {r_url}...")
+            dprint(f"Posting chunk ({i + 1} / {len(chunks)}) to {r_url}...")
         json_str = get_json_str(c)
 
         try:
@@ -301,8 +301,8 @@ def delete_pipe(
 def get_pipe_data(
         self,
         pipe: meerschaum.Pipe,
-        begin: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
+        begin: Union[str, datetime.datetime, None] = None,
+        end: Union[str, datetime.datetime, None] = None,
         params: Optional[Dict[str, Any]] = None,
         as_chunks: bool = False,
         debug: bool = False,

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -732,6 +732,7 @@ def get_pipe_data_query(
         limit: Optional[int] = None,
         begin_add_minutes: int = 0,
         end_add_minutes: int = 0,
+        replace_nulls: Optional[str] = None,
         debug: bool = False,
         **kw: Any
     ) -> Union[str, None]:
@@ -769,6 +770,9 @@ def get_pipe_data_query(
     chunksize: Optional[int], default -1
         The size of dataframe chunks to load into memory.
 
+    replace_nulls: Optional[str], default None
+        If provided, replace null values with this value.
+
     debug: bool, default False
         Verbosity toggle.
 
@@ -784,7 +788,18 @@ def get_pipe_data_query(
     from meerschaum.utils.warnings import warn
     pd = import_pandas()
 
-    query = f"SELECT * FROM {sql_item_name(pipe.target, self.flavor)}"
+    select_cols = "SELECT *"
+    if replace_nulls:
+        existing_cols = pipe.get_columns_types(debug=debug)
+        if existing_cols:
+            select_cols = "SELECT "
+            for col in existing_cols:
+                select_cols += (
+                    f"\n    COALESCE({sql_item_name(col, self.flavor)}, "
+                    + f"'{replace_nulls}') AS {sql_item_name(col, self.flavor)},"
+                )
+            select_cols = select_cols[:-1]
+    query = f"{select_cols}\nFROM {sql_item_name(pipe.target, self.flavor)}"
     where = ""
 
     if order is not None:
@@ -1107,7 +1122,11 @@ def sync_pipe(
             target = temp_target,
         )
 
-        join_cols = [col for col_key, col in pipe.columns.items() if col_key != 'value']
+        existing_cols = pipe.get_columns_types(debug=debug)
+        join_cols = [
+            col for col_key, col in pipe.columns.items()
+            if col and col_key != 'value' and col in existing_cols
+        ]
 
         queries = get_update_queries(
             pipe.target,
@@ -1210,7 +1229,7 @@ def sync_pipe_inplace(
     """
     from meerschaum.utils.sql import (
         sql_item_name, table_exists, get_sqlalchemy_table, get_pd_type,
-        get_update_queries,
+        get_update_queries, get_null_replacement,
     )
     from meerschaum.utils.misc import generate_password
     from meerschaum.utils.debug import dprint
@@ -1365,8 +1384,9 @@ def sync_pipe_inplace(
         debug = debug,
     )
     backtrack_cols = {str(col.name): str(col.type) for col in backtrack_table_obj.columns}
-    on_cols = [
-        col for col_key, col in pipe.columns.items()
+    on_cols = {
+        col: new_cols.get(col, 'object')
+        for col_key, col in pipe.columns.items()
         if (
             col
             and
@@ -1374,7 +1394,7 @@ def sync_pipe_inplace(
             and col in backtrack_cols
             and col in new_cols
         )
-    ]
+    }
 
     delta_queries = []
     drop_delta_query = f"DROP TABLE {delta_table_name}"
@@ -1383,16 +1403,26 @@ def sync_pipe_inplace(
 
     create_delta_query = (
         (
-            f"SELECT new.*\n"
+            f"SELECT\n"
+            + (
+                ', '.join([
+                    f"COALESCE(new.{sql_item_name(col, self.flavor)}, "
+                    + f"'{get_null_replacement(typ)}') AS " + sql_item_name(col, self.flavor)
+                    for col, typ in new_cols.items()
+                ])
+            )
+            + "\n"
             + f"INTO {delta_table_name}\n"
             + f"FROM {new_table_name} AS new\n"
             + f"LEFT OUTER JOIN {backtrack_table_name} AS old\nON\n"
             + '\nAND\n'.join([
                 (
-                    'new.' + sql_item_name(c, self.flavor)
+                    'COALESCE(new.' + sql_item_name(c, self.flavor) + ", '"
+                    + get_null_replacement(typ) + "') "
                     + ' = '
-                    + 'old.' + sql_item_name(c, self.flavor)
-                ) for c in new_cols
+                    + 'COALESCE(old.' + sql_item_name(c, self.flavor) + ", '"
+                    + get_null_replacement(typ) + "') "
+                ) for c, typ in new_cols.items()
             ])
             + "\nWHERE\n"
             + '\nAND\n'.join([
@@ -1400,18 +1430,34 @@ def sync_pipe_inplace(
                     'old.' + sql_item_name(c, self.flavor) + ' IS NULL'
                 ) for c in new_cols
             ])
+            #  + "\nAND\n"
+            #  + '\nAND\n'.join([
+                #  (
+                    #  'new.' + sql_item_name(c, self.flavor) + ' IS NOT NULL'
+                #  ) for c in new_cols
+            #  ])
         ) if self.flavor not in ('sqlite', 'oracle', 'mysql', 'mariadb', 'duckdb')
         else (
             f"CREATE TABLE {delta_table_name} AS\n"
-            + "SELECT new.*\n"
+            + f"SELECT\n"
+            + (
+                ', '.join([
+                    f"COALESCE(new.{sql_item_name(col, self.flavor)}, "
+                    + f"'{get_null_replacement(typ)}') AS " + sql_item_name(col, self.flavor)
+                    for col, typ in new_cols.items()
+                ])
+            )
+            + "\n"
             + f"FROM {new_table_name} new\n"
             + f"LEFT OUTER JOIN {backtrack_table_name} old\nON\n"
             + '\nAND\n'.join([
                 (
-                    'new.' + sql_item_name(c, self.flavor)
+                    'COALESCE(new.' + sql_item_name(c, self.flavor) + ", '"
+                    + get_null_replacement(typ) + "') "
                     + ' = '
-                    + 'old.' + sql_item_name(c, self.flavor)
-                ) for c in new_cols
+                    + 'COALESCE(old.' + sql_item_name(c, self.flavor) + ", '"
+                    + get_null_replacement(typ) + "') "
+                ) for c, typ in new_cols.items()
             ])
             + "\nWHERE\n"
             + '\nAND\n'.join([
@@ -1419,6 +1465,12 @@ def sync_pipe_inplace(
                     'old.' + sql_item_name(c, self.flavor) + ' IS NULL'
                 ) for c in new_cols
             ])
+            #  + "\nAND\n"
+            #  + '\nAND\n'.join([
+                #  (
+                    #  'new.' + sql_item_name(c, self.flavor) + ' IS NOT NULL'
+                #  ) for c in new_cols
+            #  ])
         )
     )
 
@@ -1471,10 +1523,12 @@ def sync_pipe_inplace(
             + f"LEFT OUTER JOIN {backtrack_table_name} AS bt\nON\n"
             + '\nAND\n'.join([
                 (
-                    'delta.' + sql_item_name(c, self.flavor)
+                    'COALESCE(delta.' + sql_item_name(c, self.flavor)
+                    + ", '" + get_null_replacement(typ) + "')"
                     + ' = '
-                    + 'bt.' + sql_item_name(c, self.flavor)
-                ) for c in on_cols
+                    + 'COALESCE(bt.' + sql_item_name(c, self.flavor)
+                    + ", '" + get_null_replacement(typ) + "')"
+                ) for c, typ in on_cols.items()
             ])
         ) if self.flavor not in ('sqlite', 'oracle', 'mysql', 'mariadb', 'duckdb')
         else (
@@ -1497,10 +1551,12 @@ def sync_pipe_inplace(
             + f"LEFT OUTER JOIN {backtrack_table_name} bt\nON\n"
             + '\nAND\n'.join([
                 (
-                    'delta.' + sql_item_name(c, self.flavor)
+                    'COALESCE(delta.' + sql_item_name(c, self.flavor)
+                    + ", '" + get_null_replacement(typ) + "')"
                     + ' = '
-                    + 'bt.' + sql_item_name(c, self.flavor)
-                ) for c in on_cols
+                    + 'COALESCE(bt.' + sql_item_name(c, self.flavor)
+                    + ", '" + get_null_replacement(typ) + "')"
+                ) for c, typ in on_cols.items()
             ])
         )
     )
@@ -1534,9 +1590,12 @@ def sync_pipe_inplace(
             "SELECT "
             + (', '.join([
                 (
-                    sql_item_name(c + '_delta', self.flavor)
+                    "CASE\n    WHEN " + sql_item_name(c + '_delta', self.flavor)
+                    + " != '" + get_null_replacement(typ) + "'"
+                    + " THEN " + sql_item_name(c + '_delta', self.flavor)
+                    + "\n    ELSE NULL\nEND "
                     + " AS " + sql_item_name(c, self.flavor)
-                ) for c in delta_cols
+                ) for c, typ in delta_cols.items()
             ]))
             + f"\nINTO {unseen_table_name}\n"
             + f"\nFROM {joined_table_name} AS joined\n"
@@ -1546,14 +1605,23 @@ def sync_pipe_inplace(
                     sql_item_name(c + '_backtrack', self.flavor) + ' IS NULL'
                 ) for c in delta_cols
             ])
+            #  + "\nAND\n"
+            #  + '\nAND\n'.join([
+                #  (
+                    #  sql_item_name(c + '_delta', self.flavor) + ' IS NOT NULL'
+                #  ) for c in delta_cols
+            #  ])
         ) if self.flavor not in ('sqlite', 'oracle', 'mysql', 'mariadb', 'duckdb') else (
             f"CREATE TABLE {unseen_table_name} AS\n"
             + "SELECT "
             + (', '.join([
                 (
-                    sql_item_name(c + '_delta', self.flavor)
+                    "CASE\n    WHEN " + sql_item_name(c + '_delta', self.flavor)
+                    + " != '" + get_null_replacement(typ) + "'"
+                    + " THEN " + sql_item_name(c + '_delta', self.flavor)
+                    + "\n    ELSE NULL\nEND "
                     + " AS " + sql_item_name(c, self.flavor)
-                ) for c in delta_cols
+                ) for c, typ in delta_cols.items()
             ]))
             + f"\nFROM {joined_table_name} joined\n"
             + f"WHERE "
@@ -1562,6 +1630,12 @@ def sync_pipe_inplace(
                     sql_item_name(c + '_backtrack', self.flavor) + ' IS NULL'
                 ) for c in delta_cols
             ])
+            #  + "\nAND\n"
+            #  + '\nAND\n'.join([
+                #  (
+                    #  sql_item_name(c + '_delta', self.flavor) + ' IS NOT NULL'
+                #  ) for c in delta_cols
+            #  ])
         )
     )
 
@@ -1601,9 +1675,12 @@ def sync_pipe_inplace(
             "SELECT "
             + (', '.join([
                 (
-                    sql_item_name(c + '_delta', self.flavor)
+                    "CASE\n    WHEN " + sql_item_name(c + '_delta', self.flavor)
+                    + " != '" + get_null_replacement(typ) + "'"
+                    + " THEN " + sql_item_name(c + '_delta', self.flavor)
+                    + "\n    ELSE NULL\nEND "
                     + " AS " + sql_item_name(c, self.flavor)
-                ) for c in delta_cols
+                ) for c, typ in delta_cols.items()
             ]))
             + f"\nINTO {update_table_name}"
             + f"\nFROM {joined_table_name} AS joined\n"
@@ -1618,9 +1695,12 @@ def sync_pipe_inplace(
             + "SELECT "
             + (', '.join([
                 (
-                    sql_item_name(c + '_delta', self.flavor)
+                    "CASE\n    WHEN " + sql_item_name(c + '_delta', self.flavor)
+                    + " != '" + get_null_replacement(typ) + "'"
+                    + " THEN " + sql_item_name(c + '_delta', self.flavor)
+                    + "\n    ELSE NULL\nEND "
                     + " AS " + sql_item_name(c, self.flavor)
-                ) for c in delta_cols
+                ) for c, typ in delta_cols.items()
             ]))
             + f"\nFROM {joined_table_name} joined\n"
             + f"WHERE "

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -904,3 +904,32 @@ def get_db_type(pd_type: str, flavor: str = 'default') -> str:
     if flavor not in flavor_types:
         warn(f"Unknown flavor '{flavor}'. Falling back to '{default_flavor_type}' (default).")
     return flavor_types.get(flavor, default_flavor_type)
+
+
+def get_null_replacement(typ: str) -> str:
+    """
+    Return a value that may temporarily be used in place of NULL for this type.
+
+    Parameters
+    ----------
+    typ: str
+        The typ to be converted to NULL.
+
+    Returns
+    -------
+    A value which may stand in place of NULL for this type.
+    `'None'` is returned if a value cannot be determined.
+    """
+    if 'int' in typ.lower():
+        return '-987654321'
+    if 'char' in typ.lower():
+        return '<MRSM_NULL>'
+    if 'bool' in typ.lower():
+        return '0'
+    if 'time' in typ.lower():
+        return '1900-01-01'
+    if 'object' in typ.lower():
+        return '<MRSM_NULL>'
+    if 'float' in typ.lower():
+        return '-987654321.0'
+    return 'None'

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -906,7 +906,7 @@ def get_db_type(pd_type: str, flavor: str = 'default') -> str:
     return flavor_types.get(flavor, default_flavor_type)
 
 
-def get_null_replacement(typ: str) -> str:
+def get_null_replacement(typ: str, flavor: str) -> str:
     """
     Return a value that may temporarily be used in place of NULL for this type.
 
@@ -922,14 +922,10 @@ def get_null_replacement(typ: str) -> str:
     """
     if 'int' in typ.lower():
         return '-987654321'
-    if 'char' in typ.lower():
-        return '<MRSM_NULL>'
     if 'bool' in typ.lower():
         return '0'
-    if 'time' in typ.lower():
-        return '1900-01-01'
-    if 'object' in typ.lower():
-        return '<MRSM_NULL>'
+    if 'time' in typ.lower() or 'date' in typ.lower():
+        return dateadd_str(flavor=flavor, begin='1900-01-01')
     if 'float' in typ.lower():
         return '-987654321.0'
-    return 'None'
+    return ('n' if flavor == 'oracle' else '') + "'<MRSM_NULL>'"


### PR DESCRIPTION
# v1.4.0 – v1.4.4

- **Added in-place syncing for SQL pipes.**  
  This feature is big (enough to warrant a new point release). When pipes with the same instance connector and data source connector are synced, the method `sync_pipe_inplace()` is invoked. For SQL pipes, this means the entire syncing process will now happen entirely in SQL, which can lead to massive performance improvements.

  ```python
  import meerschaum as mrsm
  import pandas as pd

  conn = mrsm.get_connector('sql', 'local')
  conn.to_sql(pd.DataFrame([{'a': 1}]), 'foo')
  
  pipe = mrsm.Pipe(
      "sql:local", "foo",
      instance = "sql:local",
      parameters = {
          "query": "SELECT * FROM foo"
      },
  )
  ### This will no longer load table data into memory.
  pipe.sync()
  ```

  This applies even when the source table's schema changes, just like the dynamic columns feature added in v1.3.0.

  > *To disable this behavior, run the command `edit config system` and set the value under the keys `experimental:inplace_sync` to `false`.*

- **Added negation to `--params`.**  
  The [`build_where()`](https://docs.meerschaum.io/utils/sql.html#meerschaum.utils.sql.build_where) function now allows you to negate certain values when prefixed with an underscore (`_`):

  ```bash
  ### Show recent data, excluding where `id` equals `2`.
  mrsm show data --params id:_2
  ```

- **Added `--params` to SQL pipes' queries.**  
  Specifying parameters when syncing SQL pipes will add those constraints to the fetch stage.

- **Skip invalid parameters in `--params`.**  
  If a column does not exist in a pipe's table, the value will be ignored in `--params`.

- **Fixed environment issue when starting the Web API with `gunicorn`.**
- **Added an emoji to the SQL Query option of the web console.**
- **Fixed an edge case with data type enforcement.**
- **Other bugfixes**