### PR TITLE
🐛 v1.4.10 Fixed edge case bugs in syncing, data type enforcement, and more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.4.10
+
+- **Fixed an issue with syncing background jobs.**  
+  The `--name` flag of background jobs with colliding with the `name` keyword argument of `SQLConnector.to_sql()`.
+
+- **Fixed a datetime bounding issue when `datetime` index is omitted.**  
+  If the minimum datetime value of the incoming dataframe cannot be determined, do not bound the `get_data()` request.
+
+- **Keep existing parameters when registering plugin pipes.**  
+  When a pipe is registered with a plugin as its connector, the return value of the `register()` function will be patched with the existing in-memory parameters.
+
+- **Fixed a data type syncing issue.**  
+  In cases where fetched data types do not match the data types in the pipe's table (e.g. automatic datetime columns), a bug has been patched to ensure the correct data types are enforced.
+
+- **Added `Venv` to the root namespace.**  
+  Now you can access virtual environments directly from `mrsm`:
+
+  ```python
+  import meerschaum as mrsm
+
+  with mrsm.Venv('noaa'):
+      import pandas as pd
+  ```
+
+
 ### v1.4.9
 
 - **Fixed in-place syncs for aggregate queries.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,31 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.4.10
+
+- **Fixed an issue with syncing background jobs.**  
+  The `--name` flag of background jobs with colliding with the `name` keyword argument of `SQLConnector.to_sql()`.
+
+- **Fixed a datetime bounding issue when `datetime` index is omitted.**  
+  If the minimum datetime value of the incoming dataframe cannot be determined, do not bound the `get_data()` request.
+
+- **Keep existing parameters when registering plugin pipes.**  
+  When a pipe is registered with a plugin as its connector, the return value of the `register()` function will be patched with the existing in-memory parameters.
+
+- **Fixed a data type syncing issue.**  
+  In cases where fetched data types do not match the data types in the pipe's table (e.g. automatic datetime columns), a bug has been patched to ensure the correct data types are enforced.
+
+- **Added `Venv` to the root namespace.**  
+  Now you can access virtual environments directly from `mrsm`:
+
+  ```python
+  import meerschaum as mrsm
+
+  with mrsm.Venv('noaa'):
+      import pandas as pd
+  ```
+
+
 ### v1.4.9
 
 - **Fixed in-place syncs for aggregate queries.**  

--- a/meerschaum/__init__.py
+++ b/meerschaum/__init__.py
@@ -21,6 +21,7 @@ limitations under the License.
 from meerschaum.core.Pipe import Pipe
 from meerschaum.plugins import Plugin
 from meerschaum.utils import get_pipes
+from meerschaum.utils.venv import Venv
 from meerschaum._internal.docs import index as __doc__
 from meerschaum.connectors import get_connector
 from meerschaum.config import __version__

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.4.9"
+__version__ = "1.4.10"

