### PR TITLE
🔧 v2.0.8 Cast `None` to `Decimal('NaN')` for `numeric` columns, plus bugfixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.0.8
+
+- **Cast `None` to `Decimal('NaN')` for `numeric` columns.**  
+  To allow for all-null numeric columns, `None` (and other null-like types) are coerced to `Decimal('NaN')`.
+
+- **Schema bugfixes.**  
+  A few minor edge cases have been addressed when working with custom schemas for pipes.
+
+- **Remove `APIConnector.get_backtrack_data()`.**  
+  Since 1.7 released, the `get_backtrack_data()` method for instance connectors has been optional. 
+  > **NOTE:** the `backtrack_data` API endpoint has also been removed.
+
+- **Other bugfixes.**  
+  Issues with changes made to session authentication have been addressed.
+
 ### v2.0.5 – v2.0.7
 
 - **Add the `numeric` dtype (i.e. support for `NUMERIC` columns).**  
@@ -23,7 +38,7 @@ This is the current release cycle, so stay tuned for future releases!
   # [{'foo': Decimal('1')}, {'foo': Decimal('2.01234567890123456789')}]
   ```
 
-  > **NOTE**: Due to implementation limits, `numeric` has strict precision issues in embedded databases (SQLite: `NUMERIC(38, 17)`, DuckDB: `NUMERIC(38, 4)`). PostgreSQL-like database flavors have the best support for `NUMERIC`; MSSQL and MySQL/MariaDB use a precision and scale of `NUMERIC(38, 20)`. Oracle and PostgreSQL are not capped.
+  > **NOTE**: Due to implementation limits, `numeric` has strict precision issues in embedded databases (SQLite and DuckDB: `NUMERIC(15, 4)`). PostgreSQL-like database flavors have the best support for `NUMERIC`; MSSQL and MySQL/MariaDB use a scale and precision of `NUMERIC(38, 20)`. Oracle and PostgreSQL are not capped.
 
 - **Mixing `int` and `float` will cast to `numeric`.**  
   Rather than always casting to `TEXT`, a column containing a mix of `int` and `float` will be coerced into `numeric`.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.0.8
+
+- **Cast `None` to `Decimal('NaN')` for `numeric` columns.**  
+  To allow for all-null numeric columns, `None` (and other null-like types) are coerced to `Decimal('NaN')`.
+
+- **Schema bugfixes.**  
+  A few minor edge cases have been addressed when working with custom schemas for pipes.
+
+- **Remove `APIConnector.get_backtrack_data()`.**  
+  Since 1.7 released, the `get_backtrack_data()` method for instance connectors has been optional. 
+  > **NOTE:** the `backtrack_data` API endpoint has also been removed.
+
+- **Other bugfixes.**  
+  Issues with changes made to session authentication have been addressed.
+
 ### v2.0.5 – v2.0.7
 
 - **Add the `numeric` dtype (i.e. support for `NUMERIC` columns).**  
@@ -23,7 +38,7 @@ This is the current release cycle, so stay tuned for future releases!
   # [{'foo': Decimal('1')}, {'foo': Decimal('2.01234567890123456789')}]
   ```
 
-  > **NOTE**: Due to implementation limits, `numeric` has strict precision issues in embedded databases (SQLite: `NUMERIC(38, 17)`, DuckDB: `NUMERIC(38, 4)`). PostgreSQL-like database flavors have the best support for `NUMERIC`; MSSQL and MySQL/MariaDB use a precision and scale of `NUMERIC(38, 20)`. Oracle and PostgreSQL are not capped.
+  > **NOTE**: Due to implementation limits, `numeric` has strict precision issues in embedded databases (SQLite and DuckDB: `NUMERIC(15, 4)`). PostgreSQL-like database flavors have the best support for `NUMERIC`; MSSQL and MySQL/MariaDB use a scale and precision of `NUMERIC(38, 20)`. Oracle and PostgreSQL are not capped.
 
 - **Mixing `int` and `float` will cast to `numeric`.**  
   Rather than always casting to `TEXT`, a column containing a mix of `int` and `float` will be coerced into `numeric`.

