### PR TITLE
⚡️ v1.7.2 Add minor improvements to the local stack.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.7.2
+
+- **Fix `role "root" does not exist` from stack logs.**  
+  Although the healthcheck was working as expected, the log output was filled with `Error FATAL: role "root" does not exist`. These errors have been fixed.
+
+- **Fix `MRSM_CONFIG` behavior when running `start api --production`.**  
+  Starting the Web API through `gunicorn` (i.e. `--production`) now respects `MRSM_CONFIG`. This is useful for running `stack up` with non-default credentials.
+
+- **Added `--insecure` as an alias for `--no-auth`.**  
+  To compliment the newly added `--secure` flag, starting the Web API with `--insecure` will bypass authentication.
+
+- **Bump default TimescaleDB version to PG15.**  
+  The default TimescaleDB version for the Meerschaum stack is now `latest-pg15-oss`.
+
+- **Pass sysargs to `docker compose` via `stack`**  
+  This patch allows for jumping into the `api` container:
+
+  ```bash
+  mrsm stack exec api bash
+  ```
+
+- **Added the API endpoint `/healthcheck`.**  
+  This is used to determine reachability and the health of the local stack.
+
 ### v1.7.0 – v1.7.1 
 
 - **Remove `get_backtrack_data()` for instance connectors.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,30 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.7.2
