### PR TITLE
⬇️ v1.5.6 Hold back `SQLAlchemy` to <2.0.0.

### DIFF
--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -129,7 +129,7 @@ packages['sql'] = {
     'pandas'                         : 'pandas>=1.3.0',
     'pytz'                           : 'pytz>=2022.1.0',
     'joblib'                         : 'joblib>=0.17.0',
-    'sqlalchemy'                     : 'SQLAlchemy>=1.4.42',
+    'sqlalchemy'                     : 'SQLAlchemy<2.0.0',
     'databases'                      : 'databases>=0.4.0',
     'aiosqlite'                      : 'aiosqlite>=0.16.0',
     'asyncpg'                        : 'asyncpg>=0.21.0',

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -12,7 +12,7 @@ numpy>=1.18.5
 pandas>=1.3.0
 pytz>=2022.1.0
 joblib>=0.17.0
-SQLAlchemy>=1.4.42
+SQLAlchemy<2.0.0
 databases>=0.4.0
 aiosqlite>=0.16.0
 asyncpg>=0.21.0

--- a/requirements/full.txt
+++ b/requirements/full.txt
@@ -47,7 +47,7 @@ numpy>=1.18.5
 pandas>=1.3.0
 pytz>=2022.1.0
 joblib>=0.17.0
-SQLAlchemy>=1.4.42
+SQLAlchemy<2.0.0
 databases>=0.4.0
 aiosqlite>=0.16.0
 asyncpg>=0.21.0


### PR DESCRIPTION
v2.0.0 of SQLAlchemy was released today with some breaking changes. This patch holds SQLAlchemy back to <2.0.0 until compatibility has been verified.