### PR TITLE
v1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.7
+
+- **Improve memory usage when syncing generators.**  
+  To more lazily sync chunks from generators, `pool.map()` has been replaced with `pool.imap()`.
+
 ### v1.6.6
 
 - **Issue one `ALTER TABLE` query per column for SQLite, MSSQL, DuckDB, and Oracle SQL.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.7
+
+- **Improve memory usage when syncing generators.**  
+  To more lazily sync chunks from generators, `pool.map()` has been replaced with `pool.imap()`.
+
 ### v1.6.6
 
 - **Issue one `ALTER TABLE` query per column for SQLite, MSSQL, DuckDB, and Oracle SQL.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.6"
+__version__ = "1.6.7.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.7.dev1"
+__version__ = "1.6.7"

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -344,7 +344,8 @@ class Pipe:
             _fetch_patch = {
                 'fetch': ({
                     'definition': (
-                        f"SELECT * FROM {sql_item_name(str(self), self.instance_connector.flavor)}"
+                        f"SELECT * "
+                        + f"FROM {sql_item_name(str(self.target), self.instance_connector.flavor)}"
                     ),
                 }) if self.instance_connector.type == 'sql' else ({
                     'connector_keys': self.connector_keys,

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -307,7 +307,7 @@ def sync(
 
 
             results = sorted(
-                [(chunk_success, chunk_msg)] + pool.map(_process_chunk, df)
+                [(chunk_success, chunk_msg)] + list(pool.imap(_process_chunk, df))
             )
             chunk_messages = [chunk_msg for _, chunk_msg in results]
             success_bools = [chunk_success for chunk_success, _ in results]


### PR DESCRIPTION
# v1.6.7

- **Improve memory usage when syncing generators.**  
  To more lazily sync chunks from generators, `pool.map()` has been replaced with `pool.imap()`.