--- a/meerschaum/connectors/__init__.py
+++ b/meerschaum/connectors/__init__.py
@@ -338,10 +338,13 @@ def get_connector_plugin(
     if not hasattr(connector, 'type'):
         return None
     from meerschaum import Plugin
-    return (
-        Plugin(connector.__module__.replace('plugins.', '').split('.')[0])
+    plugin_name = (
+        connector.__module__.replace('plugins.', '').split('.')[0]
         if connector.type in custom_types else (
-            Plugin(connector.label) if connector.type == 'plugin'
+            connector.label
+            if connector.type == 'plugin'
             else 'mrsm'
         )
     )
+    plugin = Plugin(plugin_name)
+    return plugin if plugin.is_installed() else None

--- a/meerschaum/connectors/api/_login.py
+++ b/meerschaum/connectors/api/_login.py
@@ -43,7 +43,7 @@ def login(
     else:
         msg = (
             f"Failed to log into '{self}' as user '{login_data['username']}'.\n" +
-            f"     Please verify login details for connector '{self}'."
+            f"    Please verify login details for connector '{self}'."
         )
         if warn:
             _warn(msg, stack=False)

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -437,12 +437,13 @@ def filter_existing(
         df = self.enforce_dtypes(df, debug=debug)
     ### begin is the oldest data in the new dataframe
     try:
-        min_dt = pd.to_datetime(df[self.get_columns('datetime')].min(skipna=True)).to_pydatetime()
+        min_dt = pd.to_datetime(
+            df[self.columns['datetime']].min(skipna=True)
+        ).to_pydatetime()
     except Exception as e:
         min_dt = None
     if not isinstance(min_dt, datetime.datetime) or str(min_dt) == 'NaT':
-        ### min_dt might be None, a user-supplied value, or the sync time.
-        min_dt = begin
+        min_dt = None
     begin = (
         round_time(
             min_dt,
@@ -452,9 +453,11 @@ def filter_existing(
 
     ### end is the newest data in the new dataframe
     try:
-        max_dt = pd.to_datetime(df[self.get_columns('datetime')].max(skipna=True)).to_pydatetime()
+        max_dt = pd.to_datetime(
+            df[self.columns['datetime']].max(skipna=True)
+        ).to_pydatetime()
     except Exception as e:
-        max_dt = end
+        max_dt = None
     if not isinstance(max_dt, datetime.datetime) or str(max_dt) == 'NaT':
         max_dt = None
 
@@ -507,7 +510,12 @@ def filter_existing(
     ### Detect changes between the old target and new source dataframes.
     from meerschaum.utils.misc import filter_unseen_df, add_missing_cols_to_df
     delta_df = add_missing_cols_to_df(
-        filter_unseen_df(backtrack_df, df, dtypes=self.dtypes, debug=debug),
+        filter_unseen_df(
+            backtrack_df,
+            df,
+            dtypes = self.dtypes,
+            debug = debug
+        ),
         on_cols_dtypes,
     )
     joined_df = pd.merge(

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -153,31 +153,15 @@ class Plugin:
         return path
 
 
-    def is_installed(self, try_import: bool = True) -> bool:
+    def is_installed(self, **kw) -> bool:
         """
         Check whether a plugin is correctly installed.
-        **NOTE:** This plugin will import the plugin's module.
-        Set `try_import` to `False` to avoid importing.
-
-        Parameters
-        ----------
-        try_import: bool, default True
-            If `True`, attempt importing the plugin's module.            
 
         Returns
         -------
         A `bool` indicating whether a plugin exists and is successfully imported.
         """
-        #  if not self.__file__:
-            #  return False
         return self.__file__ is not None
-        #  try:
-            #  _installed = (
-                #  self.__dict__.get('_module', None) is not None and self.__file__ is not None
-            #  ) if try_import else (self.__file__ is not None)
-        #  except ModuleNotFoundError as e:
-            #  _installed = False
-        #  return _installed
 
 
     def make_tar(self, debug: bool = False) -> pathlib.Path:

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -652,6 +652,7 @@ def round_time(
 
     return dt + datetime.timedelta(0, rounding - seconds, - dt.microsecond)
 
+
 def parse_df_datetimes(
         df: 'pd.DataFrame',
         debug: bool = False
@@ -961,11 +962,21 @@ def filter_unseen_df(
     ### assume the old_df knows what it's doing, even if it's technically wrong.
     if dtypes is None:
         dtypes = {col: str(typ) for col, typ in old_df.dtypes.items()}
+
     dtypes = {
         col: (
             str(typ) if str(typ) != 'int64' else 'Int64'
-        ) for col, typ in new_df.dtypes.items()
+        ) for col, typ in dtypes.items()
+        if col in new_df_dtypes and col in old_df_dtypes
     }
+    for col, typ in new_df_dtypes.items():
+        if col not in dtypes:
+            dtypes[col] = typ
+    
+    for col, typ in {k: v for k, v in dtypes.items()}.items():
+        if new_df_dtypes.get(col, None) != old_df_dtypes.get(col, None):
+            ### Fallback to object if the types don't match.
+            dtypes[col] = 'object'
 
     cast_cols = True
     try:

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -309,7 +309,10 @@ def verify_venv(
         if filename == python_versioned_name:
             real_path = pathlib.Path(os.path.realpath(python_path))
             if not real_path.exists():
-                python_path.unlink()
+                try:
+                    python_path.unlink()
+                except Exception as e:
+                    pass
                 init_venv(venv, verify=False, force=True, debug=debug)
                 if not python_path.exists():
                     raise FileNotFoundError(f"Unable to verify Python symlink:\n{python_path}")

--- a/meerschaum/utils/warnings.py
+++ b/meerschaum/utils/warnings.py
@@ -93,6 +93,7 @@ def warn(*args, stacklevel=2, stack=True, color: bool = True, **kw) -> None:
     if not stack:
         warnings.showwarning = _old_sw
 
+
 def exception_with_traceback(
         message: str,
         exception_class = Exception, 


### PR DESCRIPTION
# v1.4.10

- **Fixed an issue with syncing background jobs.**  
  The `--name` flag of background jobs with colliding with the `name` keyword argument of `SQLConnector.to_sql()`.

- **Fixed a datetime bounding issue when `datetime` index is omitted.**  
  If the minimum datetime value of the incoming dataframe cannot be determined, do not bound the `get_data()` request.

- **Keep existing parameters when registering plugin pipes.**  
  When a pipe is registered with a plugin as its connector, the return value of the `register()` function will be patched with the existing in-memory parameters.

- **Fixed a data type syncing issue.**  
  In cases where fetched data types do not match the data types in the pipe's table (e.g. automatic datetime columns), a bug has been patched to ensure the correct data types are enforced.

- **Added `Venv` to the root namespace.**  
  Now you can access virtual environments directly from `mrsm`:

  ```python
  import meerschaum as mrsm

  with mrsm.Venv('noaa'):
      import pandas as pd
  ```