### PR TITLE
🐛 v1.7.4 Fix an issue with custom database ports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.7.3
+### v1.7.3 – v1.7.4
 
 - **Fix an issue with the local stack healthcheck.**  
   Due to some edge cases, the local stack `docker-compose.yaml` file would not be correctly formatted until `edit config` had been executed. This patch ensures the files are synced with each invocation of `stack`.
+
+- **Fix an issue when running the local stack with non-default ports.**  
+  Initializing a local stack with a different database port (e.g. 5433) now routes correctly within the Docker compose network (now patching to internal port to 5432).
+
+- **Fix `upgrade mrsm` behavior.**  
+  Recent changes to `stack` broke the automatic `stack pull` within `mrsm upgrade mrsm`.
 
 ### v1.7.2
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,10 +4,16 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v1.7.3
+### v1.7.3 – v1.7.4
 
 - **Fix an issue with the local stack healthcheck.**  
   Due to some edge cases, the local stack `docker-compose.yaml` file would not be correctly formatted until `edit config` had been executed. This patch ensures the files are synced with each invocation of `stack`.
+
+- **Fix an issue when running the local stack with non-default ports.**  
+  Initializing a local stack with a different database port (e.g. 5433) now routes correctly within the Docker compose network (now patching to internal port to 5432).
+
+- **Fix `upgrade mrsm` behavior.**  
+  Recent changes to `stack` broke the automatic `stack pull` within `mrsm upgrade mrsm`.
 
 ### v1.7.2
 

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -68,6 +68,11 @@ def stack(
         sysargs = []
     if sub_args is None:
         sub_args = []
+    ### Sometimes `stack()` is called directly from Python and doesn't have sysargs.
+    if action and not sysargs:
+        sysargs = action
+        if sysargs[0] != 'stack':
+            sysargs = ['stack'] + sysargs
 
     bootstrap = False
     for path in NECESSARY_FILES:
@@ -79,14 +84,12 @@ def stack(
     else: 
         sync_files(['stack'])
 
-    compose_command = ['up']
-    ### default: alias stack as docker-compose
-    if len(action) > 0 and action[0] != '':
-        compose_command = action
-
     ### define project name when starting containers
-    project_name_list = ['--project-name', get_config(
-        'stack', 'project_name', patch=True, substitute=True)
+    project_name_list = [
+        '--project-name',
+        get_config(
+            'stack', 'project_name', patch=True, substitute=True,
+        )
     ]
     
     ### Debug list used to include --log-level DEBUG, but the flag is not supported on Windows (?)

--- a/meerschaum/config/stack/__init__.py
+++ b/meerschaum/config/stack/__init__.py
@@ -70,6 +70,7 @@ env_dict['MEERSCHAUM_API_PATCH'] = json.dumps(
                 'sql': {
                     'main': {
                         'host': db_host,
+                        'port': 5432,
                     },
                     'local': {
                         'database': volumes['api_root'] + '/sqlite/mrsm_local.db'

--- a/scripts/docker/image_setup.sh
+++ b/scripts/docker/image_setup.sh
@@ -115,3 +115,4 @@ function PostCommand() {
 }
 PROMPT_COMMAND="PostCommand"
 ' > /home/$MRSM_USER/.bashrc
+chown $MRSM_USER:$MRSM_USER /home/$MRSM_USER/.bashrc


### PR DESCRIPTION
# v1.7.4

- **Fix an issue when running the local stack with non-default ports.**  
  Initializing a local stack with a different database port (e.g. 5433) now routes correctly within the Docker compose network (now patching to internal port to 5432).

- **Fix `upgrade mrsm` behavior.**  
  Recent changes to `stack` broke the automatic `stack pull` within `mrsm upgrade mrsm`.