### PR TITLE
🐛 v1.5.8 Determine JSON columns from first non-null values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.5.8
+
+- **Infer JSON columns from the first first non-null value.**  
+  When determining complex columns (dictionaries or lists), the first non-null value of the dataframe is checked rather than the first row only. This accounts for documents which contain variable keys in the same sync, e.g.:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync([
+      {'a': {'b': 1}},
+      {'c': {'d': 2}},
+  ])
+  ```
+
+- **Fix a bug when reconstructing JSON columns.**  
+  When rebuilding JSON values after merging, a check is first performed if the value is in fact a string (sometimes `NULLS` slip in).
+
+
 ### v1.5.7
 
 - **Replace `ast.literal_eval()` with `json.loads()` when filtering JSON columns.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,24 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.5.8
+
+- **Infer JSON columns from the first first non-null value.**  
+  When determining complex columns (dictionaries or lists), the first non-null value of the dataframe is checked rather than the first row only. This accounts for documents which contain variable keys in the same sync, e.g.:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync([
+      {'a': {'b': 1}},
+      {'c': {'d': 2}},
+  ])
+  ```
+
+- **Fix a bug when reconstructing JSON columns.**  
+  When rebuilding JSON values after merging, a check is first performed if the value is in fact a string (sometimes `NULLS` slip in).
+
+
 ### v1.5.7
 
 - **Replace `ast.literal_eval()` with `json.loads()` when filtering JSON columns.**  

--- a/docs/mkdocs/reference/data-analysis-tools.md
+++ b/docs/mkdocs/reference/data-analysis-tools.md
@@ -75,7 +75,7 @@ If you're already using [SQLAlchemy](https://www.sqlalchemy.org/), Meerschaum ca
 
 ```python
 >>> import meerschaum as mrsm
->>> from meerschaum.connectors.sql.tools import get_sqlalchemy_table
+>>> from meerschaum.utils.sql import get_sqlalchemy_table
 >>> conn = mrsm.get_connector()
 >>>
 >>> ### Directly access the `sqlalchemy` engine.

--- a/docs/mkdocs/reference/plugins/writing-plugins.md
+++ b/docs/mkdocs/reference/plugins/writing-plugins.md
@@ -374,7 +374,7 @@ In case the built-in command line options are not sufficient, you can add argume
 ```python
 ### ~/.config/meerschaum/plugins/example.py
 
-from meerschaum.actions.arguments import add_plugin_argument
+from meerschaum.plugins import add_plugin_argument
 add_plugin_argument('--foo', type=int, help="This is my help text!")
 
 ```

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2531,8 +2531,11 @@ def get_to_sql_dtype(
     >>> get_to_sql_dtype(pipe, df)
     {'a': <class 'sqlalchemy.sql.sqltypes.JSON'>}
     """
+    from meerschaum.utils.misc import get_json_cols
     from meerschaum.utils.sql import get_db_type
     df_dtypes = {col: str(typ) for col, typ in df.dtypes.items()}
+    json_cols = get_json_cols(df)
+    df_dtypes.update({col: 'json' for col in json_cols})
     if update_dtypes:
         df_dtypes.update(pipe.dtypes)
     return {

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -428,7 +428,6 @@ def filter_existing(
     -------
     A tuple of three pandas DataFrames: unseen, update, and delta.
     """
-    import ast
     import datetime
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.debug import dprint
@@ -574,7 +573,13 @@ def filter_existing(
     ) if on_cols else delta_df
     for col in casted_cols:
         if col in joined_df.columns:
-            joined_df[col] = joined_df[col].apply(json.loads)
+            joined_df[col] = joined_df[col].apply(
+                lambda x: (
+                    json.loads(x)
+                    if isinstance(x, str)
+                    else x
+                )
+            )
 
     ### Determine which rows are completely new.
     new_rows_mask = (joined_df['_merge'] == 'left_only') if on_cols else None

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1896,7 +1896,16 @@ def get_json_cols(df: 'pd.DataFrame') -> List[str]:
     """
     if len(df) == 0:
         return []
+    cols_indices = {
+        col: df[col].first_valid_index()
+        for col in df.columns
+    }
     return [
-        col for col, typ in df.dtypes.items()
-        if isinstance(df.iloc[0][col], (dict, list))
+        col
+        for col, ix in cols_indices.items()
+        if (
+            ix is not None
+            and
+            isinstance(df.iloc[ix][col], (dict, list))
+        )
     ]

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1896,8 +1896,15 @@ def get_json_cols(df: 'pd.DataFrame') -> List[str]:
     """
     if len(df) == 0:
         return []
+
+    def coerce_index(ix: Any) -> Union[int, None]:
+        try:
+            return int(ix)
+        except Exception as e:
+            return None
+
     cols_indices = {
-        col: df[col].first_valid_index()
+        col: coerce_index(df[col].first_valid_index())
         for col in df.columns
     }
     return [
@@ -1906,6 +1913,6 @@ def get_json_cols(df: 'pd.DataFrame') -> List[str]:
         if (
             ix is not None
             and
-            isinstance(df.iloc[ix][col], (dict, list))
+            not isinstance(df.iloc[ix][col], Hashable)
         )
     ]

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1897,14 +1897,8 @@ def get_json_cols(df: 'pd.DataFrame') -> List[str]:
     if len(df) == 0:
         return []
 
-    def coerce_index(ix: Any) -> Union[int, None]:
-        try:
-            return int(ix)
-        except Exception as e:
-            return None
-
     cols_indices = {
-        col: coerce_index(df[col].first_valid_index())
+        col: df[col].first_valid_index()
         for col in df.columns
     }
     return [
@@ -1913,6 +1907,6 @@ def get_json_cols(df: 'pd.DataFrame') -> List[str]:
         if (
             ix is not None
             and
-            not isinstance(df.iloc[ix][col], Hashable)
+            not isinstance(df.loc[ix][col], Hashable)
         )
     ]

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -141,6 +141,8 @@ DB_TO_PD_DTYPES = {
     'BOOL': 'bool',
     'BOOLEAN': 'bool',
     'BOOLEAN()': 'bool',
+    'JSON': 'object',
+    'JSONB': 'object',
     'substrings': {
         'CHAR': 'object',
         'TIMESTAMP': 'datetime64[ns]',
@@ -150,6 +152,7 @@ DB_TO_PD_DTYPES = {
         'DECIMAL': 'float64',
         'INT': 'Int64',
         'BOOL': 'bool',
+        'JSON': 'object',
     },
     'default': 'object',
 }


### PR DESCRIPTION
# v1.5.8

- **Infer JSON columns from the first first non-null value.**  
  When determining complex columns (dictionaries or lists), the first non-null value of the dataframe is checked rather than the first row only. This accounts for documents which contain variable keys in the same sync, e.g.:

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe('a', 'b')
  pipe.sync([
      {'a': {'b': 1}},
      {'c': {'d': 2}},
  ])
  ```

- **Fix a bug when reconstructing JSON columns.**  
  When rebuilding JSON values after merging, a check is first performed if the value is in fact a string (sometimes `NULLS` slip in).