### PR TITLE
✨ Added `--params` to `edit pipes` and `register pipes`, and enforce chunksize limit in `SQLConnector.to_sql()`.

### DIFF
--- a/meerschaum/actions/register.py
+++ b/meerschaum/actions/register.py
@@ -68,6 +68,7 @@ def _register_pipes(
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn, info
     from meerschaum.utils.misc import items_str
+    from meerschaum.config._patch import apply_patch_to_config
 
     if connector_keys is None:
         connector_keys = []
@@ -99,6 +100,13 @@ def _register_pipes(
         debug = debug,
         **kw
     )
+
+    if params:
+        for pipe in pipes:
+            pipe._attributes['parameters'] = apply_patch_to_config(
+                params,
+                pipe._attributes.get('parameters', {})
+            )
 
     success, message = True, "Success"
     failed_message = ""

--- a/meerschaum/config/_patch.py
+++ b/meerschaum/config/_patch.py
@@ -9,6 +9,7 @@ Functions for patching the configuration dictionary
 import sys
 import copy
 from meerschaum.utils.typing import Dict, Any
+from meerschaum.utils.warnings import warn
 
 def apply_patch_to_config(
         config: Dict[str, Any],
@@ -22,6 +23,9 @@ def apply_patch_to_config(
     def update_dict(base, patch):
         if base is None:
             return {}
+        if not isinstance(base, dict):
+            warn(f"Overwriting the value {base} with a dictionary:\n{patch}")
+            base = {}
         for key, value in patch.items():
             if isinstance(value, dict):
                 base[key] = update_dict(base.get(key, {}), value)

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
# v1.5.1

- **Added `--params` to `edit pipes` and `register pipes`.**  
  When registering or editing a pipe, the `--params` dictionary, if provided, will be patched into the pipe's `parameters`. This should prove useful for scripting when paired with the `-y`, `-f`, or `--nopretty` flags.

- **Enforce chunksize limit with SQLite.**  
  The limit was previously only enforced when reading documents. This patch extends that to `SQLConnector.to_sql()`.