### PR TITLE
🐛 v1.7.3 Bugfixes for the local stack, MacOS, and emails as usernames.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.7.3
+
+- **Fix an issue with the local stack healthcheck.**  
+  Due to some edge cases, the local stack `docker-compose.yaml` file would not be correctly formatted until `edit config` had been executed. This patch ensures the files are synced with each invocation of `stack`.
+
 ### v1.7.2
 
 - **Fix `role "root" does not exist` from stack logs.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v1.7.3
+
+- **Fix an issue with the local stack healthcheck.**  
+  Due to some edge cases, the local stack `docker-compose.yaml` file would not be correctly formatted until `edit config` had been executed. This patch ensures the files are synced with each invocation of `stack`.
+
 ### v1.7.2
 
 - **Fix `role "root" does not exist` from stack logs.**  

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -43,6 +43,7 @@ def stack(
         attempt_import, run_python_package, venv_contains_package,
         pip_install,
     )
+    from meerschaum.config._sync import sync_files
     from meerschaum.config import get_config
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn
@@ -73,9 +74,10 @@ def stack(
         if not path.exists():
             bootstrap = True
             break
-    ### if bootstrap flag was set, create files
     if bootstrap:
         write_stack(debug=debug)
+    else: 
+        sync_files(['stack'])
 
     compose_command = ['up']
     ### default: alias stack as docker-compose

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from meerschaum.utils.venv import Venv
 from meerschaum.utils.packages import attempt_import, import_dcc, import_html
 from meerschaum.utils.typing import SuccessTuple, List
-from meerschaum.config.static import _static_config
+from meerschaum.config.static import STATIC_CONFIG
 from meerschaum.utils.misc import remove_ansi
 from meerschaum.actions import get_shell
 from meerschaum.api import endpoints, CHECK_UPDATE
@@ -154,7 +154,7 @@ def alert_from_success_tuple(success: SuccessTuple) -> dbc.Alert:
             id = 'success-alert',
             dismissable = True,
             fade = True,
-            is_open = not (success[1] in _static_config()['system']['success']['ignore']),
+            is_open = not (success[1] in STATIC_CONFIG['system']['success']['ignore']),
             color = 'success' if success[0] else 'danger',
         )
     )

--- a/meerschaum/config/__init__.py
+++ b/meerschaum/config/__init__.py
@@ -45,12 +45,13 @@ def _config(
     if config is None or reload:
         with _locks['config']:
             config = {}
+
     if keys and keys[0] not in config:
         from meerschaum.config._sync import sync_files as _sync_files
         key_config = read_config(
-            keys=[keys[0]],
-            substitute=substitute,
-            write_missing=write_missing,
+            keys = [keys[0]],
+            substitute = substitute,
+            write_missing = write_missing,
         )
         if keys[0] in key_config:
             config[keys[0]] = key_config[keys[0]]
@@ -232,7 +233,6 @@ def get_config(
                 )
             )
             if patch and keys[0] != symlinks_key:
-                #  print("Updating configuration, please wait...")
                 if write_missing:
                     write_config(config, debug=debug)
 

