### PR TITLE
🐋 Update `Dockerfile` and portable builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye AS runtime
+FROM python:3.11-slim-bookworm AS runtime
 
 ARG dep_group=full \
     mrsm_user=meerschaum \
@@ -41,4 +41,4 @@ RUN cd $MRSM_WORK_DIR && [ "$MRSM_DEP_GROUP" != "minimal" ] && \
   mrsm --version
 
 COPY --chown=$MRSM_USER:$MRSM_USER scripts/docker/entrypoint.sh /mrsm-entrypoint.sh
-ENTRYPOINT ["/mrsm-entrypoint.sh"]
+ENTRYPOINT ["python", "-m", "meerschaum"]

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -11,7 +11,7 @@ export tags=( "api" "minimal" "full" )
 
 export base_name="meerschaum"
 export image="$dockerhub_user/$base_name"
-export python_image="python:3.9-slim-bullseye"
+export python_image="python:3.11-slim-bookworm"
 export platforms="linux/amd64"
 # export platforms="linux/amd64,linux/arm64"
 # export platforms="linux/amd64,linux/arm64,linux/arm/v7"
@@ -20,7 +20,4 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 export src="$PARENT"
 export port="8000"
 export publish_branch="main"
-export remote_docs_user="meerschaum"
-export remote_docs_host="docs.meerschaum.io"
-export remote_docs_dir="~/docs"
 

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,2 +1,0 @@
-#! /bin/bash
-mrsm $@

--- a/scripts/portable/LINUX/mrsm
+++ b/scripts/portable/LINUX/mrsm
@@ -5,6 +5,6 @@ cd "$DIR"
 TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo \
 MRSM_ROOT_DIR="$DIR"/root \
 MRSM_RUNTIME=portable \
-./python/bin/python3.9 -m meerschaum $@
+./python/bin/python3.11 -m meerschaum $@
 
 

--- a/scripts/portable/LINUX/scripts/install.sh
+++ b/scripts/portable/LINUX/scripts/install.sh
@@ -8,13 +8,13 @@ cd "$ROOT"
 if [ ! -d "./scripts/_site-packages_original" ]; then
   echo "Backing up site-packages..."
   TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo \
-  ./python/bin/python3.9 -m pip install wheel --no-warn-script-location -q
-  cp -r ./python/lib/python3.9/site-packages ./scripts/_site-packages_original
+  ./python/bin/python3.11 -m pip install wheel --no-warn-script-location -q
+  cp -r ./python/lib/python3.11/site-packages ./scripts/_site-packages_original
 fi
 
 echo "Installing Meerschaum and dependencies (this might take awhile)..."
 MRSM_ROOT_DIR="$ROOT"/root/ \
 TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo \
-./python/bin/python3.9 -m pip install "$DIR"/install[full] --no-warn-script-location -q
+./python/bin/python3.11 -m pip install "$DIR"/install[full] --no-warn-script-location -q
 
 echo Finished installing.

--- a/scripts/portable/LINUX/scripts/uninstall.sh
+++ b/scripts/portable/LINUX/scripts/uninstall.sh
@@ -11,8 +11,8 @@ else
   cd ./scripts
   mv _site-packages_original site-packages
   cd "$ROOT"
-  rm -rf ./python/lib/python3.9/site-packages
-  mv ./scripts/site-packages ./python/python3.9/
+  rm -rf ./python/lib/python3.11/site-packages
+  mv ./scripts/site-packages ./python/python3.11/
 fi
 
 cd "$ROOT"

--- a/scripts/portable/MACOS/mrsm
+++ b/scripts/portable/MACOS/mrsm
@@ -5,6 +5,6 @@ cd "$DIR"
 TERMINFO_DIRS=/usr/share/terminfo \
 MRSM_ROOT_DIR="$DIR"/root \
 MRSM_RUNTIME=portable \
