### PR TITLE
🐛 v2.0.1 Fix minor bugs when syncing bools in-place.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 2.0.x Releases
 
+This is the current release cycle, so stay tuned for future releases!
+
+### v2.0.1
+
+- **Fix syncing bools within in-place SQL pipes.**  
+  SQL pipes may now sync bools in-place. For database flavors which lack native `BOOLEAN` support (e.g. `sqlite`, `oracle`, `mysql`), then the boolean columns must be stated in `pipe.dtypes`.
+
+- **Fix an issue with multiple users managing jobs.**  
+  Extra validation was added to the web UI to allow for multiple users to interact with jobs.
+
+- **Fix a minor formatting bug with `highlight_pipes()`.**  
+  Improved validation logic was added to prevent incorrectly prepending the `Pipe(` prefix.
+
+- **Hold back `pydantic` to `<2.0.0`**  
+  Pydantic 2 is supported in all features except `--schedule`. Until `rocketry` supports Pydantic 2, it will be held back.
+
 ### v2.0.0
 
 **Breaking Changes**
@@ -412,7 +428,7 @@
 
 ## 1.7.x Releases
 
-This is the current release cycle, so stay tuned for future releases!
+The 1.7 series was short and sweet with a big focus on improving the web API. The highlight feature was the integrated webterm, and the series includes many bugfixes and improvements. 
 
 ### v1.7.3 – v1.7.4
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -2,6 +2,22 @@
 
 ## 2.0.x Releases
 
+This is the current release cycle, so stay tuned for future releases!
+
+### v2.0.1
+
+- **Fix syncing bools within in-place SQL pipes.**  
+  SQL pipes may now sync bools in-place. For database flavors which lack native `BOOLEAN` support (e.g. `sqlite`, `oracle`, `mysql`), then the boolean columns must be stated in `pipe.dtypes`.
+
+- **Fix an issue with multiple users managing jobs.**  
+  Extra validation was added to the web UI to allow for multiple users to interact with jobs.
+
+- **Fix a minor formatting bug with `highlight_pipes()`.**  
+  Improved validation logic was added to prevent incorrectly prepending the `Pipe(` prefix.
+
+- **Hold back `pydantic` to `<2.0.0`**  
+  Pydantic 2 is supported in all features except `--schedule`. Until `rocketry` supports Pydantic 2, it will be held back.
+
 ### v2.0.0
 
 **Breaking Changes**
@@ -412,7 +428,7 @@
 
 ## 1.7.x Releases
 
-This is the current release cycle, so stay tuned for future releases!
+The 1.7 series was short and sweet with a big focus on improving the web API. The highlight feature was the integrated webterm, and the series includes many bugfixes and improvements. 
 
 ### v1.7.3 – v1.7.4
 

