### PR TITLE
✨ v1.5.3 Add support for syncing dictionaries and lists (`dtype=json`).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.5.3
+
+- **Pipes now support syncing dictionaries and lists.**  
+  Complex columns (dicts or lists) will now be preserved:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync([{'a': {'b': 1}}])
+  df = pipe.get_data()
+  print(df['a'][0])
+  # {'b': 1}
+  ```
+
+  You can also force strings to be parsed by setting the data type to `json`:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe(
+      'foo', 'bar',
+      columns = {'datetime': 'id'},
+      dtypes = {'data': 'json', 'id': 'Int64'},
+  )
+  docs = [{'id': 1, 'data': '{"foo": "bar"}'}]
+  pipe.sync(docs)
+  df = pipe.get_data()
+  print(df['data'][0])
+  # {'foo': 'bar'}
+  ```
+
+  For PostgreSQL-like databases (e.g. TimescaleDB), this is stored as `JSONB` under the hood. For all others, it's stored as the equivalent for `TEXT`.
+
+- **Fixed determining the version when installing plugins.**  
+  Like the `required` list, the `__version__` string must be explicitly set in order for the correct version to be determined.
+
+- **Automatically cast `postgres` to `postgresql`**  
+  When a `SQLConnector` is built with a flavor of `postgres`, it will be automatically set to `postgresql`.
+
 ### v1.5.0 – v1.5.2
 
 - **Pipes may now use integers for the `datetime` column.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,44 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.5.3
+
+- **Pipes now support syncing dictionaries and lists.**  
+  Complex columns (dicts or lists) will now be preserved:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync([{'a': {'b': 1}}])
+  df = pipe.get_data()
+  print(df['a'][0])
+  # {'b': 1}
+  ```
+
+  You can also force strings to be parsed by setting the data type to `json`:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe(
+      'foo', 'bar',
+      columns = {'datetime': 'id'},
+      dtypes = {'data': 'json', 'id': 'Int64'},
+  )
+  docs = [{'id': 1, 'data': '{"foo": "bar"}'}]
+  pipe.sync(docs)
+  df = pipe.get_data()
+  print(df['data'][0])
+  # {'foo': 'bar'}
+  ```
+
+  For PostgreSQL-like databases (e.g. TimescaleDB), this is stored as `JSONB` under the hood. For all others, it's stored as the equivalent for `TEXT`.
+
+- **Fixed determining the version when installing plugins.**  
+  Like the `required` list, the `__version__` string must be explicitly set in order for the correct version to be determined.
+
+- **Automatically cast `postgres` to `postgresql`**  
+  When a `SQLConnector` is built with a flavor of `postgres`, it will be automatically set to `postgresql`.
+
 ### v1.5.0 – v1.5.2
 
 - **Pipes may now use integers for the `datetime` column.**  

--- a/docs/mkdocs/reference/compose.md
+++ b/docs/mkdocs/reference/compose.md
@@ -62,6 +62,16 @@ mkdir awesome-sauce && \
   vim mrsm-compose.yaml
 ```
 
+!!! tip "Plugins directories"
+
+    You may set multiple paths for `plugins_dir`. This is very useful if you want to group plugins together. A value of `null` will include the environment's plugins in your project.
+
+    ```yaml
+    plugins_dir:
+      - "./plugins"
+      - null
+    ```
+
 ## 🪖 Commands
 
 If you've used `docker-compose`, you'll catch on to Meerschaum Compose pretty quickly. Here's a quick summary:
@@ -118,7 +128,7 @@ The supported top-level keys in a Compose file are the following:
 - **`root_dir`** (*optional*, default `./root/`)  
   A path to the root directory; see [`MRSM_ROOT_DIR`](/reference/environment/#mrsm_root_dir).
 - **`plugins_dir`** (*optional*, default `./plugins/`)  
-  A path to the plugins directory; see [`MRSM_PLUGINS_DIR`](/reference/environment/#mrsm_plugins_dir).
+  Either a path or list of paths to the plugins directories. A value of `null` will include the current environment plugins directories in the project. See [`MRSM_PLUGINS_DIR`](/reference/environment/#mrsm_plugins_dir).
 - **`plugins`** (*optional*)  
   A list of plugins expected to be in the plugins directory. Missing plugins will be [installed from `api:mrsm`](/reference/plugins/using-plugins/).  
   To install from a custom repository, append `@api:<label>` to the plugins' names or set the configuration variable `meerschaum:default_repository`.
@@ -126,6 +136,17 @@ The supported top-level keys in a Compose file are the following:
   Configuration keys to be patched on top of your host configuration, see [`MRSM_CONFIG`](/reference/environment/#mrsm_config). Custom connectors should be defined here.
 - **`environment`** (*optional*)  
   Additional environment variables to pass to subprocesses.
+
+!!! tip "Accessing the host configuration"
+
+    The Meerschaum Compose YAML file also supports Meerschaum symlinks. For example, to alias a new connector `sql:foo` to your host's `sql:main`:
+
+    ```yaml
+    config:
+      meerschaum:
+        sql:
+          foo: MRSM{meerschaum:connectors:sql:main}
+    ```
 
 ### The `sync` Key
 

--- a/docs/mkdocs/reference/environment.md
+++ b/docs/mkdocs/reference/environment.md
@@ -27,6 +27,17 @@ MRSM_PLUGINS_DIR=plugins \
   mrsm show plugins
 ```
 
