### PR TITLE
✨ v1.6.15 Add `as_iterator` to the `copy pipes` action.

### DIFF
--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -117,7 +117,15 @@ def _copy_pipes(
                     noask=noask, yes=yes
                 )
         ):
-            _new_pipe.sync(p.get_data(debug=debug, **kw), debug=debug, **kw)
+            _new_pipe.sync(
+                p.get_data(
+                    debug = debug,
+                    as_iterator = True,
+                    **kw
+                ),
+                debug = debug,
+                **kw
+            )
 
     msg = (
         "No pipes were copied." if successes == 0

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.6.14"
+__version__ = "1.6.15"


### PR DESCRIPTION
- **Sync chunks in the `copy pipes` action.**  
  This will help with large out-of-memory pipes.