### PR TITLE
🐛 v1.6.11 Fix a bug with in-place syncing a backtrack interval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v.1.6.11
+
+- **Fix an issue with in-place syncing.**  
+  When syncing a SQL pipe in-place with a backtrack interval, the interval is applied to the existing data stage to avoid inserting duplicate rows.
+
 ### v1.6.9 — v1.6.10
 
 - **Improve thread safety checks.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v.1.6.11
+
+- **Fix an issue with in-place syncing.**  
+  When syncing a SQL pipe in-place with a backtrack interval, the interval is applied to the existing data stage to avoid inserting duplicate rows.
+
 ### v1.6.9 — v1.6.10
 
 - **Improve thread safety checks.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.10"
+__version__ = "1.6.11"

--- a/meerschaum/connectors/sql/SQLConnector.py
+++ b/meerschaum/connectors/sql/SQLConnector.py
@@ -27,7 +27,7 @@ class SQLConnector(Connector):
     from ._create_engine import flavor_configs, create_engine
     from ._sql import read, value, exec, execute, to_sql, exec_queries
     from meerschaum.utils.sql import test_connection
-    from ._fetch import fetch, get_pipe_metadef
+    from ._fetch import fetch, get_pipe_metadef, get_pipe_backtrack_minutes
     from ._cli import cli
     from ._pipes import (
         fetch_pipes_keys,

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -137,7 +137,7 @@ def get_pipe_metadef(
     from meerschaum.config import get_config
 
     definition = get_pipe_query(pipe)
-    btm = get_pipe_backtrack_minutes(pipe) 
+    btm = self.get_pipe_backtrack_minutes(pipe) 
 
     if not pipe.columns.get('datetime', None):
         _dt = pipe.guess_datetime()
@@ -270,6 +270,7 @@ def set_pipe_query(pipe: mrsm.Pipe, query: str) -> None:
     dict_to_set[key_to_set] = query
 
 
+@staticmethod
 def get_pipe_backtrack_minutes(pipe) -> Union[int, float]:
     """
     Return the first available value for the following parameter keys:

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1414,11 +1414,12 @@ def sync_pipe_inplace(
     drop_backtrack_query = f"DROP TABLE {backtrack_table_name}"
     if table_exists(backtrack_table_raw, self, debug=debug):
         backtrack_queries.append(drop_backtrack_query)
+    btm = max(self.get_pipe_backtrack_minutes(pipe), 1)
     backtrack_def = self.get_pipe_data_query(
         pipe,
         begin = begin,
         end = end,
-        begin_add_minutes = -1,
+        begin_add_minutes = (-1 * btm),
         end_add_minutes = 1,
         params = params,
         debug = debug,


### PR DESCRIPTION
# v.1.6.11

- **Fix an issue with in-place syncing.**  
  When syncing a SQL pipe in-place with a backtrack interval, the interval is applied to the existing data stage to avoid inserting duplicate rows.