### PR TITLE
📦️ v1.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.13
+
+- **Remove `\\u0000` from strings when inserting into PostgreSQL.**  
+  Replace both `\0` and `\\u0000` with empty strings when streaming rows into PostgreSQL.
+
 ### v1.6.12
 
 - **Allow nested chunk generators.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.13
+
+- **Remove `\\u0000` from strings when inserting into PostgreSQL.**  
+  Replace both `\0` and `\\u0000` with empty strings when streaming rows into PostgreSQL.
+
 ### v1.6.12
 
 - **Allow nested chunk generators.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.12"
+__version__ = "1.6.13rc1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.13rc1"
+__version__ = "1.6.13"

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -754,12 +754,12 @@ def psql_insert_copy(
         (
             (
                 (
-                    json.dumps(item).replace('\0', '')
+                    json.dumps(item).replace('\0', '').replace('\\u0000', '')
                     if isinstance(item, (dict, list))
                     else (
                         item
                         if not isinstance(item, str)
-                        else item.replace('\0', '')
+                        else item.replace('\0', '').replace('\\u0000', '')
                     )
                 )
             ) if item is not None


### PR DESCRIPTION
# v1.6.13

- **Remove `\\u0000` from strings when inserting into PostgreSQL.**  
  Replace both `\0` and `\\u0000` with empty strings when streaming rows into PostgreSQL.