### PR TITLE
v1.6.6 SQLite fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v1.6.6
 
-- **Issue one `ALTER TABLE` query per column for SQLite.**  
-  SQLite does not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
+- **Issue one `ALTER TABLE` query per column for SQLite, MSSQL, DuckDB, and Oracle SQL.**  
+  SQLite and other flavors do not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
 
 ### v1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.6
+
+- **Issue one `ALTER TABLE` query per column for SQLite.**  
+  SQLite does not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
+
 ### v1.6.5
 
 - **Allow pipes to sync DataFrame generators.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -6,8 +6,8 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v1.6.6
 
-- **Issue one `ALTER TABLE` query per column for SQLite.**  
-  SQLite does not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
+- **Issue one `ALTER TABLE` query per column for SQLite, MSSQL, DuckDB, and Oracle SQL.**  
+  SQLite and other flavors do not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
 
 ### v1.6.5
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.6
+
+- **Issue one `ALTER TABLE` query per column for SQLite.**  
+  SQLite does not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.
+
 ### v1.6.5
 
 - **Allow pipes to sync DataFrame generators.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2370,13 +2370,25 @@ def get_add_columns_queries(
         ) for col in new_cols
     }
 
-    query = "ALTER TABLE " + sql_item_name(pipe.target, self.flavor)
+    alter_table_query = "ALTER TABLE " + sql_item_name(pipe.target, self.flavor)
+    queries = []
     for col, typ in new_cols_types.items():
-        query += "\nADD " + sql_item_name(col, self.flavor) + " " + typ + ","
-    query = query[:-1]
-    if self.flavor != 'duckdb':
-        return [query]
+        add_col_query = "\nADD " + sql_item_name(col, self.flavor) + " " + typ + ","
 
+        if self.flavor == 'sqlite':
+            queries.append(alter_table_query + add_col_query[:-1])
+        else:
+            alter_table_query += add_col_query
+
+    ### For most flavors, only one query is required.
+    ### This covers SQLite which requires one query per column.
+    if not queries:
+        queries.append(alter_table_query[:-1])
+
+    if self.flavor != 'duckdb':
+        return queries
+
+    ### NOTE: For DuckDB, we must drop and rebuild the indices.
     drop_index_queries = list(flatten_list(
         [q for ix, q in self.get_drop_index_queries(pipe, debug=debug).items()]
     ))

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2396,7 +2396,7 @@ def get_add_columns_queries(
         [q for ix, q in self.get_create_index_queries(pipe, debug=debug).items()]
     ))
 
-    return drop_index_queries + [query] + create_index_queries
+    return drop_index_queries + queries + create_index_queries
 
 
 def get_alter_columns_queries(

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2338,7 +2338,12 @@ def get_add_columns_queries(
     if not pipe.exists(debug=debug):
         return []
     import copy
-    from meerschaum.utils.sql import get_pd_type, get_db_type, sql_item_name
+    from meerschaum.utils.sql import (
+        get_pd_type,
+        get_db_type,
+        sql_item_name,
+        SINGLE_ALTER_TABLE_FLAVORS,
+    )
     from meerschaum.utils.misc import flatten_list
     table_obj = self.get_pipe_table(pipe, debug=debug)
     df_cols_types = (
@@ -2375,7 +2380,7 @@ def get_add_columns_queries(
     for col, typ in new_cols_types.items():
         add_col_query = "\nADD " + sql_item_name(col, self.flavor) + " " + typ + ","
 
-        if self.flavor == 'sqlite':
+        if self.flavor in SINGLE_ALTER_TABLE_FLAVORS:
             queries.append(alter_table_query + add_col_query[:-1])
         else:
             alter_table_query += add_col_query

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -122,6 +122,7 @@ max_name_lens = {
 }
 json_flavors = {'postgresql', 'timescaledb', 'citus', 'cockroachdb'}
 OMIT_NULLSFIRST_FLAVORS = {'mariadb', 'mysql', 'mssql'}
+SINGLE_ALTER_TABLE_FLAVORS = {'duckdb', 'sqlite', 'mssql', 'oracle'}
 DB_TO_PD_DTYPES = {
     'FLOAT': 'float64',
     'DOUBLE_PRECISION': 'float64',

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -521,3 +521,34 @@ def test_sync_generators(flavor: str):
     assert success, msg
     rowcount = pipe.get_rowcount()
     assert rowcount == num_docs
+
+
+@pytest.mark.parametrize("flavor", sorted(list(all_pipes.keys())))
+def test_add_new_columns(flavor: str):
+    """
+    Verify that we are able to add new columns dynamically.
+    """
+    conn = conns[flavor]
+    pipe = Pipe('test', 'add_columns')
+    pipe.delete()
+    pipe = Pipe(
+        'test_add', 'columns',
+        instance = conn,
+        columns = {'datetime': 'dt'},
+    )
+
+    docs = [{'dt': '2023-01-01', 'a': 1}]
+    success, msg = pipe.sync(docs, debug=debug)
+    assert success, msg
+    docs = [{'dt': '2023-01-01', 'b': 'foo', 'c': 12.3, 'd': {'e': 5}}]
+    success, msg = pipe.sync(docs, debug=debug)
+    assert success, msg
+    assert len(pipe.dtypes) == 5
+    df = pipe.get_data()
+    assert len(df) == 1
+    assert 'dt' in df.columns
+    assert 'a' in df.columns
+    assert 'b' in df.columns
+    assert 'c' in df.columns
+    assert 'd' in df.columns
+    assert 'e' in df['d'][0]

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -529,7 +529,7 @@ def test_add_new_columns(flavor: str):
     Verify that we are able to add new columns dynamically.
     """
     conn = conns[flavor]
-    pipe = Pipe('test', 'add_columns')
+    pipe = Pipe('test', 'add_columns', instance=conn)
     pipe.delete()
     pipe = Pipe(
         'test_add', 'columns',

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -529,7 +529,7 @@ def test_add_new_columns(flavor: str):
     Verify that we are able to add new columns dynamically.
     """
     conn = conns[flavor]
-    pipe = Pipe('test', 'add_columns', instance=conn)
+    pipe = Pipe('test_add', 'columns', instance=conn)
     pipe.delete()
     pipe = Pipe(
         'test_add', 'columns',


### PR DESCRIPTION
# v1.6.6

- **Issue one `ALTER TABLE` query per column for SQLite.**  
  SQLite does not support multiple columns in an `ALTER TABLE` query. This patch addresses this behavior and adds a specific test for this scenario.