### PR TITLE
⚡️ v1.6.8 Ultimate generators release!

### DIFF
--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -235,11 +235,6 @@ groups['sync'].add_argument(
     ),
 )
 groups['sync'].add_argument(
-    '--sync-chunks', action='store_true',
-    help="Sync chunks while fetching data instead of waiting until all have arrived. " +
-    "Similar to --async. WARNING! This can be very dangerous when used with --async.",
-)
-groups['sync'].add_argument(
     '--skip-check-existing', '--allow-duplicates', action='store_true',
     help = (
         "Skip checking for duplicate rows when syncing. " +

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -82,7 +82,7 @@ class Pipe:
     """
 
     from ._fetch import fetch
-    from ._data import get_data, get_backtrack_data, get_rowcount
+    from ._data import get_data, get_backtrack_data, get_rowcount, _get_data_as_iterator
     from ._register import register
     from ._attributes import (
         attributes,
@@ -104,7 +104,7 @@ class Pipe:
     )
     from ._show import show
     from ._edit import edit, edit_definition, update
-    from ._sync import sync, get_sync_time, exists, filter_existing
+    from ._sync import sync, get_sync_time, exists, filter_existing, _get_chunk_label
     from ._delete import delete
     from ._drop import drop
     from ._clear import clear

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -497,7 +497,7 @@ def dateadd_str(
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.warnings import error
     import datetime
-    dateutil = attempt_import('dateutil')
+    dateutil_parser = attempt_import('dateutil.parser')
     if 'int' in str(type(begin)).lower():
         return str(begin)
     if not begin:
@@ -507,7 +507,7 @@ def dateadd_str(
     ### Sanity check: make sure `begin` is a valid datetime before we inject anything.
     if not isinstance(begin, datetime.datetime):
         try:
-            begin_time = dateutil.parser.parse(begin)
+            begin_time = dateutil_parser.parse(begin)
         except Exception:
             begin_time = None
     else:


### PR DESCRIPTION
# v1.6.8

- **Added `as_iterator` to `Pipe.get_data()`.**  
  Passing `as_iterator=True` (or `as_chunks`) to `Pipe.get_data()` returns a generator which returns chunks of Pandas DataFrames.

  Each DataFrame is the result of a `Pipe.get_data()` call with intermediate datetime bounds between `begin` and `end` of size `chunk_interval` (default `datetime.timedelta(days=1)` for time-series / 100,000 IDs for integers).

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'a', 'b',
      columns={'datetime': 'id'},
      dtypes={'id': 'Int64'},
  )
  pipe.sync([
      {'id': 0, 'color': 'red'},
      {'id': 1, 'color': 'blue'},
      {'id': 2, 'color': 'green'},
      {'id': 3, 'color': 'yellow'},
  ])

  ### NOTE: due to non-inclusive end bounding,
  ###       sometimes chunks contain
  ###       (chunk_interval - 1) rows.
  chunks = pipe.get_data(
      chunk_interval = 2,
      as_iterator = True,
  )
  for chunk in chunks:
      print(chunk)

  #    id color
  # 0   0   red
  # 1   1  blue
  #    id   color
  # 0   2   green
  # 1   3  yellow
  ```

- **Add server-side cursor support to `SQLConnector.read()`.**  
  If `chunk_hook` is provided, keep an open cursor and stream the chunks one-at-a-time. This allows for processing very large out-of-memory data sets.

  To return the results of the `chunk_hook` callable rather than a dataframe, pass `as_hook_result=True` to receive a list of values.

  If `as_iterator` is provided or `chunksize` is `None`, then `SQLConnector.read()` reverts to the default client-side cursor implementation (which loads the entire result set into memory).


  ```python
  import meerschaum as mrsm
  conn = mrsm.get_connector()

  def process_chunk(df: 'pd.DataFrame', **kw) -> int:
      return len(df)
  
  results = conn.read(
      "very_large_table",
      chunk_hook = process_chunk,
      as_hook_results = True,
      chunksize = 100,
  )

  results[:2]
  # [100, 100]
  ```

- **Remove `--sync-chunks` and set its behavior as default.**  
  Due to the above changes to `SQLConnector.read()`, `sync_chunks` now defaults to `True` in `Pipe.sync()`. You may disable this behavior with `--chunksize 0`.