### PR TITLE
⚡️ v1.6.5 Sync data generators (in parallel!) and fix an edge case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,20 @@ This is the current release cycle, so stay tuned for future releases!
 
   This means you may now return generators to large transcations, such as reading a large CSV: 
   ```python
-  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']
+  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']:
       return pd.read_csv('data.csv', chunksize=1000)
+  ```
+
+  Any iterator of DataFrame-like chunks will work:
+
+  ```python
+  def fetch(pipe, **kw) -> Generator[List[Dict[str, Any]]]:
+      return (
+          [
+              {'id': 1, 'val': 10.0 * i},
+              {'id': 2, 'val': 20.0 * i},
+          ] for i in range(10)
+      )
   ```
 
   This new behavior has been added to `SQLConnector.fetch()` so you may now confidently sync very large tables between your databases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the current release cycle, so stay tuned for future releases!
 ### v1.6.5
 
 - **Allow pipes to sync DataFrame generators.**  
-  If `pipe.sync()` receives a generator (for `DataFrames`, dicctionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
+  If `pipe.sync()` receives a generator (for `DataFrames`, dictionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
 
   This means you may now return generators to large transcations, such as reading a large CSV: 
   ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.5
+
+- **Allow pipes to sync DataFrame generators.**  
+  If `pipe.sync()` receives a generator (for `DataFrames`, dicctionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
+
+  This means you may now return generators to large transcations, such as reading a large CSV: 
+  ```python
+  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']
+      return pd.read_csv('data.csv', chunksize=1000)
+  ```
+
+  This new behavior has been added to `SQLConnector.fetch()` so you may now confidently sync very large tables between your databases.
+
+  **NOTE:** The default `chunksize` for SQL queries has been lowered to 100,000 from 1,000,000. You may alter this value with `--chunksize` or setting the value in `MRSM{system:connectors:sql:chunksize}` (you can also edit the default pool size here).
+
+- **Fix edge case with SQL in-place syncs.**  
+  Occasionally, a few docs would be duplicated when running in-place SQL syncs. This patch increases the fetch window size to mitigate the issue.
+
+- **Remove `begin` and `end` from `filter_existing()`.**  
+  The keyword arguments were interfering with the determined datetime bounds, so this patch removes these flags (albeit `begin` was already ignored) to avoid confusion. Date bounds are solely determined from the contents of the DataFrame.
+
 ### v1.6.4
 
 - **Allow for mixed UTC offsets in datetimes.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -11,8 +11,20 @@ This is the current release cycle, so stay tuned for future releases!
 
   This means you may now return generators to large transcations, such as reading a large CSV: 
   ```python
-  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']
+  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']:
       return pd.read_csv('data.csv', chunksize=1000)
+  ```
+
+  Any iterator of DataFrame-like chunks will work:
+
+  ```python
+  def fetch(pipe, **kw) -> Generator[List[Dict[str, Any]]]:
+      return (
+          [
+              {'id': 1, 'val': 10.0 * i},
+              {'id': 2, 'val': 20.0 * i},
+          ] for i in range(10)
+      )
   ```
 
   This new behavior has been added to `SQLConnector.fetch()` so you may now confidently sync very large tables between your databases.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -7,7 +7,7 @@ This is the current release cycle, so stay tuned for future releases!
 ### v1.6.5
 
 - **Allow pipes to sync DataFrame generators.**  
-  If `pipe.sync()` receives a generator (for `DataFrames`, dicctionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
+  If `pipe.sync()` receives a generator (for `DataFrames`, dictionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
 
   This means you may now return generators to large transcations, such as reading a large CSV: 
   ```python

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,27 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.5
+
+- **Allow pipes to sync DataFrame generators.**  
+  If `pipe.sync()` receives a generator (for `DataFrames`, dicctionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.
+
+  This means you may now return generators to large transcations, such as reading a large CSV: 
+  ```python
+  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']
+      return pd.read_csv('data.csv', chunksize=1000)
+  ```
+
+  This new behavior has been added to `SQLConnector.fetch()` so you may now confidently sync very large tables between your databases.
+
+  **NOTE:** The default `chunksize` for SQL queries has been lowered to 100,000 from 1,000,000. You may alter this value with `--chunksize` or setting the value in `MRSM{system:connectors:sql:chunksize}` (you can also edit the default pool size here).
+
+- **Fix edge case with SQL in-place syncs.**  
+  Occasionally, a few docs would be duplicated when running in-place SQL syncs. This patch increases the fetch window size to mitigate the issue.
+
+- **Remove `begin` and `end` from `filter_existing()`.**  
+  The keyword arguments were interfering with the determined datetime bounds, so this patch removes these flags (albeit `begin` was already ignored) to avoid confusion. Date bounds are solely determined from the contents of the DataFrame.
+
 ### v1.6.4
 
 - **Allow for mixed UTC offsets in datetimes.**  

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -59,7 +59,7 @@ default_system_config = {
             'pandas'           : 'pandas',
         },
         'sql' : {
-            'chunksize'        : 1000000,
+            'chunksize'        : 100000,
             'poolclass'        : 'sqlalchemy.pool.QueuePool',
             'create_engine'    : {
                 'method'       : 'multi',

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -61,20 +61,30 @@ def fetch(
         debug = debug,
         **kw
     )
-    df = self.read(meta_def, chunk_hook=chunk_hook, chunksize=chunksize, debug=debug)
+    chunks = self.read(
+        meta_def,
+        chunk_hook = chunk_hook,
+        chunksize = chunksize,
+        as_iterator = True,
+        debug = debug,
+    )
     ### if sqlite, parse for datetimes
     if self.flavor == 'sqlite':
         from meerschaum.utils.misc import parse_df_datetimes
-        df = parse_df_datetimes(
-            df,
-            ignore_cols = [
-                col
-                for col, dtype in pipe.dtypes.items()
-                if 'datetime' not in str(dtype)
-            ],
-            debug = debug,
+        ignore_cols = [
+            col
+            for col, dtype in pipe.dtypes.items()
+            if 'datetime' not in str(dtype)
+        ]
+        return (
+            parse_df_datetimes(
+                chunk,
+                ignore_cols = ignore_cols,
+                debug = debug,
+            )
+            for chunk in chunks
         )
-    return df
+    return chunks
 
 
 def get_pipe_metadef(

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1141,8 +1141,6 @@ def sync_pipe(
         pipe.filter_existing(
             df,
             chunksize = chunksize,
-            begin = begin,
-            end = end,
             debug = debug,
             **kw
         ) if check_existing else (df, None, df)
@@ -1420,6 +1418,8 @@ def sync_pipe_inplace(
         pipe,
         begin = begin,
         end = end,
+        begin_add_minutes = -1,
+        end_add_minutes = 1,
         params = params,
         debug = debug,
         order = None,
@@ -1427,7 +1427,7 @@ def sync_pipe_inplace(
 
     create_backtrack_query = (
         (
-            f"WITH backtrack_def AS ({backtrack_def})\n"
+            f"WITH backtrack_def AS (\n{backtrack_def}\n)\n"
             + f"SELECT *\nINTO {backtrack_table_name}\nFROM backtrack_def"
         ) if self.flavor not in ('sqlite', 'oracle', 'mysql', 'mariadb', 'duckdb')
         else (

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -284,7 +284,7 @@ def sync(
                 )
 
 
-            pool = get_pool(workers=workers)
+            pool = get_pool(workers=kw.get('workers', 1))
             if debug:
                 dprint(f"Received {type(df)}. Attempting to sync first chunk...")
             chunk = next(df)

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -260,8 +260,11 @@ def sync(
             from meerschaum.utils.pool import get_pool
             from meerschaum.utils.misc import get_datetime_bound_from_df
             import threading
-            if p.instance_connector.type == 'sql':
-                engine_pool_size = p.instance_connector.engine.pool.size()
+            engine_pool_size = (
+                p.instance_connector.engine.pool.size()
+                if p.instance_connector.type == 'sql'
+                else 1
+            )
             current_num_threads = len(threading.enumerate())
             workers = kw.get('workers', None)
             desired_workers = min(workers or engine_pool_size, engine_pool_size)

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -551,9 +551,8 @@ def filter_existing(
         return df, df, df
 
     ### begin is the oldest data in the new dataframe
+    begin, end = None, None
     dt_col = self.columns.get('datetime', None)
-    if dt_col is None and begin:
-        dt_col = self.guess_datetime()
     dt_type = self.dtypes.get(dt_col, 'datetime64[ns]') if dt_col else None
     try:
         min_dt_val = df[dt_col].min(skipna=True) if dt_col else None

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from meerschaum.utils.typing import (
-    Union, Optional, Callable, Any, Tuple, SuccessTuple, Mapping, Dict, List
+    Union, Optional, Callable, Any, Tuple, SuccessTuple, Mapping, Dict, List, Iterable, Generator
 )
 
 class InferFetch:
@@ -251,6 +251,83 @@ def sync(
         ### CHECKPOINT: Retrieved the DataFrame.
         _checkpoint(**kw)
         
+        ### Allow for dataframe generators or iterables.
+        if (
+            not isinstance(df, (dict, list, str))
+            and 'DataFrame' not in str(type(df))
+            and isinstance(df, (Generator, Iterable))
+        ):
+            from meerschaum.utils.pool import get_pool
+            from meerschaum.utils.misc import get_datetime_bound_from_df
+            import threading
+            if p.instance_connector.type == 'sql':
+                engine_pool_size = p.instance_connector.engine.pool.size()
+            current_num_threads = len(threading.enumerate())
+            workers = kw.get('workers', None)
+            desired_workers = min(workers or engine_pool_size, engine_pool_size)
+            kw['workers'] = max(
+                (desired_workers - current_num_threads),
+                1,
+            )
+
+            dt_col = p.columns.get('datetime', None)
+            def get_chunk_label(_chunk) -> str:
+                min_dt = get_datetime_bound_from_df(_chunk, dt_col)
+                max_dt = get_datetime_bound_from_df(_chunk, dt_col, minimum=False)
+                return (
+                    f"{min_dt} - {max_dt}"
+                    if min_dt is not None and max_dt is not None
+                    else ''
+                )
+
+
+            pool = get_pool(workers=workers)
+            if debug:
+                dprint(f"Received {type(df)}. Attempting to sync first chunk...")
+            chunk = next(df)
+            chunk_success, chunk_msg = _sync(p, chunk)
+            chunk_msg = '\n' + get_chunk_label(chunk) + '\n' + chunk_msg
+            if not chunk_success:
+                return chunk_success, f"Unable to sync initial chunk for {p}:\n{chunk_msg}"
+            if debug:
+                dprint(f"Successfully synced the first chunk, attemping the rest...")
+
+            failed_chunks = []
+            def _process_chunk(_chunk):
+                try:
+                    _chunk_success, _chunk_msg = _sync(p, _chunk)
+                except Exception as e:
+                    _chunk_success, _chunk_msg = False, str(e)
+                if not _chunk_success:
+                    failed_chunks.append(_chunk)
+                return _chunk_success, '\n' + get_chunk_label(_chunk) + '\n' + _chunk_msg
+
+
+            results = sorted(
+                [(chunk_success, chunk_msg)] + pool.map(_process_chunk, df)
+            )
+            chunk_messages = [chunk_msg for _, chunk_msg in results]
+            success_bools = [chunk_success for chunk_success, _ in results]
+            failure_indices = [
+                i for i, _success_bool in enumerate(success_bools)
+                if not _success_bool
+            ]
+            success = all(success_bools)
+            msg = '\n'.join(chunk_messages)
+
+            ### If some chunks succeeded, retry the failures.
+            retry_success = True
+            if not success and any(success_bools):
+                if debug:
+                    dprint(f"Retrying failed chunks...")
+                for chunk in failed_chunks:
+                    chunk_success, chunk_msg = _process_chunk(chunk)
+                    msg += f"\nRetried chunk:\n{chunk_msg}"
+                    retry_success = retry_success and chunk_success
+
+            success = success and retry_success
+            return success, msg
+
         ### Cast to a dataframe and ensure datatypes are what we expect.
         df = self.enforce_dtypes(df, debug=debug)
         if debug:
@@ -428,8 +505,6 @@ def exists(
 def filter_existing(
         self,
         df: 'pd.DataFrame',
-        begin: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
         chunksize: Optional[int] = -1,
         params: Optional[Dict[str, Any]] = None,
         debug: bool = False,
@@ -443,13 +518,6 @@ def filter_existing(
     df: 'pd.DataFrame'
         The dataframe to inspect and filter.
         
-    begin: Optional[datetime.datetime], default None
-        NOTE: This is not used! The minimum datetime value is used.
-
-    end: Optional[datetime.datetime], default
-        If provided, use this boundary when searching for existing data.
-        Else use the maximum datetime value (+1 for integer datetimes).
-
     chunksize: Optional[int], default -1
         The `chunksize` used when fetching existing data.
 
@@ -529,16 +597,15 @@ def filter_existing(
         if 'int' not in str(type(max_dt)).lower():
             max_dt = None
 
-    if end is None:
-        if isinstance(max_dt, datetime.datetime):
-            end = (
-                round_time(
-                    max_dt,
-                    to = 'down'
-                ) + datetime.timedelta(minutes=1)
-            )
-        elif dt_type and 'int' in dt_type.lower():
-            end = max_dt + 1
+    if isinstance(max_dt, datetime.datetime):
+        end = (
+            round_time(
+                max_dt,
+                to = 'down'
+            ) + datetime.timedelta(minutes=1)
+        )
+    elif dt_type and 'int' in dt_type.lower():
+        end = max_dt + 1
 
     if max_dt is not None and min_dt is not None and min_dt > max_dt:
         warn(f"Detected minimum datetime greater than maximum datetime.")

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -2097,3 +2097,59 @@ def enforce_dtypes(
                         dprint(f"Was unable to convert to float then {t}.")
     return df
 
+
+def get_datetime_bound_from_df(
+        df: Union['pd.DataFrame', dict, list],
+        datetime_column: str,
+        minimum: bool = True,
+    ) -> Union[int, 'datetime.datetime', None]:
+    """
+    Return the minimum or maximum datetime (or integer) from a DataFrame.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The DataFrame, list, or dict which contains the range axis.
+
+    datetime_column: str
+        The name of the datetime (or int) column.
+
+    minimum: bool
+        Whether to return the minimum (default) or maximum value.
+
+    Returns
+    -------
+    The minimum or maximum datetime value in the dataframe, or `None`.
+    """
+    if not datetime_column:
+        return None
+
+    def compare(a, b):
+        if a is None:
+            return b
+        if minimum:
+            return a if a < b else b
+        return a if a > b else b
+
+    if isinstance(df, list):
+        if len(df) == 0:
+            return None
+        best_yet = df[0].get(datetime_column, None)
+        for doc in df:
+            val = doc.get(datetime_column, None)
+            best_yet = compare(best_yet, val)
+        return best_yet
+
+    if isinstance(df, dict):
+        if datetime_column not in df:
+            return None
+        best_yet = df[datetime_column][0]
+        for val in df[datetime_column]:
+            best_yet = compare(best_yet, val)
+        return best_yet
+
+    return (
+        df[datetime_column].min(skipna=True)
+        if minimum
+        else df[datetime_column].max(skipna=True)
+    )

--- a/meerschaum/utils/typing.py
+++ b/meerschaum/utils/typing.py
@@ -12,6 +12,7 @@ try:
         Any,
         Iterable,
         Hashable,
+        Generator,
     )
 except Exception as e:
     import urllib.request, sys, pathlib, os

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -501,3 +501,23 @@ def test_no_indices_inferred_datetime_to_text(flavor: str):
     df = pipe.get_data()
     assert len(df) == len(docs)
 
+
+@pytest.mark.parametrize("flavor", sorted(list(all_pipes.keys())))
+def test_sync_generators(flavor: str):
+    """
+    Verify that we are able to sync generators of chunks.
+    """
+    conn = conns[flavor]
+    pipe = Pipe(
+        'test_generators', 'foo',
+        instance = conn,
+        columns = {'datetime': 'dt'},
+    )
+    pipe.delete()
+    start_time = datetime.datetime(2023, 1, 1)
+    num_docs = 10
+    generator = ([{'dt': start_time + datetime.timedelta(days=i)}] for i in range(num_docs))
+    success, msg = pipe.sync(generator, debug=debug)
+    assert success, msg
+    rowcount = pipe.get_rowcount()
+    assert rowcount == num_docs


### PR DESCRIPTION
# v1.6.5

- **Allow pipes to sync DataFrame generators.**  
  If `pipe.sync()` receives a generator (for `DataFrames`, dicctionaries, or lists), it will attempt to consume it and sync its chunks in parallel threads (this can be single-threaded with `--workers 1`). For SQL pipes, this will be capped at your configured pool size (default 5) minus the running number of threads.

  This means you may now return generators to large transcations, such as reading a large CSV: 
  ```python
  def fetch(pipe, **kw) -> Iterable['pd.DataFrame']:
      return pd.read_csv('data.csv', chunksize=1000)
  ```

  Any iterator of DataFrame-like chunks will work:

  ```python
  def fetch(pipe, **kw) -> Generator[List[Dict[str, Any]]]:
      return (
          [
              {'id': 1, 'val': 10.0 * i},
              {'id': 2, 'val': 20.0 * i},
          ] for i in range(10)
      )
  ```

  This new behavior has been added to `SQLConnector.fetch()` so you may now confidently sync very large tables between your databases.

  **NOTE:** The default `chunksize` for SQL queries has been lowered to 100,000 from 1,000,000. You may alter this value with `--chunksize` or setting the value in `MRSM{system:connectors:sql:chunksize}` (you can also edit the default pool size here).

- **Fix edge case with SQL in-place syncs.**  
  Occasionally, a few docs would be duplicated when running in-place SQL syncs. This patch increases the fetch window size to mitigate the issue.

- **Remove `begin` and `end` from `filter_existing()`.**  
  The keyword arguments were interfering with the determined datetime bounds, so this patch removes these flags (albeit `begin` was already ignored) to avoid confusion. Date bounds are solely determined from the contents of the DataFrame.