--- a/meerschaum/config/_edit.py
+++ b/meerschaum/config/_edit.py
@@ -71,7 +71,7 @@ def write_config(
     if directory is None:
         from meerschaum.config._paths import CONFIG_DIR_PATH
         directory = CONFIG_DIR_PATH
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.config._default import default_header_comment
     from meerschaum.config._patch import apply_patch_to_config
     from meerschaum.config._read_config import get_keyfile_path
@@ -84,14 +84,14 @@ def write_config(
         cf = _config()
         config_dict = cf
 
-    default_filetype = _static_config()['config']['default_filetype']
+    default_filetype = STATIC_CONFIG['config']['default_filetype']
     filetype_dumpers = {
         'yml' : yaml.dump,
         'yaml' : yaml.dump,
         'json' : json.dump,
     }
 
-    symlinks_key = _static_config()['config']['symlinks_key']
+    symlinks_key = STATIC_CONFIG['config']['symlinks_key']
     symlinks = config_dict.pop(symlinks_key) if symlinks_key in config_dict else {}
     config_dict = apply_patch_to_config(config_dict, symlinks)
 
@@ -148,27 +148,17 @@ def write_config(
     return True
 
 def general_write_yaml_config(
-        files : Optional[Dict[str, pathlib.Path]] = None,
-        debug : bool = False
+        files: Optional[Dict[pathlib.Path, Dict[str, Any]]] = None,
+        debug: bool = False
     ):
-    """Write configuration dictionaries to file paths with optional headers.
-    
-    files : dict
-        Dictionary of paths -> dict or tuple of format (dict, header).
-        If item is a tuple, the header will be written at the top of the file.
+    """
+    Write configuration dictionaries to file paths with optional headers.
 
     Parameters
     ----------
-    files : Optional[Dict[str :
-        
-    pathlib.Path]] :
-         (Default value = None)
-    debug : bool :
-         (Default value = False)
-
-    Returns
-    -------
-
+    files: Optional[Dict[str, pathlib.Path]], default None
+        Dictionary of paths -> dict or tuple of format (dict, header).
+        If item is a tuple, the header will be written at the top of the file.
     """
 
     from meerschaum.utils.debug import dprint

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -46,7 +46,7 @@ def read_config(
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.yaml import yaml, _yaml
     from meerschaum.config._paths import CONFIG_DIR_PATH
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.config._patch import apply_patch_to_config
     if directory is None:
         directory = CONFIG_DIR_PATH
@@ -57,11 +57,11 @@ def read_config(
         return default_config
 
     ### Each key corresponds to a YAML or JSON file.
-    symlinks_key = _static_config()['config']['symlinks_key']
+    symlinks_key = STATIC_CONFIG['config']['symlinks_key']
     config = {}
     config_to_write = {}
 
-    default_filetype = _static_config()['config']['default_filetype']
+    default_filetype = STATIC_CONFIG['config']['default_filetype']
     filetype_loaders = {
         'yml' : yaml.load,
         'yaml' : yaml.load,
@@ -187,7 +187,6 @@ def read_config(
                 print(f"Unable to parse {filename}!")
                 import traceback
                 traceback.print_exc()
-                #  print(e)
                 input(f"Press [Enter] to open '{filename}' and fix formatting errors.")
                 from meerschaum.utils.misc import edit_file
                 edit_file(filepath)
@@ -363,8 +362,8 @@ def search_and_substitute_config(
             s[_keys[-1]] = _pattern
 
         from meerschaum.config._patch import apply_patch_to_config
-        from meerschaum.config.static import _static_config
-        symlinks_key = _static_config()['config']['symlinks_key']
+        from meerschaum.config.static import STATIC_CONFIG
+        symlinks_key = STATIC_CONFIG['config']['symlinks_key']
         if symlinks_key not in parsed_config:
             parsed_config[symlinks_key] = {}
         parsed_config[symlinks_key] = apply_patch_to_config(parsed_config[symlinks_key], symlinks)
@@ -403,16 +402,16 @@ def get_keyfile_path(
             os.path.join(
                 directory,
                 read_config(
-                    keys=[key],
-                    with_filenames=True,
-                    write_missing=False,
-                    substitute=False,
+                    keys = [key],
+                    with_filenames = True,
+                    write_missing = False,
+                    substitute = False,
                 )[1][0]
             )
         )
     except IndexError as e:
         if create_new:
-            from meerschaum.config.static import _static_config
-            default_filetype = _static_config()['config']['default_filetype']
+            from meerschaum.config.static import STATIC_CONFIG
+            default_filetype = STATIC_CONFIG['config']['default_filetype']
             return pathlib.Path(os.path.join(directory, key + '.' + default_filetype))
         return None

--- a/meerschaum/config/_sync.py
+++ b/meerschaum/config/_sync.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from meerschaum.utils.typing import Optional, List, Tuple
 
 def sync_yaml_configs(
-        config_path: pathlib.Path,
         keys: List[str],
         sub_path: pathlib.Path,
         substitute: bool = True,
@@ -19,28 +18,24 @@ def sync_yaml_configs(
     ) -> None:
     """Synchronize sub-configuration with main configuration file.
     
-    NOTE: This function might need refactoring to work better with the new
-    `read_config` system.
-
     Parameters
     ----------
-    config_path :
-        Not sure if this is necessary.
-    keys :
+    keys: List[str]
         The config keys to read via `get_config()`.
-    sub_path :
+
+    sub_path: pathlib.Path
         The derivative file to write.
-    substitute :
+
+    substitute: bool, default True
         If `True`, parse `MRSM{}` syntax and substitute values.
         See `get_config()` for more information.
-        Defaults to `True`.
-    permissions :
+
+    permissions: Optional[int], default None
         If not `None`, set permissions of the derivative file.
-        Defaults to `None`.
-    replace_tuples :
+
+    replace_tuples: Optional[List[Tuple[str]]], default None
         If provided, iterate through a list of tuples,
         replacing the old string (index 0) with the new string (index 1).
-        Defaults to `None`.
     """
     import os, sys
     try:
@@ -50,12 +45,12 @@ def sync_yaml_configs(
     from meerschaum.config._patch import apply_patch_to_config
     import meerschaum.config
     from meerschaum.utils.packages import reload_package
-    from meerschaum.config._read_config import search_and_substitute_config
-    if not os.path.isfile(config_path) or not os.path.isfile(sub_path):
-        return
+    from meerschaum.config._read_config import search_and_substitute_config, get_keyfile_path
 
-    def _read_config(path):
+    def _read_yaml_config(path):
         """Read YAML file with header comment."""
+        if not path.exists():
+            return "", {}
         header_comment = ""
         with open(path, 'r') as f:
             if _yaml is not None:
@@ -70,16 +65,15 @@ def sync_yaml_configs(
                 header_comment += line
         return header_comment, config
 
-    config_header, config = _read_config(config_path)
-    sub_header, sub_config = _read_config(sub_path)
-
     from meerschaum.config import get_config
+    config_path = get_keyfile_path(keys[0], create_new=True)
     c = get_config(*keys, substitute=substitute, sync_files=False)
+
+    config_header, config = _read_yaml_config(config_path)
+    sub_header, sub_config = _read_yaml_config(sub_path)
+
     if substitute:
         sub_config = search_and_substitute_config(sub_config)
-
-    config_time = os.path.getmtime(config_path)
-    sub_time = os.path.getmtime(sub_path)
 
     sub_config = c
     new_config_text = yaml.dump(c, sort_keys=False)
@@ -99,28 +93,32 @@ def sync_yaml_configs(
 def sync_files(keys: Optional[List[str]] = None):
     if keys is None:
         keys = []
+
     def _stack():
         import os
-        from meerschaum.config._paths import CONFIG_DIR_PATH, STACK_ENV_PATH, STACK_COMPOSE_PATH
-        from meerschaum.config._paths import STACK_COMPOSE_FILENAME, STACK_ENV_FILENAME
-        from meerschaum.config._paths import GRAFANA_DATASOURCE_PATH, GRAFANA_DASHBOARD_PATH
-        from meerschaum.config._paths import MOSQUITTO_CONFIG_PATH
+        from meerschaum.config._paths import (
+            CONFIG_DIR_PATH,
+            STACK_ENV_PATH,
+            STACK_COMPOSE_PATH,
+            STACK_COMPOSE_FILENAME,
+            STACK_ENV_FILENAME,
+            GRAFANA_DATASOURCE_PATH,
+            GRAFANA_DASHBOARD_PATH,
+        )
+        from meerschaum.config.static import STATIC_CONFIG
 
         sync_yaml_configs(
-            CONFIG_DIR_PATH / 'stack.yaml',
             ['stack', STACK_COMPOSE_FILENAME],
             STACK_COMPOSE_PATH,
             substitute = True,
             replace_tuples = [('$', '$$'), ('<DOLLAR>', '$')],
         )
         sync_yaml_configs(
-            CONFIG_DIR_PATH / 'stack.yaml',
             ['stack', 'grafana', 'datasource'],
             GRAFANA_DATASOURCE_PATH,
             substitute = True,
         )
         sync_yaml_configs(
-            CONFIG_DIR_PATH / 'stack.yaml',
             ['stack', 'grafana', 'dashboard'],
             GRAFANA_DASHBOARD_PATH,
             substitute = True,
@@ -128,7 +126,7 @@ def sync_files(keys: Optional[List[str]] = None):
 
 
     key_functions = {
-        'stack' : _stack,
+        'stack': _stack,
     }
     if keys is None:
         keys = list(key_functions.keys())

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -8,12 +8,13 @@ Insert non-user-editable configuration files here.
 
 import os
 import uuid
+from typing import Dict, Any
 from meerschaum.utils.misc import generate_password
 
 __all__ = ['STATIC_CONFIG']
 
-SERVER_ID = os.environ.get('MRSM_SERVER_ID', generate_password(6))
-STATIC_CONFIG = {
+SERVER_ID: str = os.environ.get('MRSM_SERVER_ID', generate_password(6))
+STATIC_CONFIG: Dict[str, Any] = {
     'api': {
         'endpoints': {
             'index': '/',
@@ -83,6 +84,9 @@ STATIC_CONFIG = {
     },
     'connectors': {
         'default_label': 'main',
+    },
+    'stack': {
+        'dollar_standin': '<DOLLAR>', ### Temporary replacement for docker-compose.yaml.
     },
     'users': {
         'password_hash': {

--- a/meerschaum/connectors/api/_actions.py
+++ b/meerschaum/connectors/api/_actions.py
@@ -50,7 +50,7 @@ def do_action(
     """
     import sys, json
     from meerschaum.utils.debug import dprint
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.misc import json_serialize_datetime
     if action is None:
         action = []
@@ -67,7 +67,7 @@ def do_action(
 
     root_action = json_dict['action'][0]
     del json_dict['action'][0]
-    r_url = f"{_static_config()['api']['endpoints']['actions']}/{root_action}"
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['actions']}/{root_action}"
     
     if debug:
         from meerschaum.utils.formatting import pprint

--- a/meerschaum/connectors/api/_login.py
+++ b/meerschaum/connectors/api/_login.py
@@ -18,7 +18,7 @@ def login(
     """Log in and set the session token."""
     from meerschaum.utils.warnings import warn as _warn, info, error
     from meerschaum.core import User
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     import json, datetime
     try:
         login_data = {
@@ -28,7 +28,7 @@ def login(
     except AttributeError:
         return False, f"Please login with the command `login {self}`."
     response = self.post(
-        _static_config()['api']['endpoints']['login'],
+        STATIC_CONFIG['api']['endpoints']['login'],
         data = login_data,
         use_token = False,
         debug = debug

--- a/meerschaum/connectors/api/_misc.py
+++ b/meerschaum/connectors/api/_misc.py
@@ -11,22 +11,12 @@ from meerschaum.utils.typing import Optional
 
 def get_mrsm_version(self, **kw) -> Optional[str]:
     """
-
-    Parameters
-    ----------
-    **kw :
-        
-
-    Returns
-    -------
-    type
-        
-
+    Return the Meerschaum version of the API instance.
     """
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     try:
         j = self.get(
-            _static_config()['api']['endpoints']['version'] + '/mrsm',
+            STATIC_CONFIG['api']['endpoints']['version'] + '/mrsm',
             use_token = True,
             **kw
         ).json()
@@ -38,22 +28,12 @@ def get_mrsm_version(self, **kw) -> Optional[str]:
 
 def get_chaining_status(self, **kw) -> Optional[bool]:
     """
-
-    Parameters
-    ----------
-    **kw :
-        
-
-    Returns
-    -------
-    type
-        
-
+    Fetch the chaining status of the API instance.
     """
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     try:
         response = self.get(
-            _static_config()['api']['endpoints']['chaining'],
+            STATIC_CONFIG['api']['endpoints']['chaining'],
             use_token = True,
             **kw
         )

--- a/meerschaum/connectors/api/_plugins.py
+++ b/meerschaum/connectors/api/_plugins.py
@@ -13,8 +13,8 @@ def plugin_r_url(
         plugin: Union[meerschaum.core.Plugin, str]
     ) -> str:
     """Generate a relative URL path from a Plugin."""
-    from meerschaum.config.static import _static_config
-    return f"{_static_config()['api']['endpoints']['plugins']}/{plugin}"
+    from meerschaum.config.static import STATIC_CONFIG
+    return f"{STATIC_CONFIG['api']['endpoints']['plugins']}/{plugin}"
 
 def register_plugin(
         self,
@@ -105,9 +105,9 @@ def get_plugins(
     """
     import json
     from meerschaum.utils.warnings import warn, error
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     response = self.get(
-        _static_config()['api']['endpoints']['plugins'],
+        STATIC_CONFIG['api']['endpoints']['plugins'],
         params = {'user_id' : user_id, 'search_term' : search_term},
         use_token = True,
         debug = debug
@@ -129,7 +129,6 @@ def get_plugin_attributes(
     """
     import json
     from meerschaum.utils.warnings import warn, error
-    from meerschaum.config.static import _static_config
     r_url = plugin_r_url(plugin) + '/attributes'
     response = self.get(r_url, use_token=True, debug=debug)
     attributes = response.json()

--- a/meerschaum/connectors/api/_users.py
+++ b/meerschaum/connectors/api/_users.py
@@ -17,10 +17,10 @@ def get_users(
     """
     Return a list of registered usernames.
     """
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     import json
     response = self.get(
-        f"{_static_config()['api']['endpoints']['users']}",
+        f"{STATIC_CONFIG['api']['endpoints']['users']}",
         debug = debug,
         use_token = True,
     )
@@ -69,8 +69,8 @@ def register_user(
     ) -> SuccessTuple:
     """Register a new user."""
     import json
-    from meerschaum.config.static import _static_config
-    r_url = f"{_static_config()['api']['endpoints']['users']}/register"
+    from meerschaum.config.static import STATIC_CONFIG
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['users']}/register"
     data = {
         'username': user.username,
         'password': user.password,
@@ -100,9 +100,9 @@ def get_user_id(
         **kw: Any
     ) -> Optional[int]:
     """Get a user's ID."""
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     import json
-    r_url = f"{_static_config()['api']['endpoints']['users']}/{user.username}/id"
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['users']}/{user.username}/id"
     response = self.get(r_url, debug=debug, **kw)
     try:
         user_id = int(json.loads(response.text))
@@ -117,9 +117,9 @@ def delete_user(
         **kw: Any
     ) -> SuccessTuple:
     """Delete a user."""
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     import json
-    r_url = f"{_static_config()['api']['endpoints']['users']}/{user.username}"
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['users']}/{user.username}"
     response = self.delete(r_url, debug=debug)
     try:
         _json = json.loads(response.text)
@@ -137,9 +137,9 @@ def get_user_attributes(
         **kw
     ) -> int:
     """Get a user's attributes."""
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     import json
-    r_url = f"{_static_config()['api']['endpoints']['users']}/{user.username}/attributes"
+    r_url = f"{STATIC_CONFIG['api']['endpoints']['users']}/{user.username}/attributes"
     response = self.get(r_url, debug=debug, **kw)
     try:
         attributes = json.loads(response.text)
@@ -158,8 +158,8 @@ def get_user_password_hash(
         **kw: Any
     ) -> Optional[str]:
     """If configured, get a user's password hash."""
-    from meerschaum.config.static import _static_config
-    r_url = _static_config()['api']['endpoints']['users'] + '/' + user.username + '/password_hash'
+    from meerschaum.config.static import STATIC_CONFIG
+    r_url = STATIC_CONFIG['api']['endpoints']['users'] + '/' + user.username + '/password_hash'
     response = self.get(r_url, debug=debug, **kw)
     if not response:
         return None
@@ -172,8 +172,8 @@ def get_user_type(
         **kw: Any
     ) -> Optional[str]:
     """If configured, get a user's type."""
-    from meerschaum.config.static import _static_config
-    r_url = _static_config()['api']['endpoints']['users'] + '/' + user.username + '/type'
+    from meerschaum.config.static import STATIC_CONFIG
+    r_url = STATIC_CONFIG['api']['endpoints']['users'] + '/' + user.username + '/type'
     response = self.get(r_url, debug=debug, **kw)
     if not response:
         return None

--- a/meerschaum/connectors/parse.py
+++ b/meerschaum/connectors/parse.py
@@ -53,14 +53,14 @@ def parse_connector_keys(
     import copy
     from meerschaum.connectors import get_connector
     from meerschaum.config import get_config
-    from meerschaum.config.static import _static_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.warnings import error
 
     ### `get_connector()` handles the logic for falling back to 'main',
     ### so don't make any decisions here.
     vals = str(keys).split(':')
     _type = vals[0]
-    _label = vals[1] if len(vals) > 1 else _static_config()['connectors']['default_label']
+    _label = vals[1] if len(vals) > 1 else STATIC_CONFIG['connectors']['default_label']
     _get_connector_kw = {'type': _type, 'label': _label}
     _get_connector_kw.update(kw)
 

--- a/meerschaum/connectors/sql/_users.py
+++ b/meerschaum/connectors/sql/_users.py
@@ -70,7 +70,7 @@ def valid_username(username: str) -> SuccessTuple:
     if len(username) > max_length:
         fail_reasons.append(f"Usernames must contain {max_length} or fewer characters.")
 
-    acceptable_chars = {'_', '-'}
+    acceptable_chars = {'_', '-', '.', '@'}
     for c in username:
         if not c.isalnum() and c not in acceptable_chars:
             fail_reasons.append(

--- a/meerschaum/core/User/_User.py
+++ b/meerschaum/core/User/_User.py
@@ -13,9 +13,9 @@ pwd_context = None
 def get_pwd_context():
     global pwd_context
     if pwd_context is None:
-        from meerschaum.config.static import _static_config
+        from meerschaum.config.static import STATIC_CONFIG
         from meerschaum.utils.packages import attempt_import
-        hash_config = _static_config()['users']['password_hash']
+        hash_config = STATIC_CONFIG['users']['password_hash']
         passlib_context = attempt_import('passlib.context')
         pwd_context = passlib_context.CryptContext(
             schemes = hash_config['schemes'],
@@ -24,7 +24,11 @@ def get_pwd_context():
         )
     return pwd_context
 
-class User():
+class User:
+    """
+    The Meerschaum User object manages authentication to a given instance.
+    """
+
     def __init__(
         self,
         username: str,

--- a/meerschaum/utils/venv/_Venv.py
+++ b/meerschaum/utils/venv/_Venv.py
@@ -93,6 +93,8 @@ class Venv:
         Return the top-level path for this virtual environment.
         """
         from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
+        if self._venv is None:
+            return self.target_path.parent
         return VIRTENV_RESOURCES_PATH / self._venv
 
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,11 +14,7 @@ $PYTHON_BIN -m meerschaum show packages docs --nopretty >> "$reqs_file"
 $PYTHON_BIN -m pip install --upgrade -r "$reqs_file" || exit 1
 ### Install pdoc3 and docker-compose outside of the declared docs dependencies.
 $PYTHON_BIN -m pip install pdoc3 || exit 1
-$PYTHON_BIN -m pip install docker-compose || exit 1
 rm -f "$reqs_file"
-
-### Install Meerschaum plugins.
-$PYTHON_BIN -m meerschaum install plugin thanks
 
 ### Enable docker buildx.
 
@@ -33,7 +29,7 @@ if [ "$MRSM_SKIP_DOCKER_EXPERIMENTAL" != "1" ]; then
       case "$yn" in
         Y ) echo "$daemon_json" | sudo tee /etc/docker/daemon.json && sudo systemctl restart docker
           break ;;
-        N ) echo "Please enable experimental mode." && exit 1 ;;
+        N ) echo "Skipping experimental features." && exit 0 ;;
       esac
     done
   fi


### PR DESCRIPTION
# v1.7.3

- **Fix an issue with the local stack healthcheck.**  
  Due to some edge cases, the local stack `docker-compose.yaml` file would not be correctly formatted until `edit config` had been executed. This patch ensures the files are synced with each invocation of `stack`.

- **Allow for email usernames.**  
  For users who would like their usernames to match their emails, the acceptable usernames allow all alphanumeric characters as well as the following special characters: `_`, `-`, `.`, and `@`.

- **Minor bugfixes for MacOS.**  
  Edge cases when mixing Brew-installed Pythons and system Pythons have been addressed.