### PR TITLE
🔒️ Security patch and add `temporary` to avoid automatic table creation.

### DIFF
--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -196,6 +196,7 @@ groups['pipes'].add_argument(
     '-t', '--tags', nargs='+', help="Only include pipes with these tags.",
 )
 
+
 ### Sync options
 groups['sync'].add_argument(
     '--min-seconds', '--cooldown', type=float, help=(
@@ -315,7 +316,14 @@ groups['misc'].add_argument(
         "--params key1:value1,key2:value2"
     )
 )
-
+groups['misc'].add_argument(
+    '--temporary', '--temp',
+    action = 'store_true',
+    help = (
+        "Skip creating or modifying instance tables when working with pipes "
+        + "(plugins and users still trigger table creation)."
+    ),
+)
 groups['misc'].add_argument(
     '--gui', action='store_true',
     help="Open a DataFrame in an interactive pandasgui or matplotlib window."

--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -32,6 +32,7 @@ def copy(
     }
     return choose_subaction(action, options, **kw)
 
+
 def _complete_copy(
         action : Optional[List[str]] = None,
         **kw : Any
@@ -59,6 +60,7 @@ def _complete_copy(
 
     from meerschaum._internal.shell import default_action_completer
     return default_action_completer(action=(['copy'] + action), **kw)
+
 
 def _copy_pipes(
         yes: bool = False,
@@ -115,7 +117,7 @@ def _copy_pipes(
                     noask=noask, yes=yes
                 )
         ):
-            _new_pipe.sync(p.get_data(debug=debug, **kw))
+            _new_pipe.sync(p.get_data(debug=debug, **kw), debug=debug, **kw)
 
     msg = (
         "No pipes were copied." if successes == 0

--- a/meerschaum/api/__init__.py
+++ b/meerschaum/api/__init__.py
@@ -85,7 +85,7 @@ private = get_uvicorn_config().get('private', False)
 _include_dash = (not no_dash)
 
 connector = None
-def get_api_connector(instance_keys : Optional[str] = None):
+def get_api_connector(instance_keys: Optional[str] = None):
     """Create the instance connector."""
     from meerschaum.utils.debug import dprint
     global connector

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -308,6 +308,12 @@ def sync_pipe(
     if data is None:
         data = {}
     p = get_pipe(connector_keys, metric_key, location_key)
+    if p.target in ('users', 'plugins', 'pipes'):
+        raise fastapi.HTTPException(
+            status_code = 409,
+            detail = f"Cannot sync data to protected table '{p.target}'.",
+        )
+
     if not p.columns and columns is not None:
         p.columns = json.loads(columns)
     if not p.columns and not is_pipe_registered(p, pipes(refresh=True)):
@@ -363,7 +369,13 @@ def get_pipe_data(
     if not is_pipe_registered(p, pipes(refresh=True)):
         raise fastapi.HTTPException(
             status_code = 409,
-            detail = "Pipe must be registered with the datetime column specified"
+            detail = "Pipe must be registered with the datetime column specified."
+        )
+
+    if p.target in ('users', 'plugins', 'pipes'):
+        raise fastapi.HTTPException(
+            status_code = 409,
+            detail = f"Cannot retrieve data from protected table '{p.target}'.",
         )
 
     #  chunks = p.get_data(

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.4.13"
+__version__ = "1.4.14"

--- a/meerschaum/connectors/api/_delete.py
+++ b/meerschaum/connectors/api/_delete.py
@@ -17,27 +17,7 @@ def delete(
         debug : bool = False,
         **kw : Ahy,
     ) -> requests.Response:
-    """Wrapper for requests.delete
-
-    Parameters
-    ----------
-    r_url : str :
-        
-    headers : Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    use_token : bool :
-         (Default value = True)
-    debug : bool :
-         (Default value = False)
-    **kw : Ahy :
-        
-
-    Returns
-    -------
-
-    """
+    """Wrapper for `requests.delete`."""
     if debug:
         from meerschaum.utils.debug import dprint
     
@@ -51,10 +31,7 @@ def delete(
 
     if debug:
         from meerschaum.utils.formatting import pprint
-        dprint(f"Sending DELETE request to {self.url + r_url}")
-        if headers:
-            pprint(headers)
-        pprint(kw)
+        dprint(f"Sending DELETE request to {self.url + r_url}.")
 
     return self.session.delete(
         self.url + r_url,

--- a/meerschaum/connectors/api/_get.py
+++ b/meerschaum/connectors/api/_get.py
@@ -11,11 +11,11 @@ from meerschaum.utils.typing import Optional, Any, Dict, Union
 
 def get(
         self,
-        r_url : str,
-        headers : Optional[Dict[str, str]] = None,
-        use_token : bool = True,
-        debug : bool = False,
-        **kw : Any
+        r_url: str,
+        headers: Optional[Dict[str, str]] = None,
+        use_token: bool = True,
+        debug: bool = False,
+        **kw: Any
     ) -> requests.Reponse:
     """Wrapper for `requests.get`."""
     if debug:
@@ -27,14 +27,11 @@ def get(
     if use_token:
         if debug:
             dprint(f"Checking login token.")
-        headers.update({ 'Authorization': f'Bearer {self.token}' })
+        headers.update({'Authorization': f'Bearer {self.token}'})
 
     if debug:
         from meerschaum.utils.formatting import pprint
         dprint(f"Sending GET request to {self.url + r_url}.")
-        if headers:
-            pprint(headers)
-        pprint(kw)
 
     return self.session.get(
         self.url + r_url,
@@ -44,12 +41,12 @@ def get(
 
 def wget(
         self,
-        r_url : str,
-        dest : Optional[Union[str, pathlib.Path]] = None,
+        r_url: str,
+        dest: Optional[Union[str, pathlib.Path]] = None,
         headers: Optional[Dict[str, Any]] = None,
         use_token: bool = True,
         debug: bool = False,
-        **kw : Any
+        **kw: Any
     ) -> pathlib.Path:
     """Mimic wget with requests.
     """
@@ -60,5 +57,5 @@ def wget(
     if use_token:
         if debug:
             dprint(f"Checking login token.")
-        headers.update({ 'Authorization': f'Bearer {self.token}' })
+        headers.update({'Authorization': f'Bearer {self.token}'})
     return wget(self.url + r_url, dest=dest, headers=headers, **kw)

--- a/meerschaum/connectors/api/_patch.py
+++ b/meerschaum/connectors/api/_patch.py
@@ -11,33 +11,13 @@ from meerschaum.utils.typing import Optional, Dict, Any
 
 def patch(
         self,
-        r_url : str,
-        headers : Optional[Dict[str, Any]] = None,
-        use_token : bool = True,
-        debug : bool = False,
-        **kw : Any
+        r_url: str,
+        headers: Optional[Dict[str, Any]] = None,
+        use_token: bool = True,
+        debug: bool = False,
+        **kw: Any
     ) -> requests.Response:
-    """Wrapper for requests.patch
-
-    Parameters
-    ----------
-    r_url : str :
-        
-    headers : Optional[Dict[str :
-        
-    Any]] :
-         (Default value = None)
-    use_token : bool :
-         (Default value = True)
-    debug : bool :
-         (Default value = False)
-    **kw : Any :
-        
-
-    Returns
-    -------
-
-    """
+    """Wrapper for `requests.patch`."""
     if debug:
         from meerschaum.utils.debug import dprint
 
@@ -52,9 +32,6 @@ def patch(
     if debug:
         from meerschaum.utils.formatting import pprint
         dprint(f"Sending PATCH request to {self.url + r_url}")
-        if headers:
-            pprint(headers)
-        pprint(kw)
 
     return self.session.patch(
         self.url + r_url,

--- a/meerschaum/connectors/api/_post.py
+++ b/meerschaum/connectors/api/_post.py
@@ -27,14 +27,11 @@ def post(
     if use_token:
         if debug:
             dprint(f"Checking token...")
-        headers.update({ 'Authorization': f'Bearer {self.token}' })
+        headers.update({'Authorization': f'Bearer {self.token}'})
 
     if debug:
         from meerschaum.utils.formatting import pprint
         dprint(f"Sending POST request to {self.url + r_url}")
-        if headers:
-            pprint(headers)
-        pprint(kw)
 
     return self.session.post(
         self.url + r_url,

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -122,6 +122,7 @@ class Pipe:
         target: Optional[str] = None,
         dtypes: Optional[Dict[str, str]] = None,
         instance: Optional[Union[str, InstanceConnector]] = None,
+        temporary: bool = False,
         mrsm_instance: Optional[Union[str, InstanceConnector]] = None,
         cache: bool = False,
         debug: bool = False,
@@ -165,6 +166,9 @@ class Pipe:
         instance: Optional[Union[str, InstanceConnector]], default None
             Alias for `mrsm_instance`. If `mrsm_instance` is supplied, this value is ignored.
 
+        temporary: bool, default False
+            If `True`, prevent instance tables (pipes, users, plugins) from being created.
+
         cache: bool, default False
             If `True`, cache fetched data into a local database file.
             Defaults to `False`.
@@ -199,6 +203,7 @@ class Pipe:
         self.connector_key = self.connector_keys ### Alias
         self.metric_key = metric
         self.location_key = location
+        self.temporary = temporary
 
         self._attributes = {
             'connector_keys': self.connector_keys,
@@ -353,9 +358,10 @@ class Pipe:
                 self.instance_keys,
                 (self.connector_keys + '_' + self.metric_key + '_cache'),
                 self.location_key,
-                mrsm_instance=self.cache_connector,
-                parameters=_parameters,
-                cache=False,
+                mrsm_instance = self.cache_connector,
+                parameters = _parameters,
+                cache = False,
+                temporary = True,
             )
 
         return self._cache_pipe

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -34,7 +34,7 @@ def attributes(self) -> Dict[str, Any]:
         or
         (timeout_seconds is not None and (now - last_refresh) >= timeout_seconds)
     )
-    if timed_out:
+    if not self.temporary and timed_out:
         self._attributes_sync_time = now
         local_attributes = self.__dict__.get('_attributes', {})
         with Venv(get_connector_plugin(self.instance_connector)):
@@ -215,6 +215,8 @@ def get_id(self, **kw: Any) -> Union[int, None]:
     Fetch a pipe's ID from its instance connector.
     If the pipe does not exist, return `None`.
     """
+    if self.temporary:
+        return None
     from meerschaum.utils.venv import Venv
     from meerschaum.connectors import get_connector_plugin
 

--- a/meerschaum/core/Pipe/_bootstrap.py
+++ b/meerschaum/core/Pipe/_bootstrap.py
@@ -233,17 +233,9 @@ def _ask_for_columns(pipe, debug: bool=False) -> Dict[str, str]:
         if id_name == '':
             id_name = None
 
-        try:
-            value_name = prompt(f"Value column (empty to omit):", icon=False)
-        except KeyboardInterrupt:
-            return False, f"Cancelled bootstrapping {pipe}."
-        if value_name == '':
-            value_name = None
-
         break
 
     return {
         'datetime': datetime_name,
         'id': id_name,
-        'value': value_name,
     }

--- a/meerschaum/core/Pipe/_edit.py
+++ b/meerschaum/core/Pipe/_edit.py
@@ -44,6 +44,9 @@ def edit(
     from meerschaum.utils.venv import Venv
     from meerschaum.connectors import get_connector_plugin
 
+    if self.temporary:
+        return False, "Cannot edit pipes created with `temporary=True` (read-only)."
+
     if not interactive:
         with Venv(get_connector_plugin(self.instance_connector)):
             return self.instance_connector.edit_pipe(self, patch=patch, debug=debug, **kw)
@@ -109,6 +112,9 @@ def edit_definition(
     A `SuccessTuple` of success, message.
 
     """
+    if self.temporary:
+        return False, "Cannot edit pipes created with `temporary=True` (read-only)."
+
     from meerschaum.connectors import instance_types
     if (self.connector is None) or self.connector.type not in instance_types:
         return self.edit(interactive=True, debug=debug, **kw)

--- a/meerschaum/core/Pipe/_register.py
+++ b/meerschaum/core/Pipe/_register.py
@@ -25,6 +25,9 @@ def register(
     A `SuccessTuple` of success, message.
 
     """
+    if self.temporary:
+        return False, "Cannot register pipes created with `temporary=True` (read-only)."
+
     from meerschaum.utils.formatting import get_console
     from meerschaum.utils.venv import Venv
     from meerschaum.connectors import get_connector_plugin, custom_types

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -151,7 +151,7 @@ def sync(
                 + "Omit the DataFrame to infer fetching.",
             )
         ### Ensure that Pipe is registered.
-        if p.get_id(debug=debug) is None:
+        if not p.temporary and p.get_id(debug=debug) is None:
             ### NOTE: This may trigger an interactive session for plugins!
             register_tuple = p.register(debug=debug)
             if not register_tuple[0]:

--- a/meerschaum/utils/get_pipes.py
+++ b/meerschaum/utils/get_pipes.py
@@ -237,8 +237,6 @@ def fetch_pipes_keys(
     [('sql:main', 'weather', None)]
     """
     from meerschaum.utils.warnings import error
-    from meerschaum.connectors.sql.tables import get_tables
-    tables = get_tables(connector)
 
     def _registered(
             connector_keys: Optional[List[str]] = None,

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -786,7 +786,7 @@ def get_sqlalchemy_table(
     from meerschaum.utils.packages import attempt_import
     if refresh:
         connector.metadata.clear()
-    tables = get_tables(mrsm_instance=connector, debug=debug)
+    tables = get_tables(mrsm_instance=connector, debug=debug, create=False)
     sqlalchemy = attempt_import('sqlalchemy')
     truncated_table_name = truncate_item_name(str(table), connector.flavor)
     if refresh or truncated_table_name not in tables:


### PR DESCRIPTION
# v1.4.14

- **Added flag `temporary` to `Pipe` (and `--temporary`).**  
  Pipes built with `temporary=True`, will not create instance tables (`pipes`, `users`, and `plugins`) or be able to modify registration. This is particularly useful when creating pipes from existing tables when automatic registration is not desired.

  ```python
  import meerschaum as mrsm
  import pandas as pd
  conn = mrsm.get_connector('sql:temp', uri='postgresql://user:pass@localhost:5432/db')

  ### Simulating an existing table.
  table_name = 'my_table'
  conn.to_sql(
      pd.DataFrame([{'id_column': 1, 'value': 1.0}]),
      name = table_name,
  )

  ### Create a temporary pipe with the existing table as its target.
  pipe = mrsm.Pipe(
      'foo', 'bar',
      target = table_name,
      temporary = True,
      instance = conn,
      columns = {
          'id': 'id_column',
      },
  )

  docs = [
      {
          "id_column": 1,
          "value": 123.456,
          "new_column": "hello, world!",
      },
  ]

  ### Existing table `my_table` is synced without creating other tables
  ### or affecting pipes' registration.
  pipe.sync(docs)
  ```

- **Fixed potential security of public instance tables.**  
  The API now refuses to sync or serve data if the target is a protected instance table (`pipes`, `users`, or `plugins`).

- **Added not-null check to `pipe.get_sync_time().`**  
  The `datetime` column should never contain null values, but just in case, `pipe.get_sync_time()` now passes a not-null check to `params` for the datetime column.

- **Removed prompt for `value` from `pipe.bootstrap()`.**  
  The prompt for an optional `value` column has been removed from the bootstrapping wizard because `pipe.columns` is now largely used as a collection of indices rather than the original purpose of meta-columns.

- **Pass `--debug` and other flags in `copy pipes`.**  
  Command line flags are now passed to the new pipe when copying an existing pipe.