### PR TITLE
🐛 v1.6.14 Fix `--no-auth` and tweak `mrsm stack`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.14
+
+- **Added healthchecks to `mrsm stack up`.**  
+  The internal Docker Compose file for `mrsm stack` was bumped to version 3.9, and secrets were replaced with environment variable references.
+
+- **Fixed `--no-auth` when starting the API.**  
+  The command `mrsm start api --no-auth` now correctly handles sessions.
+
 ### v1.6.13
 
 - **Remove `\\u0000` from strings when inserting into PostgreSQL.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,14 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.6.14
+
+- **Added healthchecks to `mrsm stack up`.**  
+  The internal Docker Compose file for `mrsm stack` was bumped to version 3.9, and secrets were replaced with environment variable references.
+
+- **Fixed `--no-auth` when starting the API.**  
+  The command `mrsm start api --no-auth` now correctly handles sessions.
+
 ### v1.6.13
 
 - **Remove `\\u0000` from strings when inserting into PostgreSQL.**  

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -47,6 +47,15 @@ def stack(
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.formatting import ANSI
     from meerschaum.utils.misc import is_docker_available
+    from meerschaum.config._read_config import search_and_substitute_config
+
+    stack_env_dict = {
+        var: val
+        for var, val in search_and_substitute_config(
+            meerschaum.config.stack.env_dict
+        ).items()
+        if isinstance(val, str)
+    }
 
     if action is None:
         action = []
@@ -139,7 +148,7 @@ def stack(
         cwd = STACK_COMPOSE_PATH.parent,
         stdout = stdout,
         stderr = stderr,
-        env = os.environ,
+        env = stack_env_dict,
     ) if (has_builtin_compose or has_binary_compose) else run_python_package(
         'compose',
         args = cmd_list,
@@ -147,6 +156,7 @@ def stack(
         venv = _compose_venv,
         capture_output = _capture_output,
         as_proc = True,
+        env = stack_env_dict,
     )
     try:
         rc = proc.wait() if proc is not None else 1

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.13"
+__version__ = "1.6.14"


### PR DESCRIPTION
# v1.6.14

- **Added healthchecks to `mrsm stack up`.**  
  The internal Docker Compose file for `mrsm stack` was bumped to version 3.9, and secrets were replaced with environment variable references.

- **Fixed `--no-auth` when starting the API.**  
  The command `mrsm start api --no-auth` now correctly handles sessions.