-./python/bin/python3.9 -m meerschaum $@
+./python/bin/python3.11 -m meerschaum $@
 
 

--- a/scripts/portable/MACOS/scripts/install.sh
+++ b/scripts/portable/MACOS/scripts/install.sh
@@ -8,13 +8,13 @@ cd "$ROOT"
 if [ ! -d "./scripts/_site-packages_original" ]; then
   echo "Backing up site-packages..."
   TERMINFO_DIRS=/usr/share/terminfo \
-  ./python/bin/python3.9 -m pip install wheel --no-warn-script-location -q
-  cp -r ./python/lib/python3.9/site-packages ./scripts/_site-packages_original
+  ./python/bin/python3.11 -m pip install wheel --no-warn-script-location -q
+  cp -r ./python/lib/python3.11/site-packages ./scripts/_site-packages_original
 fi
 
 echo "Installing Meerschaum and dependencies (this might take awhile)..."
 MRSM_ROOT_DIR="$ROOT"/root/ \
 TERMINFO_DIRS=/usr/share/terminfo \
-./python/bin/python3.9 -m pip install "$DIR"/install[full] --no-warn-script-location -q
+./python/bin/python3.11 -m pip install "$DIR"/install[full] --no-warn-script-location -q
 
 echo Finished installing.

--- a/scripts/portable/MACOS/scripts/uninstall.sh
+++ b/scripts/portable/MACOS/scripts/uninstall.sh
@@ -11,8 +11,8 @@ else
   cd ./scripts
   mv _site-packages_original site-packages
   cd "$ROOT"
-  rm -rf ./python/lib/python3.9/site-packages
-  mv ./scripts/site-packages ./python/python3.9/
+  rm -rf ./python/lib/python3.11/site-packages
+  mv ./scripts/site-packages ./python/python3.11/
 fi
 
 cd "$ROOT"

--- a/scripts/portable/build.sh
+++ b/scripts/portable/build.sh
@@ -23,12 +23,9 @@ else
 fi
 
 declare -A urls
-# urls["WINDOWS"]="https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst"
-urls["WINDOWS"]="https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15+20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst"
-# urls["LINUX"]="https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-pgo-20211017T1616.tar.zst"
-urls["LINUX"]="https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15+20221106-x86_64-unknown-linux-gnu-pgo+lto-full.tar.zst"
-# urls["MACOS"]="https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo+lto-20211017T1616.tar.zst"
-urls["MACOS"]="https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15+20221106-x86_64-apple-darwin-pgo+lto-full.tar.zst"
+urls["WINDOWS"]="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3+20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst"
+urls["LINUX"]="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3+20230507-x86_64-unknown-linux-gnu-pgo+lto-full.tar.zst"
+urls["MACOS"]="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3+20230507-x86_64-apple-darwin-pgo+lto-full.tar.zst"
 urls["get-pip.py"]="https://bootstrap.pypa.io/get-pip.py"
 
 declare -A tars
@@ -43,8 +40,8 @@ taropts["MACOS"]="-I zstd -xf "
 
 declare -A sites
 sites["WINDOWS"]="Lib/site-packages"
-sites["LINUX"]="lib/python3.9/site-packages"
-sites["MACOS"]="lib/python3.9/site-packages"
+sites["LINUX"]="lib/python3.11/site-packages"
+sites["MACOS"]="lib/python3.11/site-packages"
 
 ### Check if zstd is installed.
 v=$(zstd -V)

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -22,7 +22,3 @@ fi
 ### Publish to Python Package Index.
 cd "$PARENT"
 python -m twine upload dist/*
-
-### Update documentation.
-cd "$PARENT/docs"
-ssh "$remote_docs_user"@"$remote_docs_host" "cd $remote_docs_dir/Meerschaum; git pull origin $publish_branch; scripts/docs.sh"


### PR DESCRIPTION
Update the Docker base to Python 3.11 on Debian Bookworm and bump the portable builds to Python 3.11 as well.