### PR TITLE
🔧 v2.0.2 Skip backtracking when syncing with `--skip-check-existing`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.0.2
+
+- **Syncing with `--skip-check-existing` will not apply the backtrack interval.**  
+  Because `--skip-check-existing` (or `check_existing=False`) is guaranteed to produce duplicates, the backtrack interval will be set to 0 when running in insert-only mode.
+
+- **Allow for `columns` to be a list.**  
+  Note that building a pipe with `columns` as a list must have the datetime column named `datetime`.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b', columns=['a'])
+  print(pipe.columns)
+  # {'a': 'a'}
+  ```
+
+- **Bump default SQLAlchemy pool size to 8 connections.**
+
+- **Fix `pipe.get_data(as_dask=True)` for JSON columns.**
+
 ### v2.0.1
 
 - **Fix syncing bools within in-place SQL pipes.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Bump default SQLAlchemy pool size to 8 connections.**
 
+- **Consider the number of checked out connections when choosing workers.**  
+  For pipes on `sql` instances, `pipe.get_num_workers()` will now consider the number of checked out connections rather than only the number of active threads.
+
 - **Fix `pipe.get_data(as_dask=True)` for JSON columns.**
 
 ### v2.0.1

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.0.2
+
+- **Syncing with `--skip-check-existing` will not apply the backtrack interval.**  
+  Because `--skip-check-existing` (or `check_existing=False`) is guaranteed to produce duplicates, the backtrack interval will be set to 0 when running in insert-only mode.
+
+- **Allow for `columns` to be a list.**  
+  Note that building a pipe with `columns` as a list must have the datetime column named `datetime`.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b', columns=['a'])
+  print(pipe.columns)
+  # {'a': 'a'}
+  ```
+
+- **Bump default SQLAlchemy pool size to 8 connections.**
+
+- **Fix `pipe.get_data(as_dask=True)` for JSON columns.**
+
 ### v2.0.1
 
 - **Fix syncing bools within in-place SQL pipes.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -21,6 +21,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Bump default SQLAlchemy pool size to 8 connections.**
 
+- **Consider the number of checked out connections when choosing workers.**  
+  For pipes on `sql` instances, `pipe.get_num_workers()` will now consider the number of checked out connections rather than only the number of active threads.
+
 - **Fix `pipe.get_data(as_dask=True)` for JSON columns.**
 
 ### v2.0.1

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -63,8 +63,8 @@ default_system_config = {
             'poolclass': 'sqlalchemy.pool.QueuePool',
             'create_engine': {
                 'method': 'multi',
-                'pool_size': 5,
-                'max_overflow': 10,
+                'pool_size': 8,
+                'max_overflow': 12,
                 'pool_recycle': 3600,
                 'connect_args': {},
             },

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/meerschaum/connectors/__init__.py
+++ b/meerschaum/connectors/__init__.py
@@ -13,6 +13,7 @@ For ease of use, you can also import from the root `meerschaum` module:
 
 from __future__ import annotations
 
+import meerschaum as mrsm
 from meerschaum.utils.typing import Any, SuccessTuple, Union, Optional, List, Dict
 from meerschaum.utils.threading import Lock, RLock
 from meerschaum.utils.warnings import error, warn
@@ -328,7 +329,7 @@ def load_plugin_connectors():
 
 def get_connector_plugin(
         connector: Connector,
-    ) -> Union[str, None, 'meerschaum.Plugin']:
+    ) -> Union[str, None, mrsm.Plugin]:
     """
     Determine the plugin for a connector.
     This is useful for handling virtual environments for custom instance connectors.
@@ -344,7 +345,6 @@ def get_connector_plugin(
     """
     if not hasattr(connector, 'type'):
         return None