+### Multiple Plugins Directories
+
+To allow you to group plugins together, Meerschaum supports a multiple plugins directories at once. Just set `MRSM_PLUGINS_DIR` to a JSON-encoded list of paths:
+
+```bash
+export MRSM_PLUGINS_DIR='[
+    "./plugins",
+    "./plugins_2"
+]'
+```
+
 ## **`MRSM_<TYPE>_<LABEL>`**
 
 You can temporarily register new connectors in a variable in the form `MRSM_<TYPE>_<LABEL>`, where `<TYPE>` is either `SQL` or `API`, and `<LABEL>` is the label for the connector (converted to lower case). Check here for more information about [environment connectors](/reference/connectors/#-environment-connectors), but in a nutshell, set the variable to the [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) of your connector.

--- a/meerschaum/actions/stop.py
+++ b/meerschaum/actions/stop.py
@@ -102,7 +102,8 @@ def _stop_jobs(
         (("Stopped job" + ("s" if len(_quit_daemons) != 1 else '') +
             " '" + "', '".join([d.daemon_id for d in _quit_daemons]) + "'.")
             if _quit_daemons else '')
-        + (("Killed job" + ("s" if len(_kill_daemons) != 1 else '') +
+        + (("\n" if _quit_daemons else "")
+           + ("Killed job" + ("s" if len(_kill_daemons) != 1 else '') +
             " '" + "', '".join([d.daemon_id for d in _kill_daemons]) + "'.")
             if _kill_daemons else '')
     )

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/meerschaum/connectors/sql/SQLConnector.py
+++ b/meerschaum/connectors/sql/SQLConnector.py
@@ -54,6 +54,7 @@ class SQLConnector(Connector):
         clear_pipe,
         get_pipe_table,
         get_pipe_columns_types,
+        get_to_sql_dtype,
     )
     from ._plugins import (
         register_plugin,
@@ -118,6 +119,10 @@ class SQLConnector(Connector):
             as long enough parameters are supplied to the constructor.
         """
         if 'uri' in kw:
+            uri = kw['uri']
+            if uri.startswith('postgres://'):
+                uri = uri.replace('postgres://', 'postgresql://', 1)
+            kw['uri'] = uri
             from_uri_params = self.from_uri(kw['uri'], as_dict=True)
             label = label or from_uri_params.get('label', None)
             from_uri_params.pop('label', None)
@@ -150,6 +155,9 @@ class SQLConnector(Connector):
                     f"    Missing flavor. Provide flavor as a key for '{self}'."
                 )
             self.flavor = flavor or self.parse_uri(self.__dict__['uri']).get('flavor', None)
+
+        if self.flavor == 'postgres':
+            self.flavor = 'postgresql'
 
         self._debug = debug
         ### Store the PID and thread at initialization

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -407,7 +407,7 @@ def guess_datetime(self) -> Union[str, None]:
     """
     dt_cols = [
         col for col, typ in self.dtypes.items()
-        if typ.startswith('datetime')
+        if str(typ).startswith('datetime')
     ]
     if not dt_cols:
         return None

--- a/meerschaum/core/Pipe/_register.py
+++ b/meerschaum/core/Pipe/_register.py
@@ -6,11 +6,12 @@
 Register a Pipe object
 """
 
-from meerschaum.utils.typing import SuccessTuple
+from meerschaum.utils.typing import SuccessTuple, Any
 
 def register(
         self,
-        debug: bool = False
+        debug: bool = False,
+        **kw: Any
     ) -> SuccessTuple:
     """
     Register a new Pipe along with its attributes.
@@ -20,10 +21,12 @@ def register(
     debug: bool, default False
         Verbosity toggle.
 
+    kw: Any
+        Keyword arguments to pass to `instance_connector.register_pipe()`.
+
     Returns
     -------
     A `SuccessTuple` of success, message.
-
     """
     if self.temporary:
         return False, "Cannot register pipes created with `temporary=True` (read-only)."
@@ -71,4 +74,4 @@ def register(
         }
 
     with Venv(get_connector_plugin(self.instance_connector)):
-        return self.instance_connector.register_pipe(self, debug=debug)
+        return self.instance_connector.register_pipe(self, debug=debug, **kw)

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -280,6 +280,8 @@ class Plugin:
         if debug:
             from meerschaum.utils.debug import dprint
         import tarfile
+        import re
+        import ast
         from meerschaum.plugins import reload_plugins, sync_plugins_symlinks
         from meerschaum.utils.packages import attempt_import, determine_version
         from meerschaum.utils.venv import init_venv
@@ -322,14 +324,17 @@ class Plugin:
             fpath = fpath / '__init__.py'
 
         init_venv(self.name, debug=debug)
-        new_version = determine_version(
-            fpath,
-            import_name = self.name,
-            search_for_metadata = False,
-            warn = True,
-            debug = debug,
-            #  venv = self.name,
-        )
+        with open(fpath, 'r', encoding='utf-8') as f:
+            init_lines = f.readlines()
+        new_version = None
+        for line in init_lines:
+            if '__version__' not in line:
+                continue
+            version_match = re.search(r'__version__(\s?)=', line.lstrip().rstrip())
+            if not version_match:
+                continue
+            new_version = ast.literal_eval(line.split('=')[1].lstrip().rstrip())
+            break
         if not new_version:
             warn(
                 f"No `__version__` defined for plugin '{self}'. "

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -184,9 +184,6 @@ class Plugin:
         from meerschaum.utils.packages import attempt_import
         pathspec = attempt_import('pathspec', debug=debug)
 
-        old_cwd = os.getcwd()
-        os.chdir(PLUGINS_RESOURCES_PATH)
-
         if not self.__file__:
             from meerschaum.utils.warnings import error
             error(f"Could not find file for plugin '{self}'.")
@@ -196,6 +193,10 @@ class Plugin:
         else:
             path = self.__file__
             is_dir = False
+
+        old_cwd = os.getcwd()
+        real_parent_path = pathlib.Path(os.path.realpath(path)).parent
+        os.chdir(real_parent_path)
 
         default_patterns_to_ignore = [
             '.pyc',

--- a/meerschaum/utils/typing.py
+++ b/meerschaum/utils/typing.py
@@ -11,6 +11,7 @@ try:
         Union,
         Any,
         Iterable,
+        Hashable,
     )
 except Exception as e:
     import urllib.request, sys, pathlib, os


### PR DESCRIPTION
# v1.5.3

- **Pipes now support syncing dictionaries and lists.**  
  Complex columns (dicts or lists) will now be preserved:

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe('a', 'b')
  pipe.sync([{'a': {'b': 1}}])
  df = pipe.get_data()
  print(df['a'][0])
  # {'b': 1}
  ```

  You can also force strings to be parsed by setting the data type to `json`:

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe(
      'foo', 'bar',
      columns = {'datetime': 'id'},
      dtypes = {'data': 'json', 'id': 'Int64'},
  )
  docs = [{'id': 1, 'data': '{"foo": "bar"}'}]
  pipe.sync(docs)
  df = pipe.get_data()
  print(df['data'][0])
  # {'foo': 'bar'}
  ```

  For PostgreSQL-like databases (e.g. TimescaleDB), this is stored as `JSONB` under the hood. For all others, it's stored as the equivalent for `TEXT`.

- **Fixed determining the version when installing plugins.**  
  Like the `required` list, the `__version__` string must be explicitly set in order for the correct version to be determined.

- **Automatically cast `postgres` to `postgresql`**  
  When a `SQLConnector` is built with a flavor of `postgres`, it will be automatically set to `postgresql`.