--- a/meerschaum/actions/sql.py
+++ b/meerschaum/actions/sql.py
@@ -123,9 +123,10 @@ def sql(
     if result is False:
         return (False, f"Failed to execute query:\n\n{query}")
     
-    from meerschaum.utils.packages import attempt_import
+    from meerschaum.utils.packages import attempt_import, import_pandas
     from meerschaum.utils.formatting import print_tuple, pprint
     sqlalchemy_engine_result = attempt_import('sqlalchemy.engine.result')
+    pd = import_pandas()
     if 'sqlalchemy' in str(type(result)):
         if not nopretty:
             print_tuple((True, f"Successfully executed query:\n\n{query}"))
@@ -133,9 +134,13 @@ def sql(
         if not nopretty:
             pprint(result)
         else:
-            print(result.to_json(date_format='iso', orient='split', index=False, date_unit='us'))
-        if gui:
-            pandasgui = attempt_import('pandasgui')
-            pandasgui.show(result)
+            print(
+                result.fillna(pd.NA).to_json(
+                    date_format = 'iso',
+                    orient = 'split',
+                    index = False,
+                    date_unit = 'us'
+                )
+            )
 
     return (True, "Success")

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 from dash.dependencies import Input, Output, State
 from meerschaum.utils.typing import List, Optional, Dict, Any, Tuple, Union
 from meerschaum.utils.misc import string_to_dict, json_serialize_datetime
-from meerschaum.utils.packages import attempt_import, import_dcc, import_html
+from meerschaum.utils.packages import attempt_import, import_dcc, import_html, import_pandas
 from meerschaum.utils.sql import get_pd_type
 from meerschaum.utils.yaml import yaml
 from meerschaum.connectors.sql._fetch import get_pipe_query
@@ -29,6 +29,7 @@ dbc = attempt_import('dash_bootstrap_components', lazy=False, check_update=CHECK
 dash_ace = attempt_import('dash_ace', lazy=False, check_update=CHECK_UPDATE)
 html, dcc = import_html(check_update=CHECK_UPDATE), import_dcc(check_update=CHECK_UPDATE)
 humanfriendly = attempt_import('humanfriendly', check_update=CHECK_UPDATE)
+pd = import_pandas()
 
 def pipe_from_ctx(ctx, trigger_property: str = 'n_clicks') -> Union[mrsm.Pipe, None]:
     """
@@ -360,7 +361,7 @@ def accordion_items_from_pipe(
     if 'sync-data' in active_items:
         backtrack_df = pipe.get_backtrack_data(debug=debug, limit=1)
         try:
-            json_text = backtrack_df.to_json(
+            json_text = backtrack_df.fillna(pd.NA).to_json(
                 orient = 'records',
                 date_format = 'iso',
                 force_ascii = False,

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"

--- a/meerschaum/connectors/api/APIConnector.py
+++ b/meerschaum/connectors/api/APIConnector.py
@@ -42,7 +42,6 @@ class APIConnector(Connector):
         sync_pipe,
         delete_pipe,
         get_pipe_data,
-        get_backtrack_data,
         get_pipe_id,
         get_pipe_attributes,
         get_sync_time,

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1521,6 +1521,7 @@ def sync_pipe_inplace(
     backtrack_table_obj = get_sqlalchemy_table(
         backtrack_table_raw,
         connector = self,
+        schema = self.get_pipe_schema(pipe),
         refresh = True,
         debug = debug,
     )
@@ -1594,6 +1595,7 @@ def sync_pipe_inplace(
     delta_table_obj = get_sqlalchemy_table(
         delta_table_raw,
         connector = self,
+        schema = self.get_pipe_schema(pipe),
         refresh = True,
         debug = debug,
     )
@@ -2224,7 +2226,6 @@ def get_pipe_table(
     ----------
     pipe: mrsm.Pipe:
         The pipe in question.
-        
 
     Returns
     -------
@@ -2234,7 +2235,13 @@ def get_pipe_table(
     from meerschaum.utils.sql import get_sqlalchemy_table
     if not pipe.exists(debug=debug):
         return None
-    return get_sqlalchemy_table(pipe.target, connector=self, debug=debug, refresh=True)
+    return get_sqlalchemy_table(
+        pipe.target,
+        connector = self,
+        schema = self.get_pipe_schema(pipe),
+        debug = debug,
+        refresh = True,
+    )
 
 
 def get_pipe_columns_types(
@@ -2480,6 +2487,8 @@ def get_alter_columns_queries(
                 f"Failed to update dtypes for numeric columns {items_str(numeric_cols)}:\n"
                 + f"{edit_msg}"
             )
+    else:
+        numeric_cols.extend([col for col, typ in pipe.dtypes.items() if typ == 'numeric'])
 
     pipe_dtypes = pipe.dtypes
     numeric_type = get_db_type_from_pd_type('numeric', self.flavor, as_sqlalchemy=False)

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -682,6 +682,7 @@ def to_sql(
     """
     import time
     import json
+    import decimal
     from decimal import Decimal, Context
     from meerschaum.utils.warnings import error, warn
     import warnings
@@ -701,7 +702,7 @@ def to_sql(
         truncate_item_name,
     )
     from meerschaum.utils.dataframe import get_json_cols, get_numeric_cols
-    from meerschaum.utils.dtypes import are_dtypes_equal
+    from meerschaum.utils.dtypes import are_dtypes_equal, quantize_decimal
     from meerschaum.utils.dtypes.sql import NUMERIC_PRECISION_FLAVORS
     from meerschaum.connectors.sql._create_engine import flavor_configs
     from meerschaum.utils.packages import attempt_import, import_pandas
@@ -813,11 +814,10 @@ def to_sql(
     numeric_scale, numeric_precision = NUMERIC_PRECISION_FLAVORS.get(self.flavor, (None, None))
     if numeric_precision is not None and numeric_scale is not None:
         numeric_cols = get_numeric_cols(df)
-        precision_decimal = Decimal((('1' * numeric_scale) + '.' + ('1' * numeric_precision)))
         for col in numeric_cols:
             df[col] = df[col].apply(
                 lambda x: (
-                    x.quantize(precision_decimal, context=Context(prec=numeric_scale))
+                    quantize_decimal(x, numeric_scale, numeric_precision)
                     if isinstance(x, Decimal)
                     else x
                 )

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -603,7 +603,7 @@ def enforce_dtypes(
                     if debug:
                         dprint(f"Unable to parse column '{col}' as JSON:\n{e}")
 
-    if numeric_cols and len(df) > 0:
+    if numeric_cols:
         if debug:
             dprint(f"Checking for numerics: {numeric_cols}")
         for col in numeric_cols:

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -13,8 +13,8 @@ NUMERIC_PRECISION_FLAVORS: Dict[str, Tuple[int, int]] = {
     'mariadb': (38, 20),
     'mysql': (38, 20),
     'mssql': (38, 20),
-    'duckdb': (38, 4),
-    'sqlite': (38, 17),
+    'duckdb': (15, 4),
+    'sqlite': (15, 4),
 }
 
 DB_TO_PD_DTYPES: Dict[str, Union[str, Dict[str, str]]] = {

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1048,7 +1048,7 @@ def run_python_package(
 
 
 def attempt_import(
-        *names: List[str],
+        *names: str,
         lazy: bool = True,
         warn: bool = True,
         install: bool = True,

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -112,7 +112,6 @@ packages: Dict[str, Dict[str, str]] = {
     'extras': {
         'cmd2'                       : 'cmd2>=1.4.0',
         'ruamel.yaml'                : 'ruamel.yaml>=0.16.12',
-        'pandasgui'                  : 'pandasgui>=0.2.9',      
         'modin'                      : 'modin[ray]>=0.8.3',
         'nanoid'                     : 'nanoid>=2.0.0',
         'importlib_metadata'         : 'importlib-metadata>=4.12.0',

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -673,7 +673,7 @@ def get_sqlalchemy_table(
 
     Parameters
     ----------
-    table: str :
+    table: str
         The name of the table on the database. Does not need to be escaped.
         
     connector: Optional[meerschaum.connectors.sql.SQLConnector], default None:
@@ -730,6 +730,7 @@ def get_update_queries(
         patch: str,
         connector: mrsm.connectors.sql.SQLConnector,
         join_cols: Iterable[str],
+        schema: Optional[str] = None,
         debug: bool = False,
     ) -> List[str]:
     """
@@ -749,6 +750,10 @@ def get_update_queries(
     join_cols: List[str]
         The columns to use to join the patch to the target.
 
+    schema: Optional[str], default None
+        If provided, use this schema when quoting the target table.
+        Defaults to `connector.schema`.
+
     debug: bool, default False
         Verbosity toggle.
 
@@ -763,7 +768,8 @@ def get_update_queries(
     base_queries = update_queries.get(flavor, update_queries['default'])
     if not isinstance(base_queries, list):
         base_queries = [base_queries]
-    target_table = get_sqlalchemy_table(target, connector)
+    schema = schema or connector.schema
+    target_table = get_sqlalchemy_table(target, connector, schema=schema)
     value_cols = []
     if debug:
         dprint(f"target_table.columns: {dict(target_table.columns)}")
@@ -805,8 +811,8 @@ def get_update_queries(
         sets_subquery_f = sets_subquery('f.', 'p.'),
         and_subquery_f = and_subquery('p.', 'f.'),
         and_subquery_t = and_subquery('p.', 't.'),
-        target_table_name = sql_item_name(target, connector.flavor, None),
-        patch_table_name = sql_item_name(patch, connector.flavor, None),
+        target_table_name = sql_item_name(target, connector.flavor, schema),
+        patch_table_name = sql_item_name(patch, connector.flavor, schema),
     ) for base_query in base_queries]
 
     


### PR DESCRIPTION
# v2.0.8

- **Cast `None` to `Decimal('NaN')` for `numeric` columns.**  
  To allow for all-null numeric columns, `None` (and other null-like types) are coerced to `Decimal('NaN')`.

- **Schema bugfixes.**  
  A few minor edge cases have been addressed when working with custom schemas for pipes.

- **Remove `APIConnector.get_backtrack_data()`.**  
  Since 1.7 released, the `get_backtrack_data()` method for instance connectors has been optional. 
  > **NOTE:** the `backtrack_data` API endpoint has also been removed.

- **Other bugfixes.**  
  Issues with changes made to session authentication have been addressed.