--- a/meerschaum/api/dash/callbacks/jobs.py
+++ b/meerschaum/api/dash/callbacks/jobs.py
@@ -151,7 +151,6 @@ def refresh_jobs_on_interval(
     """
     When the jobs refresh interval fires, rebuild the jobs' onscreen components.
     """
-    raise PreventUpdate
     session_id = session_data.get('session-id', None)
     is_authenticated = is_session_authenticated(session_id)
 

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -766,14 +766,13 @@ def to_sql(
                 dtype[col] = sqlalchemy.types.NVARCHAR(2000)
             elif are_dtypes_equal(str(typ), 'int'):
                 dtype[col] = sqlalchemy.types.INTEGER
-
         to_sql_kw['dtype'] = dtype
-    #  elif self.flavor in ('mysql', 'mariadb'):
-        #  dtype = to_sql_kw.get('dtype', {})
-        #  for col, typ in df.dtypes.items():
-            #  if are_dtypes_equal(str(typ), 'bool'):
-                #  dtype[col] = sqlalchemy.types.BOOLEAN
-        #  to_sql_kw['dtype'] = dtype
+    elif self.flavor == 'mssql':
+        dtype = to_sql_kw.get('dtype', {})
+        for col, typ in df.dtypes.items():
+            if are_dtypes_equal(str(typ), 'bool'):
+                dtype[col] = sqlalchemy.types.INTEGER
+        to_sql_kw['dtype'] = dtype
 
     ### Check for JSON columns.
     if self.flavor not in json_flavors:

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -324,7 +324,7 @@ def _get_data_as_iterator(
 
 def get_backtrack_data(
         self,
-        backtrack_minutes: int = 0,
+        backtrack_minutes: Optional[int] = None,
         begin: Union[datetime, int, None] = None,
         params: Optional[Dict[str, Any]] = None,
         fresh: bool = False,
@@ -336,9 +336,9 @@ def get_backtrack_data(
 
     Parameters
     ----------
-    backtrack_minutes: int, default 0
+    backtrack_minutes: Optional[int], default None
         How many minutes from `begin` to select from.
-        If 0 (default), use `pipe.parameters['fetch']['backtrack_minutes']`.
+        If `None`, use `pipe.parameters['fetch']['backtrack_minutes']`.
 
     begin: Optional[datetime], default None
         The starting point to search for data.
@@ -379,7 +379,7 @@ def get_backtrack_data(
         return None
 
     backtrack_interval = self.get_backtrack_interval(debug=debug)
-    if backtrack_minutes == 0:
+    if backtrack_minutes is None:
         backtrack_minutes = (
             (backtrack_interval.total_seconds() * 60)
             if isinstance(backtrack_interval, timedelta)

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -8,7 +8,7 @@ Functions for fetching new data into the Pipe
 
 from __future__ import annotations
 from datetime import timedelta, datetime
-from meerschaum.utils.typing import Optional, Any
+from meerschaum.utils.typing import Optional, Any, Union
 from meerschaum.config import get_config
 
 def fetch(
@@ -111,15 +111,16 @@ def get_backtrack_interval(self, debug: bool = False) -> Union[timedelta, int]:
         else default_backtrack_minutes
     )
 
+    backtrack_interval = timedelta(minutes=backtrack_minutes)
     dt_col = self.columns.get('datetime', None)
     if dt_col is None:
-        return timedelta(minutes=backtrack_minutes)
+        return backtrack_interval
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime64[ns]')
-    if 'datetime' in dt_dtype.lower():
-        return timedelta(minutes=backtrack_minutes)
+    if 'int' in dt_dtype.lower():
+        return backtrack_minutes
 
-    return backtrack_minutes
+    return backtrack_interval
 
 
 def _determine_begin(

--- a/meerschaum/utils/daemon/Daemon.py
+++ b/meerschaum/utils/daemon/Daemon.py
@@ -499,7 +499,15 @@ class Daemon:
         A SuccessTuple indicating success.
         """
         try:
-            os.kill(int(self.pid), signal_to_send)
+            pid = self.pid
+            if pid is None:
+                return (
+                    False,
+                    f"Daemon '{self.daemon_id}' is not running, "
+                    + f"cannot send signal '{signal_to_send}'."
+                )
+            
+            os.kill(pid, signal_to_send)
         except Exception as e:
             return False, f"Failed to send signal {signal_to_send}:\n{traceback.format_exc()}"
 

--- a/meerschaum/utils/daemon/_names.py
+++ b/meerschaum/utils/daemon/_names.py
@@ -11,94 +11,90 @@ import os, random
 from meerschaum.utils.typing import Dict, List, Tuple
 from meerschaum.config._paths import DAEMON_RESOURCES_PATH
 
-_bank : Dict[str, Dict[str, List[str]]] = {
-    'adjectives' : {
-        'colors' : [
+_bank: Dict[str, Dict[str, List[str]]] = {
+    'adjectives': {
+        'colors': [
             'red', 'blue', 'green', 'orange', 'pink', 'amber',
             'bright', 'dark', 'neon',
         ],
-        'sizes' : [
+        'sizes': [
             'big', 'small', 'large', 'huge', 'tiny', 'long', 'short', 'grand', 'mini', 'micro'
         ],
-        'personalities' : [
+        'personalities': [
             'groovy', 'cool', 'awesome', 'nice', 'fantastic', 'sweet', 'great', 'amazing',
             'terrific', 'funky', 'fancy', 'sneaky', 'elegant', 'dreamy',
         ],
-        'emotions' : [
+        'emotions': [
             'angry', 'happy', 'excited', 'suspicious', 'sad', 'thankful', 'grateful', 'satisfied',
         ],
-        'sensations' : [
+        'sensations': [
             'sleepy', 'awake', 'alert', 'thirsty', 'comfy', 'warm', 'cold', 'chilly', 'soft',
             'smooth', 'chunky',
         ],
-        'materials' : [
+        'materials': [
             'golden', 'silver', 'metal', 'plastic', 'wool', 'wooden', 'nylon', 'fuzzy', 'silky',
         ],
-        'qualities' : [
+        'qualities': [
             'expensive', 'cheap', 'premier', 'best', 'favorite', 'better', 'good', 'affordable',
         ],
     },
     'nouns' : {
-        'animals' : [
+        'animals': [
             'mouse', 'fox', 'horse', 'dragon', 'pig', 'hippo', 'elephant' , 'tiger', 'deer',
             'gerbil', 'snake', 'turtle', 'rhino', 'dog', 'cat', 'giraffe', 'rabbit', 'squirrel',
             'unicorn', 'lizard', 'lion', 'bear', 'gazelle', 'whale', 'dolphin', 'fish', 'butterfly',
             'ladybug', 'fly', 'shrimp', 'flamingo', 'parrot', 'tuna', 'panda', 'lemur', 'duck',
             'seal', 'walrus', 'seagull', 'iguana', 'salamander', 'kitten', 'puppy', 'octopus',
         ],
-        'plants' : [
+        'plants': [
             'tree', 'flower', 'vine', 'fern', 'palm', 'palmetto', 'oak', 'pine', 'rose', 'lily',
             'ivy',
         ],
-        'foods' : [
+        'foods': [
             'pizza', 'sushi', 'apple', 'banana', 'sandwich', 'burger', 'taco', 'bratwurst',
             'grape', 'coconut', 'bread', 'toast',
         ],
-        'geographies' : [
+        'geographies': [
             'ocean', 'mountain', 'desert', 'forest', 'tundra', 'savanna', 'grassland', 'prairie',
             'lake', 'city', 'river',
         ],
-        'vehicles' : [
+        'vehicles': [
             'car', 'bike', 'boat', 'bus', 'trolley', 'tram', 'plane', 'skates', 'skateboard',
             'kayak', 'canoe', 'paddleboard', 'skis', 'snowboard', 'truck', 'bicycle', 'unicycle',
             'tricycle',
         ],
-        'clothing' : [
+        'clothing': [
             'socks', 'shirt', 'dress', 'shoes', 'hat', 'glasses', 'pocket', 'shorts', 'pants',
             'skirt', 'capris', 'helmet',
         ],
-        'instruments' : [
+        'instruments': [
             'guitar', 'piano', 'trombone', 'drums', 'viola', 'violin', 'trumpet', 'bass',
             'harmonica', 'banjo',
         ],
     },
 }
 
-_disallow_combinations : List[Tuple[str, str]] = [
-    #  ('colors', 'animals'), ('emotions', 'animals'),
-]
+_disallow_combinations: List[Tuple[str, str]] = []
 
-_adjectives : List[str]= []
+_adjectives: List[str]= []
 for category, items in _bank['adjectives'].items():
     _adjectives += items
 
-_nouns : List[str] = []
+_nouns: List[str] = []
 for category, items in _bank['nouns'].items():
     _nouns += items
 
-def generate_random_name(seperator : str = '_'):
+def generate_random_name(separator: str = '_'):
     """
+    Return a random adjective and noun combination.
 
     Parameters
     ----------
-    seperator : str :
-         (Default value = '_')
+    separator: str, default '_'
 
     Returns
     -------
-    type
-        
-
+    A string containing an random adjective and random noun. 
     """
     while True:
         adjective_category = random.choice(list(_bank['adjectives'].keys()))
@@ -108,23 +104,21 @@ def generate_random_name(seperator : str = '_'):
         break
     return (
         random.choice(_bank['adjectives'][adjective_category])
-        + seperator
+        + separator
         + random.choice(_bank['nouns'][noun_category])
     )
 
-def get_new_daemon_name():
+
+def get_new_daemon_name() -> str:
     """
-
-    Parameters
-    ----------
-
-    Returns
-    -------
-    type
-        Validates that generated names are unique, up to ~6000 maximum possibilities.
-
+    Generate a new random name until a unique one is found
+    (up to ~6000 maximum possibilities).
     """
-    existing_names = os.listdir(DAEMON_RESOURCES_PATH)
+    existing_names = (
+        os.listdir(DAEMON_RESOURCES_PATH)
+        if DAEMON_RESOURCES_PATH.exists()
+        else []
+    )
     while True:
         _name = generate_random_name()
         if _name in existing_names:

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -119,7 +119,7 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'postgresql': 'BOOLEAN',
         'mariadb': 'BOOLEAN',
         'mysql': 'BOOLEAN',
-        'mssql': 'BIT',
+        'mssql': 'INTEGER',
         'oracle': 'INTEGER',
         'sqlite': 'BOOLEAN',
         'duckdb': 'BOOLEAN',

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -309,7 +309,7 @@ def highlight_pipes(message: str) -> str:
     """
     Add syntax highlighting to an info message containing stringified `meerschaum.Pipe` objects.
     """
-    if 'Pipe(' not in message and ')' not in message:
+    if 'Pipe(' not in message:
         return message
 
     from meerschaum import Pipe
@@ -326,6 +326,7 @@ def highlight_pipes(message: str) -> str:
         has_paren = paren_index != -1
         has_single_quote = single_quote_index != -1
         has_double_quote = double_quote_index != -1
+        has_quote = has_single_quote or has_double_quote
         quote_index = double_quote_index if has_double_quote else single_quote_index
 
         has_pipe = (
@@ -333,9 +334,9 @@ def highlight_pipes(message: str) -> str:
             and
             has_paren
             and
-            (has_single_quote or has_double_quote)
+            has_quote
             and not
-            (has_double_quote and has_double_quote)
+            (has_single_quote and has_double_quote)
             and not
             (comma_index > paren_index or quote_index > paren_index)
         )
@@ -345,6 +346,7 @@ def highlight_pipes(message: str) -> str:
             try:
                 exec(code)
                 _to_add = pipe_repr(_d['pipe']) + segment[paren_index + 1:]
+                _ = _d.pop('pipe', None)
             except Exception as e:
                 _to_add = 'Pipe(' + segment
             msg += _to_add

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -155,7 +155,7 @@ packages['api'] = {
     'passlib'                        : 'passlib>=1.7.4',
     'fastapi_login'                  : 'fastapi-login>=1.7.2',
     'multipart'                      : 'python-multipart>=0.0.5',
-    'pydantic'                       : 'pydantic>=1.7.4',
+    'pydantic'                       : 'pydantic<2.0.0',
     'httpx'                          : 'httpx>=0.24.1',
     'websockets'                     : 'websockets>=11.0.3',
 }

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -6,7 +6,7 @@ fastapi>=0.100.0
 passlib>=1.7.4
 fastapi-login>=1.7.2
 python-multipart>=0.0.5
-pydantic>=1.7.4
+pydantic<2.0.0
 httpx>=0.24.1
 numpy>=1.18.5
 pandas[parquet]>=2.0.1

--- a/requirements/full.txt
+++ b/requirements/full.txt
@@ -67,5 +67,5 @@ fastapi>=0.100.0
 passlib>=1.7.4
 fastapi-login>=1.7.2
 python-multipart>=0.0.5
-pydantic>=1.7.4
+pydantic<2.0.0
 httpx>=0.24.1


### PR DESCRIPTION
# v2.0.1

- **Fix syncing bools within in-place SQL pipes.**  
  SQL pipes may now sync bools in-place. For database flavors which lack native `BOOLEAN` support (e.g. `sqlite`, `oracle`, `mysql`), then the boolean columns must be stated in `pipe.dtypes`.

- **Fix an issue with multiple users managing jobs.**  
  Extra validation was added to the web UI to allow for multiple users to interact with jobs.

- **Fix a minor formatting bug with `highlight_pipes()`.**  
  Improved validation logic was added to prevent incorrectly prepending the `Pipe(` prefix.

- **Hold back `pydantic` to `<2.0.0`**  
  Pydantic 2 is supported in all features except `--schedule`. Until `rocketry` supports Pydantic 2, it will be held back.