+
+- **Fix `role "root" does not exist` from stack logs.**  
+  Although the healthcheck was working as expected, the log output was filled with `Error FATAL: role "root" does not exist`. These errors have been fixed.
+
+- **Fix `MRSM_CONFIG` behavior when running `start api --production`.**  
+  Starting the Web API through `gunicorn` (i.e. `--production`) now respects `MRSM_CONFIG`. This is useful for running `stack up` with non-default credentials.
+
+- **Added `--insecure` as an alias for `--no-auth`.**  
+  To compliment the newly added `--secure` flag, starting the Web API with `--insecure` will bypass authentication.
+
+- **Bump default TimescaleDB version to PG15.**  
+  The default TimescaleDB version for the Meerschaum stack is now `latest-pg15-oss`.
+
+- **Pass sysargs to `docker compose` via `stack`**  
+  This patch allows for jumping into the `api` container:
+
+  ```bash
+  mrsm stack exec api bash
+  ```
+
+- **Added the API endpoint `/healthcheck`.**  
+  This is used to determine reachability and the health of the local stack.
+
 ### v1.7.0 – v1.7.1 
 
 - **Remove `get_backtrack_data()` for instance connectors.**  

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -270,7 +270,7 @@ groups['api'].add_argument(
     help = "Start the API in secure mode, only allowing `admin` users to execute actions.",
 )
 groups['api'].add_argument(
-    '--no-auth', '--noauth', action='store_true',
+    '--no-auth', '--noauth', '--insecure', action='store_true',
     help = 'When starting the API, do not require authentication. WARNING: This is dangerous!',
 )
 groups['api'].add_argument(

--- a/meerschaum/actions/api.py
+++ b/meerschaum/actions/api.py
@@ -157,7 +157,6 @@ def _api_start(
     from meerschaum.connectors.parse import parse_instance_keys
     from meerschaum.utils.pool import get_pool
     import shutil
-    import os
     from copy import deepcopy
 
     if action is None:
@@ -276,6 +275,7 @@ def _api_start(
     env_dict = {
         MRSM_SERVER_ID: SERVER_ID,
         MRSM_RUNTIME: 'api',
+        MRSM_CONFIG: json.loads(os.environ.get(MRSM_CONFIG, '{}')),
     }
     for env_var in get_env_vars():
         if env_var in env_dict:
@@ -319,7 +319,8 @@ def _api_start(
         ]
         for key, val in env_dict.items():
             gunicorn_args += [
-                '--env', key + '=' + (json.dumps(val) if isinstance(val, dict) else val)
+                '--env', key + "="
+                + (json.dumps(val) if isinstance(val, (dict, list)) else val)
             ]
         if workers is not None:
             gunicorn_args += ['--workers', str(workers)]

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -125,14 +125,8 @@ def stack(
                 warn(f"Unable to install `pyyaml` into venv '{_compose_venv}'.")
 
     cmd_list = [
-        _arg for _arg in (
-            settings_list
-            + compose_command
-            + (
-                sysargs[2:] if len(sysargs) > 2 and not sub_args
-                else sub_args
-            )
-        )
+        _arg
+        for _arg in (settings_list + sysargs[1:])
         if _arg != '--debug'
     ]
     if debug:

--- a/meerschaum/api/routes/_misc.py
+++ b/meerschaum/api/routes/_misc.py
@@ -16,10 +16,14 @@ from meerschaum.api import (
     private, no_auth, manager
 )
 import fastapi
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, JSONResponse
+from meerschaum.connectors.poll import _wrap_retry_connect
 
 @app.get(endpoints['favicon'], tags=['Misc'])
 def get_favicon() -> Any:
+    """
+    Return the favicon file.
+    """
     from meerschaum.config._paths import API_STATIC_PATH
     return FileResponse(os.path.join(API_STATIC_PATH, 'ico', 'logo.ico'))
 
@@ -30,6 +34,9 @@ def get_chaining_status(
             fastapi.Depends(manager) if private else None
         ),
     ) -> bool:
+    """
+    Return whether this API instance may be chained.
+    """
     return check_allow_chaining()
 
 
@@ -39,6 +46,9 @@ def get_instance_info(
             fastapi.Depends(manager) if private else None
         ),
     ) -> Dict[str, Union[str, int]]:
+    """
+    Return information about this API instance.
+    """
     from meerschaum import __version__ as version
     num_plugins = len(get_api_connector().get_plugins(debug=debug))
     num_users = len(get_api_connector().get_users(debug=debug))
@@ -49,6 +59,22 @@ def get_instance_info(
         'num_users': num_users,
         'num_pipes': num_pipes,
     }
+
+
+@app.get(endpoints['healthcheck'], tags=['Misc'])
+def get_healtheck() -> Dict[str, Any]:
+    """
+    Return a success message to confirm this API is reachable.
+    """
+    conn = get_api_connector()
+    success = _wrap_retry_connect(
+        conn.meta,
+        max_retries = 1, 
+    )
+    message = "Success" if success else "Failed to connect to instance connector."
+    status_code = 200 if success else 503
+    return JSONResponse({"success": success, "message": message}, status_code=status_code)
+
 
 if debug:
     @app.get('/id', tags=['Misc'])

--- a/meerschaum/config/_sync.py
+++ b/meerschaum/config/_sync.py
@@ -41,24 +41,6 @@ def sync_yaml_configs(
         If provided, iterate through a list of tuples,
         replacing the old string (index 0) with the new string (index 1).
         Defaults to `None`.
-    config_path: pathlib.Path :
-        
-    keys: List[str] :
-        
-    sub_path: pathlib.Path :
-        
-    substitute: bool :
-         (Default value = True)
-    permissions: Optional[int] :
-         (Default value = None)
-    replace_tuples: Optional[List[Tuple[str :
-        
-    str]]] :
-         (Default value = None)
-
-    Returns
-    -------
-
     """
     import os, sys
     try:
@@ -73,17 +55,7 @@ def sync_yaml_configs(
         return
 
     def _read_config(path):
-        """Read YAML file with header comment
-
-        Parameters
-        ----------
-        path :
-            
-
-        Returns
-        -------
-
-        """
+        """Read YAML file with header comment."""
         header_comment = ""
         with open(path, 'r') as f:
             if _yaml is not None:
@@ -106,22 +78,21 @@ def sync_yaml_configs(
     if substitute:
         sub_config = search_and_substitute_config(sub_config)
 
-    if c != sub_config:
-        config_time = os.path.getmtime(config_path)
-        sub_time = os.path.getmtime(sub_path)
+    config_time = os.path.getmtime(config_path)
+    sub_time = os.path.getmtime(sub_path)
 
-        sub_config = c
-        new_config_text = yaml.dump(c, sort_keys=False)
-        if replace_tuples:
-            for replace_tuple in replace_tuples:
-                new_config_text = new_config_text.replace(replace_tuple[0], replace_tuple[1])
-        new_header = sub_header
-        new_path = sub_path
+    sub_config = c
+    new_config_text = yaml.dump(c, sort_keys=False)
+    if replace_tuples:
+        for replace_tuple in replace_tuples:
+            new_config_text = new_config_text.replace(replace_tuple[0], replace_tuple[1])
+    new_header = sub_header
+    new_path = sub_path
 
-        ### write changes
-        with open(new_path, 'w+') as f:
-            f.write(new_header)
-            f.write(new_config_text)
+    ### write changes
+    with open(new_path, 'w+') as f:
+        f.write(new_header)
+        f.write(new_config_text)
     if permissions is not None:
         os.chmod(new_path, permissions)
 
@@ -140,7 +111,7 @@ def sync_files(keys: Optional[List[str]] = None):
             ['stack', STACK_COMPOSE_FILENAME],
             STACK_COMPOSE_PATH,
             substitute = True,
-            replace_tuples = [('$', '$$')],
+            replace_tuples = [('$', '$$'), ('<DOLLAR>', '$')],
         )
         sync_yaml_configs(
             CONFIG_DIR_PATH / 'stack.yaml',

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/meerschaum/config/stack/__init__.py
+++ b/meerschaum/config/stack/__init__.py
@@ -101,15 +101,15 @@ default_docker_compose_config = {
         'db': {
             'environment': {
                 'TIMESCALEDB_TELEMETRY': 'off',
-                'POSTGRES_USER': '$POSTGRES_USER',
-                'POSTGRES_DB': '$POSTGRES_DB',
-                'POSTGRES_PASSWORD': '$POSTGRES_PASSWORD',
+                'POSTGRES_USER': '<DOLLAR>POSTGRES_USER',
+                'POSTGRES_DB': '<DOLLAR>POSTGRES_DB',
+                'POSTGRES_PASSWORD': '<DOLLAR>POSTGRES_PASSWORD',
                 'ALLOW_IP_RANGE': env_dict['ALLOW_IP_RANGE'],
             },
             'command': 'postgres -c max_connections=1000 -c shared_buffers=1024MB',
             'healthcheck': {
                 'test': [
-                    'CMD-SHELL', 'pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}',
+                    'CMD-SHELL', 'pg_isready -d <DOLLAR>POSTGRES_DB -U <DOLLAR>POSTGRES_USER',
                 ],
                 'interval': '5s',
                 'timeout': '3s',

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -32,6 +32,7 @@ STATIC_CONFIG = {
             'webterm': '/webterm',
             'webterm_websocket': '/websocket',
             'info': '/info',
+            'healthcheck': '/healthcheck',
         },
         'oauth': {
             'token_expires_minutes': 720,

--- a/scripts/docker/image_setup.sh
+++ b/scripts/docker/image_setup.sh
@@ -10,7 +10,7 @@ groupadd -r $MRSM_USER \
   && chown -R $MRSM_USER:$MRSM_USER $MRSM_WORK_DIR
 
 ### We need sudo to switch from root to the user.
-apt-get update && apt-get install sudo -y --no-install-recommends
+apt-get update && apt-get install sudo curl less -y --no-install-recommends
 
 ### Install user-level build tools.
 sudo -u $MRSM_USER python -m pip install --user --upgrade wheel pip setuptools
@@ -53,3 +53,65 @@ apt-get clean && \
 if [ "$MRSM_DEP_GROUP" != "minimal" ]; then
   apt-get purge -y $(apt-get -s purge python3-dev | grep '^ ' | tr -d '*')
 fi
+
+sudo -u $MRSM_USER echo '
+HISTCONTROL=ignoreboth
+shopt -s histappend
+HISTSIZE=1000
+HISTFILESIZE=2000
+shopt -s checkwinsize
+
+export LS_COLORS="rs=0:di=1;35:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lz=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.axv=01;35:*.anx=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.axa=00;36:*.oga=00;36:*.spx=00;36:*.xspf=00;36:";
+alias ll="ls -alF --color=auto"
+alias la="ls -A --color=auto"
+alias l="ls -CF --color=auto"
+
+function cd {
+	builtin cd "$@" && ls
+}
+
+c(){
+	clear;
+	width_line
+}
+
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi
+
+
+RESET="\e[0m"
+export PS1="\n \[$(tput bold)\]\u\[$(tput sgr0)\]\[$(tput sgr0)\]\[\033[38;5;7m\]@\[$(tput sgr0)\]\[\033[38;5;183m\]\[$(tput bold)\]\H\[$(tput sgr0)\]\[$(tput sgr0)\]\[\033[38;5;15m\]\n \[$(tput sgr0)\]\[\033[38;5;2m\][\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;6m\]\W\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;2m\]]\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;10m\]\\$\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]"
+DULL_CYAN_BG="\033[46m"
+BLOCK="$DULL_CYAN_BG $RESET"
+width_line(){
+	w=""
+	for i in `seq 1 $COLUMNS`; do
+		w="$w$BLOCK"
+	done
+	echo -e $w
+}
+function PreCommand() {
+  if [ -z "$AT_PROMPT" ]; then
+    return
+  fi
+  unset AT_PROMPT
+  c
+}
+trap "PreCommand" DEBUG
+
+FIRST_PROMPT=1
+function PostCommand() {
+  AT_PROMPT=1
+
+  if [ -n "$FIRST_PROMPT" ]; then
+    unset FIRST_PROMPT
+    return
+  fi
+}
+PROMPT_COMMAND="PostCommand"
+' > /home/$MRSM_USER/.bashrc

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup_kw_args = {
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Database",
         "Natural Language :: English",
     ],


### PR DESCRIPTION
# v1.7.2

- **Fix `role "root" does not exist` from stack logs.**  
  Although the healthcheck was working as expected, the log output was filled with `Error FATAL: role "root" does not exist`. These errors have been fixed.

- **Fix `MRSM_CONFIG` behavior when running `start api --production`.**  
  Starting the Web API through `gunicorn` (i.e. `--production`) now respects `MRSM_CONFIG`. This is useful for running `stack up` with non-default credentials.

- **Added `--insecure` as an alias for `--no-auth`.**  
  To compliment the newly added `--secure` flag, starting the Web API with `--insecure` will bypass authentication.

- **Bump default TimescaleDB version to PG15.**  
  The default TimescaleDB version for the Meerschaum stack is now `latest-pg15-oss`.

- **Pass sysargs to `docker compose` via `stack`**  
  This patch allows for jumping into the `api` container:

  ```bash
  mrsm stack exec api bash
  ```

- **Added the API endpoint `/healthcheck`.**  
  This is used to determine reachability and the health of the local stack.