-    from meerschaum import Plugin
     plugin_name = (
         connector.__module__.replace('plugins.', '').split('.')[0]
         if connector.type in custom_types else (
@@ -353,5 +353,5 @@ def get_connector_plugin(
             else 'mrsm'
         )
     )
-    plugin = Plugin(plugin_name)
+    plugin = mrsm.Plugin(plugin_name)
     return plugin if plugin.is_installed() else None

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -243,6 +243,9 @@ class Pipe:
                 warn(f"The provided parameters are of invalid type '{type(parameters)}'.")
             self._attributes['parameters'] = {}
 
+        columns = columns or self._attributes.get('parameters', {}).get('columns', {})
+        if isinstance(columns, list):
+            columns = {str(col): str(col) for col in columns}
         if isinstance(columns, dict):
             self._attributes['parameters']['columns'] = columns
         elif columns is not None:

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -144,8 +144,7 @@ def get_data(
         ]
         dask_meta = {
             col: to_pandas_dtype(typ)
-            for col, typ
-            in self.dtypes.items()
+            for col, typ in self.dtypes.items()
         }
         return dd.from_delayed(dask_chunks, meta=dask_meta)
 

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -89,6 +89,7 @@ def get_data(
     from meerschaum.utils.venv import Venv
     from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.misc import iterate_chunks, items_str
+    from meerschaum.utils.dtypes import to_pandas_dtype
     from meerschaum.utils.dataframe import add_missing_cols_to_df
     from meerschaum.utils.packages import attempt_import
     dd = attempt_import('dask.dataframe') if as_dask else None
@@ -141,7 +142,12 @@ def get_data(
             )
             for (chunk_begin, chunk_end) in bounds
         ]
-        return dd.from_delayed(dask_chunks, meta=self.dtypes)
+        dask_meta = {
+            col: to_pandas_dtype(typ)
+            for col, typ
+            in self.dtypes.items()
+        }
+        return dd.from_delayed(dask_chunks, meta=dask_meta)
 
     if not self.exists(debug=debug):
         return None

--- a/meerschaum/core/Pipe/_deduplicate.py
+++ b/meerschaum/core/Pipe/_deduplicate.py
@@ -8,7 +8,7 @@ Delete duplicate rows within a pipe's table.
 
 from __future__ import annotations
 from datetime import datetime, timedelta
-from meerschaum.utils.typing import SuccessTuple, Any, Optional, Dict
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, Dict, Tuple
 
 
 def deduplicate(

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -8,18 +8,20 @@ Functions for fetching new data into the Pipe
 
 from __future__ import annotations
 from datetime import timedelta, datetime
-from meerschaum.utils.typing import Optional, Any, Union
+import meerschaum as mrsm
+from meerschaum.utils.typing import Optional, Any, Union, SuccessTuple, Iterator
 from meerschaum.config import get_config
+from meerschaum.utils.warnings import warn
 
 def fetch(
         self,
         begin: Optional[datetime.datetime, str] = '',
         end: Optional[datetime.datetime] = None,
+        check_existing: bool = True,
         sync_chunks: bool = False,
-        deactivate_plugin_venv: bool = True,
         debug: bool = False,
         **kw: Any
-    ) -> 'pd.DataFrame or None':
+    ) -> Union['pd.DataFrame', Iterator['pd.DataFrame'], None]:
     """
     Fetch a Pipe's latest data from its connector.
 
@@ -30,6 +32,9 @@ def fetch(
 
     end: Optional[datetime.datetime], default None:
         If provided, only fetch data older than or equal to `end`.
+
+    check_existing: bool, default True
+        If `False`, do not apply the backtrack interval.
 
     sync_chunks: bool, default False
         If `True` and the pipe's connector is of type `'sql'`, begin syncing chunks while fetching
@@ -44,27 +49,15 @@ def fetch(
 
     """
     if 'fetch' not in dir(self.connector):
-        from meerschaum.utils.warnings import warn
         warn(f"No `fetch()` function defined for connector '{self.connector}'")
         return None
 
-    from meerschaum.connectors import custom_types
+    import contextlib
+    from meerschaum.connectors import custom_types, get_connector_plugin
     from meerschaum.utils.debug import dprint, _checkpoint
-    if (
-        self.connector.type == 'plugin'
-        or
-        self.connector.type in custom_types
-    ):
-        from meerschaum.plugins import Plugin
-        from meerschaum.utils.packages import activate_venv, deactivate_venv
-        plugin_name = (
-            self.connector.label if self.connector.type == 'plugin'
-            else self.connector.__module__.replace('plugins.', '').split('.')[0]
-        )
-        connector_plugin = Plugin(plugin_name)
-        connector_plugin.activate_venv(debug=debug)
-    
+
     _chunk_hook = kw.pop('chunk_hook', None)
+    kw['workers'] = self.get_num_workers(kw.get('workers', None))
     if sync_chunks and _chunk_hook is None:
 
         def _chunk_hook(chunk, **_kw) -> SuccessTuple:
@@ -79,25 +72,36 @@ def fetch(
                 chunk_message = '\n' + chunk_label + '\n' + chunk_message
             return chunk_success, chunk_message
 
-    workers = kw.get('workers', None)
-    if workers is None and not getattr(self.instance_connector, 'IS_THREAD_SAFE', False):
-        workers = 1
-    kw['workers'] = workers
 
-    df = self.connector.fetch(
-        self,
-        begin = _determine_begin(self, begin, debug=debug),
-        end = end,
-        chunk_hook = _chunk_hook,
-        debug = debug,
-        **kw
-    )
+    with mrsm.Venv(get_connector_plugin(self.connector)):
+        df = self.connector.fetch(
+            self,
+            begin = _determine_begin(
+                self,
+                begin,
+                check_existing = check_existing,
+                debug = debug,
+            ),
+            end = end,
+            chunk_hook = _chunk_hook,
+            debug = debug,
+            **kw
+        )
     return df
 
 
-def get_backtrack_interval(self, debug: bool = False) -> Union[timedelta, int]:
+def get_backtrack_interval(
+        self,
+        check_existing: bool = True,
+        debug: bool = False,
+    ) -> Union[timedelta, int]:
     """
     Get the chunk interval to use for this pipe.
+
+    Parameters
+    ----------
+    check_existing: bool, default True
+        If `False`, return a backtrack_interval of 0 minutes.
 
     Returns
     -------
@@ -109,7 +113,7 @@ def get_backtrack_interval(self, debug: bool = False) -> Union[timedelta, int]:
         configured_backtrack_minutes
         if configured_backtrack_minutes is not None
         else default_backtrack_minutes
-    )
+    ) if check_existing else 0
 
     backtrack_interval = timedelta(minutes=backtrack_minutes)
     dt_col = self.columns.get('datetime', None)
@@ -124,19 +128,33 @@ def get_backtrack_interval(self, debug: bool = False) -> Union[timedelta, int]:
 
 
 def _determine_begin(
-        pipe: meerschaum.Pipe,
+        pipe: mrsm.Pipe,
         begin: Union[datetime, int, str] = '',
+        check_existing: bool = True,
         debug: bool = False,
     ) -> Union[datetime, int, None]:
     """
     Apply the backtrack interval if `--begin` is not provided.
+
+    Parameters
+    ----------
+    begin: Union[datetime, int, str], default ''
+        The provided begin timestamp.
+
+    check_existing: bool, default True
+        If `False`, do not apply the backtrack interval.
+
+    Returns
+    -------
+    A datetime (or int) value from which to fetch.
+    Returns `None` if no begin may be determined.
     """
     if begin != '':
         return begin
     sync_time = pipe.get_sync_time(debug=debug)
     if sync_time is None:
         return sync_time
-    backtrack_interval = pipe.get_backtrack_interval(debug=debug)
+    backtrack_interval = pipe.get_backtrack_interval(check_existing=check_existing, debug=debug)
     if isinstance(sync_time, datetime) and isinstance(backtrack_interval, int):
         backtrack_interval = timedelta(minutes=backtrack_interval)
     try:

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -52,7 +52,6 @@ def fetch(
         warn(f"No `fetch()` function defined for connector '{self.connector}'")
         return None
 
-    import contextlib
     from meerschaum.connectors import custom_types, get_connector_plugin
     from meerschaum.utils.debug import dprint, _checkpoint
 


### PR DESCRIPTION
# v2.0.2

- **Syncing with `--skip-check-existing` will not apply the backtrack interval.**  
  Because `--skip-check-existing` (or `check_existing=False`) is guaranteed to produce duplicates, the backtrack interval will be set to 0 when running in insert-only mode.

- **Allow for `columns` to be a list.**  
  Note that building a pipe with `columns` as a list must have the datetime column named `datetime`.

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe('a', 'b', columns=['a'])
  print(pipe.columns)
  # {'a': 'a'}
  ```

- **Bump default SQLAlchemy pool size to 8 connections.**

- **Fix `pipe.get_data(as_dask=True)` for JSON columns.**