### PR TITLE
🩹 v1.5.7 Fix minor issues when syncing large integers in a JSON column.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.5.3 – v1.5.5
+### v1.5.7
+
+- **Replace `ast.literal_eval()` with `json.loads()` when filtering JSON columns.**  
+  This patch replaces the use of `str` and `ast.literal_eval()` with `json.dumps()` and `json.loads()` to preserve accuracy.
+
+- **Fix a subtle bug with subprocesses.**  
+  The function `run_python_package()` now better handles environment passing and raises a more verbose warning when something goes wrong.
+
+- **Allow columns with `'create'` in the name.**  
+  A security measure previously disallowed certain keywords when sanitizing input. Now columns are allowed to contain certain keywords.
+
+### v1.5.3 – v1.5.6
 
 - **Pipes now support syncing dictionaries and lists.**  
   Complex columns (dicts or lists) will now be preserved:

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.5.3 – v1.5.5
+### v1.5.7
+
+- **Replace `ast.literal_eval()` with `json.loads()` when filtering JSON columns.**  
+  This patch replaces the use of `str` and `ast.literal_eval()` with `json.dumps()` and `json.loads()` to preserve accuracy.
+
+- **Fix a subtle bug with subprocesses.**  
+  The function `run_python_package()` now better handles environment passing and raises a more verbose warning when something goes wrong.
+
+- **Allow columns with `'create'` in the name.**  
+  A security measure previously disallowed certain keywords when sanitizing input. Now columns are allowed to contain certain keywords.
+
+### v1.5.3 – v1.5.6
 
 - **Pipes now support syncing dictionaries and lists.**  
   Complex columns (dicts or lists) will now be preserved:

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.5.6"
+__version__ = "1.5.7"

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -8,6 +8,7 @@ Synchronize a pipe's data with its source via its connector
 
 from __future__ import annotations
 
+import json
 from meerschaum.utils.typing import (
     Union, Optional, Callable, Any, Tuple, SuccessTuple, Mapping, Dict, List
 )
@@ -558,9 +559,9 @@ def filter_existing(
     unhashable_delta_cols = get_unhashable_cols(delta_df)
     unhashable_backtrack_cols = get_unhashable_cols(backtrack_df)
     for col in unhashable_delta_cols:
-        delta_df[col] = delta_df[col].apply(str)
+        delta_df[col] = delta_df[col].apply(json.dumps)
     for col in unhashable_backtrack_cols:
-        backtrack_df[col] = backtrack_df[col].apply(str)
+        backtrack_df[col] = backtrack_df[col].apply(json.dumps)
     casted_cols = set(unhashable_delta_cols + unhashable_backtrack_cols)
 
     joined_df = pd.merge(
@@ -573,7 +574,7 @@ def filter_existing(
     ) if on_cols else delta_df
     for col in casted_cols:
         if col in joined_df.columns:
-            joined_df[col] = joined_df[col].apply(ast.literal_eval)
+            joined_df[col] = joined_df[col].apply(json.loads)
 
     ### Determine which rows are completely new.
     new_rows_mask = (joined_df['_merge'] == 'left_only') if on_cols else None

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1012,13 +1012,17 @@ def run_python_package(
             command, foreground=foreground, as_proc=as_proc, capture_output=capture_output, **kw
         )
     except Exception as e:
-        ### For some weird reason, the traceback here breaks the tests (???).
-        #  print(traceback.format_exc(e))
-        warn(e, color=False)
+        msg = f"Failed to execute {command}, will try again:\n{traceback.format_exc()}"
+        warn(msg, color=False)
         stdout, stderr = (
             (None, None) if not capture_output else (subprocess.PIPE, subprocess.PIPE)
         )
-        proc = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=os.environ)
+        proc = subprocess.Popen(
+            command,
+            stdout = stdout,
+            stderr = stderr,
+            env = kw.get('env', os.environ),
+        )
         to_return = proc if as_proc else proc.wait()
     except KeyboardInterrupt:
         to_return = 1 if not as_proc else None

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -421,7 +421,7 @@ def clean(substring: str) -> str:
     Raises an exception when banned words are used.
     """
     from meerschaum.utils.warnings import error
-    banned_symbols = [';', '--', 'drop', 'create', 'alter', 'delete', 'commit']
+    banned_symbols = [';', '--', 'drop ',]
     for symbol in banned_symbols:
         if symbol in str(substring).lower():
             error(f"Invalid string: '{substring}'")


### PR DESCRIPTION
# v1.5.7

- **Replace `ast.literal_eval()` with `json.loads()` when filtering JSON columns.**  
  This patch replaces the use of `str` and `ast.literal_eval()` with `json.dumps()` and `json.loads()` to preserve accuracy.

- **Fix a subtle bug with subprocesses.**  
  The function `run_python_package()` now better handles environment passing and raises a more verbose warning when something goes wrong.

- **Allow columns with `'create'` in the name.**  
  A security measure previously disallowed certain keywords when sanitizing input. Now columns are allowed to contain certain keywords.