### PR TITLE
✨ v2.1.3 Add `@pre_sync_hook`, `@post_sync_hook`, improve tags, and more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ This is the current release cycle, so stay tuned for future releases!
       mrsm.pprint(return_tuple)
   ```
 
+- **Add the action `show tags`.**  
+  The action `show tags` will now display panels of pipes grouped together by common tags. This is useful for large deployments which share common tags.
+
+- **Fix shell crashes in Docker containers.**  
+  Reloading the running Meerschaum session from an interactive shell via a Docker container will no longer cause crashes on custom commands.
+
+- **Improve reloading times.**  
+  Reloading the running Meerschaum session has been sped up by several seconds (due to skipping the internal shell modules).
+
+- **Improve virtual environments in the Docker image.**  
+  Initial startup of Docker containers on a fresh persistent volume has been sped up due to preloading the default virtual environment creation. Additionally, the environment variable `$MRSM_VENVS_DIR` has been unset, reverting the virtual environments to be stored under `/meerschaum/venvs`.
+
 ### v2.1.1 – v2.1.2
 
 - **Add `upsert` for high-performance pipes.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,25 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.1.3
 
-- **Add the decorator `@sync_hook`.**  
-  The new decorator `@sync_hook` lets you intercept a Pipe and its success tuple on every sync.
+- **Add the decorators `@pre_sync_hook` and `@post_sync_hook`.**  
+  The new decorators `@pre_sync_hook` and `@post_sync_hook` let you intercept a Pipe immediately before and after a sync, capturing its return tuple and the duration in seconds.
 
   ```python
   import meerschaum as mrsm
-  from meerschaum.plugins import sync_hook
+  from meerschaum.plugins import pre_sync_hook, post_sync_hook
 
-  @sync_hook
-  def log_sync(pipe, success_tuple, duration=0):
-      print(f"It took {round(duration, 2)} seconds to sync {pipe}.")
-      mrsm.pprint(success_tuple)
+  @pre_sync_hook
+  def prepare_for_sync(pipe: mrsm.Pipe, **kwargs):
+      print(f"About to sync {pipe} with kwargs:\n{kwargs}")
+
+  @post_sync_hook
+  def log_sync(
+          pipe: mrsm.Pipe,
+          return_tuple: mrsm.SuccessTuple,
+          duration: float = 0.0
+      ):
+      print(f"It took {round(duration, 2)} seconds to sync {pipe} with result:")
+      mrsm.pprint(return_tuple)
   ```
 
 ### v2.1.1 – v2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.1.3
+
+- **Add the decorator `@sync_hook`.**  
+  The new decorator `@sync_hook` lets you intercept a Pipe and its success tuple on every sync.
+
+  ```python
+  import meerschaum as mrsm
+  from meerschaum.plugins import sync_hook
+
+  @sync_hook
+  def log_sync(pipe, success_tuple, duration=0):
+      print(f"It took {round(duration, 2)} seconds to sync {pipe}.")
+      mrsm.pprint(success_tuple)
+  ```
+
 ### v2.1.1 – v2.1.2
 
 - **Add `upsert` for high-performance pipes.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add the action `show tags`.**  
   The action `show tags` will now display panels of pipes grouped together by common tags. This is useful for large deployments which share common tags.
 
+- **Add dropdowns and inputs for flags with arguments to the Web Console.**  
+  Leverage the full power of the Meerschaum CLI in the Web Console with the new dynamic flags dropdowns.
+
 - **Fix shell crashes in Docker containers.**  
   Reloading the running Meerschaum session from an interactive shell via a Docker container will no longer cause crashes on custom commands.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,45 @@ Here are a couple ways you can help out! 💪
 
 ## What About Pull Requests?
 
-If you write code directly and open a PR, I will consider your changes, but due to the development pattern of Meerschaum, I likely may choose to reject PRs for a number of reasons. A more effective method of addressing your concerns is to open an issue or start a discussion.
+PRs are welcome! Due to the development pattern of Meerschaum, I likely may tweak PRs for a number of reasons. A good first step to making changes is to open an issue or start a discussion.
+
+## Setting Up A Development Environment
+
+For local development, you will need the following:
+
+- Docker
+- Git
+- Python
+
+First, clone the Meerschaum repo:
+
+```bash
+git clone https://github.com/bmeares/Meerschaum.git ~/Meerschaum
+cd ~/Meerschaum
+```
+
+Build a local Docker image to install dependencies (note: this will overwrite `bmeares/meerschaum` on your machine):
+
+```bash
+./scripts/docker/buildx.sh
+```
+
+Start the development container, which will mount your cloned repository as the installed package in the container.
+
+
+```bash
+docker compose up -d
+```
+
+Start a new Bash shell in the container:
+
+```bash
+docker exec -it mrsm bash
+```
+
+You can now run `mrsm` commands in the Docker container. Changes you make to your cloned repository will be reflected in the container, so iterate to your heart's content!
+
+The script `./scripts/setup.sh` will install dependencies for local development, and `./scripts/build.sh` will build a wheel and local documentation. This is only needed for local Python development.
 
 ## Sponsorship
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://meerschaum.io/assets/banner_1920x320.png" alt="Meerschaum banner"/>
+<img src="https://meerschaum.io/assets/banner_1920x320.png" alt="Meerschaum banner" style="width: 100%"/>
 
 | PyPI | GitHub | Info | Stats |
 |---|---|---|---|

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.9'
+services:
+  mrsm:
+    image: "bmeares/meerschaum"
+    entrypoint: ["/scripts/dev.sh"]
+    network_mode: "host"
+    init: true
+    volumes:
+      - "./:/app"
+      - "dev_root:/meerschaum"
+
+volumes:
+  dev_root:

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -27,6 +27,18 @@ This is the current release cycle, so stay tuned for future releases!
       mrsm.pprint(return_tuple)
   ```
 
+- **Add the action `show tags`.**  
+  The action `show tags` will now display panels of pipes grouped together by common tags. This is useful for large deployments which share common tags.
+
+- **Fix shell crashes in Docker containers.**  
+  Reloading the running Meerschaum session from an interactive shell via a Docker container will no longer cause crashes on custom commands.
+
+- **Improve reloading times.**  
+  Reloading the running Meerschaum session has been sped up by several seconds (due to skipping the internal shell modules).
+
+- **Improve virtual environments in the Docker image.**  
+  Initial startup of Docker containers on a fresh persistent volume has been sped up due to preloading the default virtual environment creation. Additionally, the environment variable `$MRSM_VENVS_DIR` has been unset, reverting the virtual environments to be stored under `/meerschaum/venvs`.
+
 ### v2.1.1 – v2.1.2
 
 - **Add `upsert` for high-performance pipes.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -6,17 +6,25 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.1.3
 
-- **Add the decorator `@sync_hook`.**  
-  The new decorator `@sync_hook` lets you intercept a Pipe and its success tuple on every sync.
+- **Add the decorators `@pre_sync_hook` and `@post_sync_hook`.**  
+  The new decorators `@pre_sync_hook` and `@post_sync_hook` let you intercept a Pipe immediately before and after a sync, capturing its return tuple and the duration in seconds.
 
   ```python
   import meerschaum as mrsm
-  from meerschaum.plugins import sync_hook
+  from meerschaum.plugins import pre_sync_hook, post_sync_hook
 
-  @sync_hook
-  def log_sync(pipe, success_tuple, duration=0):
-      print(f"It took {round(duration, 2)} seconds to sync {pipe}.")
-      mrsm.pprint(success_tuple)
+  @pre_sync_hook
+  def prepare_for_sync(pipe: mrsm.Pipe, **kwargs):
+      print(f"About to sync {pipe} with kwargs:\n{kwargs}")
+
+  @post_sync_hook
+  def log_sync(
+          pipe: mrsm.Pipe,
+          return_tuple: mrsm.SuccessTuple,
+          duration: float = 0.0
+      ):
+      print(f"It took {round(duration, 2)} seconds to sync {pipe} with result:")
+      mrsm.pprint(return_tuple)
   ```
 
 ### v2.1.1 – v2.1.2

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.1.3
+
+- **Add the decorator `@sync_hook`.**  
+  The new decorator `@sync_hook` lets you intercept a Pipe and its success tuple on every sync.
+
+  ```python
+  import meerschaum as mrsm
+  from meerschaum.plugins import sync_hook
+
+  @sync_hook
+  def log_sync(pipe, success_tuple, duration=0):
+      print(f"It took {round(duration, 2)} seconds to sync {pipe}.")
+      mrsm.pprint(success_tuple)
+  ```
+
 ### v2.1.1 – v2.1.2
 
 - **Add `upsert` for high-performance pipes.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -30,6 +30,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add the action `show tags`.**  
   The action `show tags` will now display panels of pipes grouped together by common tags. This is useful for large deployments which share common tags.
 
+- **Add dropdowns and inputs for flags with arguments to the Web Console.**  
+  Leverage the full power of the Meerschaum CLI in the Web Console with the new dynamic flags dropdowns.
+
 - **Fix shell crashes in Docker containers.**  
   Reloading the running Meerschaum session from an interactive shell via a Docker container will no longer cause crashes on custom commands.
 

--- a/docs/mkdocs/reference/actions/index.md
+++ b/docs/mkdocs/reference/actions/index.md
@@ -556,7 +556,7 @@ Below are all of the Meerschaum commands and descriptions.
   </tr>
   <tr>
     <td class="tg-yrlk">pipes</td>
-    <td class="tg-3y4y">Verify the contents of pipes using iterative backtracking.<br><br><span style="font-weight:bold">NOTE:</span> Not implemented!<br>See my thesis research for <a href="https://github.com/bmeares/syncx" target="_blank" rel="noopener noreferrer">potential strategies</a>.</td>
+    <td class="tg-3y4y">Verify the contents of pipes using iterative backtracking.<br><br>See my thesis research for <a href="https://github.com/bmeares/syncx" target="_blank" rel="noopener noreferrer">potential strategies</a>.</td>
     <td class="tg-zjt4" colspan="2">• -i, --instance, --mrsm-instance<br>• -c, -C, --connector-keys<br>• -m, -M, --metric-keys<br>• -l, -L, --location-keys<br>• -t, --tags</td>
     <td class="tg-tijg">verify pipes</td>
   </tr>

--- a/docs/mkdocs/reference/plugins/writing-plugins.md
+++ b/docs/mkdocs/reference/plugins/writing-plugins.md
@@ -89,6 +89,8 @@ Plugins are just modules with functions. This section explains the roles of the 
   Create new commands.
 - **`#!python @api_plugin`**  
   Create new FastAPI endpoints.
+- **`#!python @sync_hook`**  
+  Inject a callback when a pipe is synced by the `sync pipes` action.
 - **`#!python setup(**kwargs)`**  
   Executed during plugin installation or with `mrsm setup plugins <plugin>`.
 
@@ -438,6 +440,10 @@ For your endpoints, arguments will be used as HTTP parameters, and to require th
 
     ![Custom Meerschaum API endpoint which requires a login.](/assets/screenshots/api-plugin-endpoint-login-required.png)
 
+
+### **The `#!python @sync_hook` Decorator**
+
+To insert a pipe-level callback into the `sync pipes` action, decorate your function with `#!python @sync_hook`.
 
 ### **The `#!python setup()` Function**
 

--- a/docs/mkdocs/reference/plugins/writing-plugins.md
+++ b/docs/mkdocs/reference/plugins/writing-plugins.md
@@ -89,8 +89,8 @@ Plugins are just modules with functions. This section explains the roles of the 
   Create new commands.
 - **`#!python @api_plugin`**  
   Create new FastAPI endpoints.
-- **`#!python @sync_hook`**  
-  Inject a callback when a pipe is synced by the `sync pipes` action.
+- **`#!python @pre_sync_hook` and `#!python @post_sync_hook`**  
+  Inject callbacks when pipes are synced by the `sync pipes` action.
 - **`#!python setup(**kwargs)`**  
   Executed during plugin installation or with `mrsm setup plugins <plugin>`.
 
@@ -441,9 +441,41 @@ For your endpoints, arguments will be used as HTTP parameters, and to require th
     ![Custom Meerschaum API endpoint which requires a login.](/assets/screenshots/api-plugin-endpoint-login-required.png)
 
 
-### **The `#!python @sync_hook` Decorator**
+### **The `#!python @pre_sync_hook` and `#!python @post_sync_hook` Decorators**
 
-To insert a pipe-level callback into the `sync pipes` action, decorate your function with `#!python @sync_hook`.
+You can tap into the built-in syncing engine via the `sync pipes` action by decorating callback functions with `#!python @pre_sync_hook` and/or `#!python @post_sync_hook`. Both callbacks accept a positional `pipe` argument, and `#!python @post_sync_hook` also takes a second positional argument `return_tuple` (`bool` and `str`).
+
+If you add `**kwargs` (optional), you can inspect the state of sync, e.g.:
+
+- `sync_method`  
+  A bound function of either `pipe.sync()`, `pipe.verify()`, or `pipe.deduplicate()`.
+- `min_seconds`
+- `workers`
+- `bounded`
+- `chunk_interval`
+
+For `#!python @post_sync_hook`, the keyword argument `duration` is included as the run-time in seconds of the sync.
+
+??? example "`#!python @pre_sync_hook` and `#!python @post_sync_hook` example"
+
+    ```python
+    import meerschaum as mrsm
+    from meerschaum.plugins import pre_sync_hook, post_sync_hook
+
+    @pre_sync_hook
+    def capture_before_sync(pipe: mrsm.Pipe, **kwargs):
+        print(f"About to sync {pipe} with kwargs:\n{kwargs}")
+
+    @post_sync_hook
+    def capture_after_sync(
+            pipe: mrsm.Pipe,
+            return_tuple: mrsm.SuccessTuple,
+            duration: float | None = None,
+            **kwargs
+        ):
+        print(f"Synced {pipe} in {duration} seconds with result:")
+        mrsm.pprint(return_tuple)
+    ```
 
 ### **The `#!python setup()` Function**
 

--- a/meerschaum/__init__.py
+++ b/meerschaum/__init__.py
@@ -22,25 +22,31 @@ import atexit
 from meerschaum.utils.typing import SuccessTuple
 from meerschaum.core.Pipe import Pipe
 from meerschaum.plugins import Plugin
-from meerschaum.utils import get_pipes
 from meerschaum.utils.venv import Venv
+from meerschaum.connectors import get_connector
+from meerschaum.utils import get_pipes
 from meerschaum.utils.formatting import pprint
 from meerschaum._internal.docs import index as __doc__
-from meerschaum.connectors import get_connector
 from meerschaum.config import __version__, get_config
 from meerschaum.utils.packages import attempt_import
 from meerschaum.__main__ import _close_pools
 
 atexit.register(_close_pools)
 
-__pdoc__ = {'gui': False, 'api': False, 'core': False,}
+__pdoc__ = {'gui': False, 'api': False, 'core': False, '_internal': False}
 __all__ = (
-    "Pipe",
     "get_pipes",
     "get_connector",
+    "get_config",
+    "Pipe",
     "Plugin",
     "Venv",
     "Plugin",
     "pprint",
     "attempt_import",
+    "actions",
+    "config",
+    "connectors",
+    "plugins",
+    "utils",
 )

--- a/meerschaum/_internal/docs/index.py
+++ b/meerschaum/_internal/docs/index.py
@@ -3,7 +3,7 @@
 # vim:fenc=utf-8
 
 """
-<img src="https://meerschaum.io/assets/banner_1920x320.png" alt="Meerschaum banner"/>
+<img src="https://meerschaum.io/assets/banner_1920x320.png" alt="Meerschaum banner" style="width: 100%;"/>
 
 | PyPI | GitHub | Info | Stats |
 |---|---|---|---|
@@ -28,17 +28,6 @@ Data engineering often gets in analysts' way, and when work needs to get done, e
 
 Rather than copy / pasting your ETL scripts, simply build pipes with Meerschaum! [Meerschaum gives you the tools to design your data streams how you like](https://towardsdatascience.com/easy-time-series-etl-for-data-scientists-with-meerschaum-5aade339b398) ― and don't worry — you can always incorporate Meerschaum into your existing systems!
 
-#### Want to Learn More?
-
-You can find a wealth of information at [meerschaum.io](https://meerschaum.io)!
-
-Additionally, below are several articles published about Meerschaum:
-
-- Interview featured in [*Console 100 - The Open Source Newsletter*](https://console.substack.com/p/console-100)
-- [*A Data Scientist's Guide to Fetching COVID-19 Data in 2022*](https://towardsdatascience.com/a-data-scientists-guide-to-fetching-covid-19-data-in-2022-d952b4697) (Towards Data Science)
-- [*Time-Series ETL with Meerschaum*](https://towardsdatascience.com/easy-time-series-etl-for-data-scientists-with-meerschaum-5aade339b398) (Towards Data Science)
-- [*How I automatically extract my M1 Finance transactions*](https://bmeares.medium.com/how-i-automatically-extract-my-m1-finance-transactions-b43cef857bc7)
-
 ## Features
 
 - 📊 **Built for Data Scientists and Analysts**  
@@ -58,8 +47,8 @@ Additionally, below are several articles published about Meerschaum:
     - Manage your database connections with [Meerschaum connectors](https://meerschaum.io/reference/connectors/)
     - Utility commands with sensible syntax let you control many pipes with grace.
 - 💼 **Portable from the Start**  
-    - The environment variable `$MRSM_ROOT_DIR` lets you emulate multiple installations and group together your [instances](https://meerschaum.io/reference/connectors/#instances-and-repositories).
-    - No dependencies required; anything needed will be installed into a virtual environment.
+    - The environment variables `$MRSM_ROOT_DIR`, `$MRSM_PLUGINS_DIR`, and `$MRSM_VENVS_DIR` let you emulate multiple installations and group together your [instances](https://meerschaum.io/reference/connectors/#instances-and-repositories).
+    - No dependencies required; anything needed will be installed into virtual environments.
     - [Specify required packages for your plugins](https://meerschaum.io/reference/plugins/writing-plugins/), and users will get those packages in a virtual environment.
 
 ## Installation
@@ -81,28 +70,29 @@ Please visit [meerschaum.io](https://meerschaum.io) for setup, usage, and troubl
 ```python
 >>> import meerschaum as mrsm
 >>> pipe = mrsm.Pipe("plugin:noaa", "weather")
->>> df = pipe.get_data(begin='2022-02-02')
->>> df[['timestamp', 'station', 'temperature (wmoUnit:degC)']]
-               timestamp station  temperature (wmoUnit:degC)
-0    2022-03-29 09:54:00    KCEU                         8.3
-1    2022-03-29 09:52:00    KATL                        10.6
-2    2022-03-29 09:52:00    KCLT                         7.2
-3    2022-03-29 08:54:00    KCEU                         8.3
-4    2022-03-29 08:52:00    KATL                        11.1
-...                  ...     ...                         ...
-1626 2022-02-02 01:52:00    KATL                        10.0
-1627 2022-02-02 01:52:00    KCLT                         7.8
-1628 2022-02-02 00:54:00    KCEU                         8.3
-1629 2022-02-02 00:52:00    KATL                        10.0
-1630 2022-02-02 00:52:00    KCLT                         8.3
+>>> cols_to_select = ['timestamp', 'station', 'temperature (degC)']
+>>> df = pipe.get_data(cols_to_select, begin='2023-11-15', end='2023-11-20')
+>>> df
+              timestamp station  temperature (degC)
+0   2023-11-15 00:52:00    KATL                16.1
+1   2023-11-15 00:52:00    KCLT                11.7
+2   2023-11-15 00:53:00    KGMU                15.0
+3   2023-11-15 00:54:00    KCEU                13.9
+4   2023-11-15 01:52:00    KATL                15.6
+..                  ...     ...                 ...
+535 2023-11-19 22:54:00    KCEU                15.6
+536 2023-11-19 23:52:00    KATL                16.7
+537 2023-11-19 23:52:00    KCLT                13.9
+538 2023-11-19 23:53:00    KGMU                15.6
+539 2023-11-19 23:54:00    KCEU                15.0
 
-[1631 rows x 3 columns]
+[540 rows x 3 columns]
 >>>
 ```
 
 ## Plugins
 
-Here is the [list of community plugins](https://meerschaum.io/reference/plugins/list-of-plugins/) and the [public plugins repository](https://api.mrsm.io/dash/plugins).
+Check out the [Awesome Meerschaum list](https://github.com/bmeares/awesome-meerschaum) for a list of community plugins as well as the [public plugins repository](https://api.mrsm.io/dash/plugins).
 
 For details on installing, using, and writing plugins, check out the [plugins documentation](https://meerschaum.io/reference/plugins/types-of-plugins) at [meerschaum.io](https://meerschaum.io).
 
@@ -123,12 +113,17 @@ def register(pipe, **kw):
     }
 
 def fetch(pipe, **kw):
-    import datetime, random
-    return {
-        'dt': [datetime.datetime.utcnow()],
-        'id': [1],
-        'val': [random.randint(0, 100)],
-    }
+    import random
+    from datetime import datetime
+    docs = [
+        {
+            'dt': datetime.now(),
+            'id': i,
+            'val': random.ranint(0, 200),
+        }
+        for i in range(random.randint(0, 100))
+    ]
+    return docs
 ```
 
 ## Support Meerschaum's Development

--- a/meerschaum/_internal/entry.py
+++ b/meerschaum/_internal/entry.py
@@ -118,6 +118,7 @@ def entry_with_args(
     return result
 
 
+_shells = []
 _shell = None
 def get_shell(
         sysargs: Optional[List[str]] = None,
@@ -141,4 +142,6 @@ def get_shell(
             _shell = shell_pkg.Shell(actions, sysargs=sysargs)
         elif reload:
             _shell.__init__()
+
+        _shells.append(_shell)
     return _shell

--- a/meerschaum/_internal/shell/ShellCompleter.py
+++ b/meerschaum/_internal/shell/ShellCompleter.py
@@ -24,7 +24,9 @@ class ShellCompleter(Completer):
         """
         Bridge the built-in cmd completer with the `prompt_toolkit` completer system.
         """
-        shell_actions = [a[3:] for a in dir(get_shell()) if a.startswith('do_')]
+        from meerschaum._internal.shell.Shell import shell_attrs
+        shell = get_shell()
+        shell_actions = [a[3:] for a in dir(shell) if a.startswith('do_')]
         yielded = []
         ensure_readline()
         parts = document.text.split('-')
@@ -32,7 +34,6 @@ class ShellCompleter(Completer):
         part_0_subbed_spaces = parts[0].replace(' ', '_')
         parsed_text = part_0_subbed_spaces + '-'.join(parts[1:])
 
-        shell = get_shell()
 
         ### Index is the rank order (0 is closest match).
         ### Break when no results are returned.
@@ -50,11 +51,14 @@ class ShellCompleter(Completer):
             yielded.append(poss)
 
         args = parse_line(document.text)
-        action_function = get_action(args['action'], _actions=shell._actions)
+        action_function = get_action(args['action'], _actions=shell_attrs.get('_actions', None))
         if action_function is None:
             return
 
-        main_action_name = get_main_action_name(args['action'], _actions=shell._actions)
+        main_action_name = get_main_action_name(
+            args['action'],
+            _actions = shell_attrs.get('_actions', None)
+        )
 
         ### If we haven't yet hit space, don't suggest subactions.
         if not parsed_text.replace(

--- a/meerschaum/actions/__init__.py
+++ b/meerschaum/actions/__init__.py
@@ -323,7 +323,8 @@ original_actions = actions.copy()
 from meerschaum._internal.entry import entry, get_shell
 import meerschaum.plugins
 make_action = meerschaum.plugins.make_action
-sync_hook = meerschaum.plugins.sync_hook
+pre_sync_hook = meerschaum.plugins.pre_sync_hook
+post_sync_hook = meerschaum.plugins.post_sync_hook
 
 ### Instruct pdoc to skip the `meerschaum.actions.plugins` subdirectory.
 __pdoc__ = {

--- a/meerschaum/actions/__init__.py
+++ b/meerschaum/actions/__init__.py
@@ -291,7 +291,6 @@ __all__ = ['actions', 'get_subactions', 'get_action', 'get_main_action_name', 'g
 ### functions that do not begin with '_' from all submodules.
 from inspect import getmembers, isfunction
 actions = {}
-"This docstring will be replaced in __pdoc__ at the end of this file."
 
 for module in modules:
     ### A couple important things happening here:
@@ -324,6 +323,7 @@ original_actions = actions.copy()
 from meerschaum._internal.entry import entry, get_shell
 import meerschaum.plugins
 make_action = meerschaum.plugins.make_action
+sync_hook = meerschaum.plugins.sync_hook
 
 ### Instruct pdoc to skip the `meerschaum.actions.plugins` subdirectory.
 __pdoc__ = {

--- a/meerschaum/actions/reload.py
+++ b/meerschaum/actions/reload.py
@@ -17,8 +17,5 @@ def reload(
     """
     Reload the running Meerschaum instance.
     """
-    from meerschaum.utils.packages import reload_package
-    from meerschaum.plugins import reload_plugins
-    reload_package('meerschaum')
-    reload_plugins(debug=debug)
-    return True, "Success"
+    from meerschaum.utils.packages import reload_meerschaum
+    return reload_meerschaum(debug=debug)

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -39,6 +39,7 @@ def show(
         'users'      : _show_users,
         'jobs'       : _show_jobs,
         'logs'       : _show_logs,
+        'tags'       : _show_tags,
     }
     return choose_subaction(action, show_options, **kw)
 
@@ -732,6 +733,40 @@ def _show_environment(
         },
         nopretty = nopretty,
     )
+    return True, "Success"
+
+
+def _show_tags(
+        tags: Optional[List[str]] = None,
+        nopretty: bool = False,
+        **kwargs
+    ) -> SuccessTuple:
+    """
+    Show the existing tags and their associated pipes.
+    """
+    from collections import defaultdict
+    import meerschaum as mrsm
+    from meerschaum.utils.formatting import pipe_repr
+    rich_tree = mrsm.attempt_import('rich.tree')
+    tree = rich_tree.Tree('Tags')
+    pipes = mrsm.get_pipes(as_list=True, **kwargs)
+
+    tags_pipes = defaultdict(lambda: [])
+
+    for pipe in pipes:
+        for tag in pipe.tags:
+            tags_pipes[tag].append(pipe)
+
+    sorted_tags = sorted([tag for tag in tags_pipes])
+    for tag in sorted_tags:
+        _pipes = tags_pipes[tag]
+        tag_branch = tree.add(tag)
+        for pipe in _pipes:
+            tag_branch.add(pipe_repr(pipe, as_rich_text=True))
+
+    mrsm.pprint(tree, nopretty=nopretty)
+
+
     return True, "Success"
 
 

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -425,6 +425,7 @@ def _wrap_pipe(
     else:
         sync_method = pipe.verify
         sync_kwargs['deduplicate'] = deduplicate
+    sync_kwargs['sync_method'] = sync_method
 
     for module_name, pre_sync_hooks in _pre_sync_hooks.items():
         plugin_name = module_name.split('.')[-1] if module_name.startswith('plugins.') else None

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -10,6 +10,7 @@ NOTE: `sync` required a SQL connection and is not intended for client use
 
 from __future__ import annotations
 from datetime import timedelta
+import meerschaum as mrsm
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Tuple, Union
 
 def sync(
@@ -403,30 +404,38 @@ def _wrap_pipe(
     import time
     from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.venv import Venv
-    from meerschaum.plugins import _sync_hooks
+    from meerschaum.plugins import _pre_sync_hooks, _post_sync_hooks
     from meerschaum.utils.misc import filter_keywords
 
     sync_start = time.perf_counter()
-    
+    sync_kwargs = {k: v for k, v in kw.items() if k != 'blocking'}
+    sync_kwargs.update({
+        'blocking': (not unblock),
+        'force': force,
+        'debug': debug,
+        'min_seconds': min_seconds,
+        'workers': workers,
+        'bounded': 'bounded',
+        'chunk_interval': chunk_interval,
+    })
+    if not verify and not deduplicate:
+        sync_method = pipe.sync
+    elif not verify and deduplicate:
+        sync_method = pipe.deduplicate
+    else:
+        sync_method = pipe.verify
+        sync_kwargs['deduplicate'] = deduplicate
+
+    for module_name, pre_sync_hooks in _pre_sync_hooks.items():
+        plugin_name = module_name.split('.')[-1] if module_name.startswith('plugins.') else None
+        plugin = mrsm.Plugin(plugin_name) if plugin_name else None
+        with Venv(plugin):
+            for pre_sync_hook in pre_sync_hooks:
+                _ = pre_sync_hook(pipe, **filter_keywords(pre_sync_hook, **sync_kwargs))
+   
     try:
         with Venv(get_connector_plugin(pipe.connector), debug=debug):
-            if not verify and not deduplicate:
-                sync_method = pipe.sync
-            elif not verify and deduplicate:
-                sync_method = pipe.deduplicate
-            else:
-                sync_method = pipe.verify
-                kw['deduplicate'] = deduplicate
-            return_tuple = sync_method(
-                blocking = (not unblock),
-                force = force,
-                debug = debug,
-                min_seconds = min_seconds,
-                workers = workers,
-                bounded = bounded,
-                chunk_interval = chunk_interval,
-                **{k: v for k, v in kw.items() if k != 'blocking'}
-            )
+            return_tuple = sync_method(**sync_kwargs)
     except Exception as e:
         import traceback
         traceback.print_exception(type(e), e, e.__traceback__)
@@ -434,10 +443,18 @@ def _wrap_pipe(
         return_tuple = (False, f"Failed to sync {pipe} with exception:" + "\n" + str(e))
 
     duration = time.perf_counter() - sync_start
-    for plugin_name, sync_hooks in _sync_hooks.items():
-        for sync_hook in sync_hooks:
-            _ = sync_hook(pipe, return_tuple, **filter_keywords(sync_hook, duration=duration))
-
+    sync_kwargs['duration'] = duration
+    for module_name, post_sync_hooks in _post_sync_hooks.items():
+        plugin_name = module_name.split('.')[-1] if module_name.startswith('plugins.') else None
+        plugin = mrsm.Plugin(plugin_name) if plugin_name else None
+        with Venv(plugin):
+            for post_sync_hook in post_sync_hooks:
+                _ = post_sync_hook(
+                    pipe,
+                    return_tuple,
+                    **filter_keywords(post_sync_hook, **sync_kwargs)
+                )
+ 
     return return_tuple
 
 

--- a/meerschaum/api/dash/keys.py
+++ b/meerschaum/api/dash/keys.py
@@ -85,7 +85,7 @@ action_dropdown_row = html.Div(
                                 ),
                                 dbc.Input(
                                     id = 'subaction-dropdown-text',
-                                    placeholder = 'Action arguments',
+                                    placeholder = 'Positional arguments',
                                     className = 'input-text',
                                 ),
                             ],
@@ -107,9 +107,9 @@ action_dropdown_row = html.Div(
                         dcc.Dropdown(
                             id = 'flags-dropdown',
                             multi = True,
-                            placeholder = 'Optional flags',
+                            placeholder = 'Boolean flags',
                             options = [],
-                            value = ['yes'],
+                            value = ['--yes'],
                         ),
                         id = 'flags-dropdown-div',
                         className = 'dbc_dark input-text',
@@ -119,64 +119,43 @@ action_dropdown_row = html.Div(
             ],
         ),
         html.Br(),
-        #  dbc.Row(
-            #  [
-                #  dbc.Col(
-                    #  html.Div(
-                        #  dcc.Dropdown(
-                            #  id = {'type': 'input-flags-dropdown', 'index': 0},
-                            #  multi = False,
-                            #  placeholder = 'Optional flags',
-                            #  options = [],
-                            #  value = ['yes'],
-                        #  ),
-                        #  id = 'flags-dropdown-div',
-                        #  className = 'dbc_dark input-text',
-                    #  ),
-                    #  width = widths['flags'],
-                    #  id = 'input-flags-left-col',
-                #  ),
-                #  dbc.Col(),
-            #  ],
-            #  id = 'input-flags-row',
-            #  className = 'input-text',
-        #  ),
-        #  dbc.Row(
-            #  children = [
-                #  dbc.Col(
-                    #  children = [
-                        #  html.Div(
-                            #  children = [
-                                #  dbc.Button(
-                                    #  'Additional parameters',
-                                    #  id = 'show-arguments-collapse-button',
-                                    #  color = 'link',
-                                    #  size = 'md',
-                                    #  outline = True,
-                                    #  style = {'display': 'none'},
-                                #  ),
-                                #  #  html.Br(),
-                                #  dbc.Collapse(
-                                    #  children = [
-                                        #  dbc.Button(
-                                            #  'Clear',
-                                            #  id = 'clear-begin-end-datepicker-button',
-                                            #  color = 'link',
-                                            #  size = 'sm',
-                                        #  ),
-                                        #  dcc.DatePickerRange(
-                                            #  id = 'begin-end-datepicker',
-                                        #  ),
-                                    #  ],
-                                    #  id = 'arguments-collapse',
-                                #  ),
-                            #  ], ### end of div children
-                        #  ),
-                    #  ], ### end of col children
-                    #  width = widths['arguments'],
-                #  ),
-            #  ], ### end of row children
-        #  ),
+        html.Div(id='input-flags-div'),
+        dbc.Row(
+            children = [
+                dbc.Col(
+                    children = [
+                        html.Div(
+                            children = [
+                                dbc.Button(
+                                    'Additional parameters',
+                                    id = 'show-arguments-collapse-button',
+                                    color = 'link',
+                                    size = 'md',
+                                    outline = True,
+                                    style = {'display': 'none'},
+                                ),
+                                #  html.Br(),
+                                dbc.Collapse(
+                                    children = [
+                                        dbc.Button(
+                                            'Clear',
+                                            id = 'clear-begin-end-datepicker-button',
+                                            color = 'link',
+                                            size = 'sm',
+                                        ),
+                                        dcc.DatePickerRange(
+                                            id = 'begin-end-datepicker',
+                                        ),
+                                    ],
+                                    id = 'arguments-collapse',
+                                ),
+                            ], ### end of div children
+                        ),
+                    ], ### end of col children
+                    width = widths['arguments'],
+                ),
+            ], ### end of row children
+        ),
     ], ### end of parent div children
     id = 'action-div',
 )

--- a/meerschaum/api/dash/pages/dashboard.py
+++ b/meerschaum/api/dash/pages/dashboard.py
@@ -54,16 +54,17 @@ layout = html.Div(
                                 id = 'pipes-filter-tabs',
                                 children = [
                                     dbc.Tab(
-                                        dropdown_tab_content, label='Filter',
-                                        id='pipes-filter-dropdown-tab',
-                                        tab_id='dropdown',
+                                        dropdown_tab_content,
+                                        label = 'Filter',
+                                        id = 'pipes-filter-dropdown-tab',
+                                        tab_id = 'dropdown',
                                     ),
                                     dbc.Tab(
                                         text_tab_content,
-                                        label='Text',
-                                        id='pipes-filter-input-tab',
-                                        tab_id='input',
-                                        tab_style={"display": "none"},
+                                        label = 'Text',
+                                        id = 'pipes-filter-input-tab',
+                                        tab_id = 'input',
+                                        tab_style = {"display": "none"},
                                     ),
                                 ]
                             ),

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -62,7 +62,15 @@ window.addEventListener(
     }
     flags = event.data['flags'] ? event.data['flags'] : [];
     for (fl of flags){
-        flags_str += " --" + fl;
+        flags_str += " " + fl;
+    }
+    // NOTE: Input flags are not quoted to allow for multiple arguments.
+    input_flags = event.data['input_flags'] ? event.data['input_flags'] : [];
+    for (const [index, fl] of input_flags.entries()){
+        if (!fl){ continue; }
+        fl_val = event.data['input_flags_texts'][index];
+        if (!fl_val){ continue; }
+        flags_str += " " + fl + " " + fl_val;
     }
 
     line = (

--- a/meerschaum/config/_edit.py
+++ b/meerschaum/config/_edit.py
@@ -6,9 +6,9 @@
 Functions for editing the configuration file
 """
 
-#  from meerschaum.utils.debug import dprint
 from __future__ import annotations
 import sys
+import pathlib
 from meerschaum.utils.typing import Optional, Any, SuccessTuple, Mapping, Dict, List, Union
 
 def edit_config(
@@ -21,7 +21,7 @@ def edit_config(
     from meerschaum.config import get_config, config
     from meerschaum.config._read_config import get_keyfile_path
     from meerschaum.config._paths import CONFIG_DIR_PATH
-    from meerschaum.utils.packages import reload_package
+    from meerschaum.utils.packages import reload_meerschaum
     from meerschaum.utils.misc import edit_file
     from meerschaum.utils.debug import dprint
 
@@ -35,10 +35,7 @@ def edit_config(
         get_config(k, write_missing=True, warn=False)
         edit_file(get_keyfile_path(k, create_new=True))
 
-    if debug:
-        dprint("Reloading configuration...")
-    reload_package('meerschaum', debug=debug, **kw)
-
+    reload_meerschaum(debug=debug)
     return (True, "Success")
 
 
@@ -78,7 +75,7 @@ def write_config(
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.yaml import yaml
     from meerschaum.utils.misc import filter_keywords
-    import json, os, pathlib
+    import json, os
     if config_dict is None:
         from meerschaum.config import _config
         cf = _config()
@@ -162,7 +159,6 @@ def general_write_yaml_config(
     """
 
     from meerschaum.utils.debug import dprint
-    from pathlib import Path
 
     if files is None:
         files = {}
@@ -172,7 +168,7 @@ def general_write_yaml_config(
         header = None
         if isinstance(value, tuple):
             config, header = value
-        path = Path(fp)
+        path = pathlib.Path(fp)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.touch(exist_ok=True)
         with open(path, 'w+') as f:
@@ -193,32 +189,12 @@ def general_write_yaml_config(
     return True
 
 def general_edit_config(
-        action : Optional[List[str]] = None,
-        files : Optional[Dict[str, Union[str, pathlib.Path]]] = None,
-        default : str = None,
-        debug : bool = False
+        action: Optional[List[str]] = None,
+        files: Optional[Dict[str, Union[str, pathlib.Path]]] = None,
+        default: Optional[str] = None,
+        debug: bool = False
     ):
-    """Edit any config files
-
-    Parameters
-    ----------
-    action : Optional[List[str]] :
-         (Default value = None)
-    files : Optional[Dict[str :
-        
-    Union[str :
-        
-    pathlib.Path]]] :
-         (Default value = None)
-    default : str :
-         (Default value = None)
-    debug : bool :
-         (Default value = False)
-
-    Returns
-    -------
-
-    """
+    """Prompt the user to edit any config files."""
     if default is None:
         raise Exception("Provide a default choice for which file to edit")
     import os

--- a/meerschaum/config/_formatting.py
+++ b/meerschaum/config/_formatting.py
@@ -35,6 +35,7 @@ default_formatting_config = {
         'running'          : '🟢',
         'paused'           : '🟡',
         'stopped'          : '🔴',
+        'tag'              : '🏷️',
     },
     'pipes'                : {
         'unicode'          : {
@@ -43,6 +44,7 @@ default_formatting_config = {
                 'metric'   : 'MRSM{formatting:emoji:metric} ',
                 'location' : 'MRSM{formatting:emoji:location} ',
                 'key'      : 'MRSM{formatting:emoji:key} ',
+                'tag'      : 'MRSM{formatting:emoji:tag} ',
             },
         },
         'ascii'            : {
@@ -51,6 +53,7 @@ default_formatting_config = {
                 'metric'   : '',
                 'location' : '',
                 'key'      : '',
+                'tag'      : '',
             },
         },
         'ansi'             : {
@@ -61,6 +64,7 @@ default_formatting_config = {
                 'key'      : '',
                 'guide'    : 'dim',
                 'none'     : 'black on magenta',
+                'tags'     : 'bold yellow underline',
             },
         },
         '__repr__'         : {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.3.dev2"
+__version__ = "2.1.3.dev3"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.3.dev1"
+__version__ = "2.1.3.dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.2"
+__version__ = "2.1.3.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.3.dev3"
+__version__ = "2.1.3"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -56,6 +56,8 @@ STATIC_CONFIG: Dict[str, Any] = {
         'dep_group': 'MRSM_DEP_GROUP',
         'home': 'MRSM_HOME',
         'src': 'MRSM_SRC',
+        'uid': 'MRSM_UID',
+        'gid': 'MRSM_GID',
         'noask': 'MRSM_NOASK',
         'id': 'MRSM_SERVER_ID',
         'uri_regex': r'MRSM_([a-zA-Z0-9]*)_(\d*[a-zA-Z][a-zA-Z0-9-_+]*$)',

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -257,7 +257,6 @@ def fetch_pipes_keys(
     tag_groups = [tag.split(',') for tag in tags]
     in_ex_tag_groups = [separate_negation_values(tag_group) for tag_group in tag_groups]
 
-    #  _in_tags, _ex_tags = separate_negation_values(tags)
     ors, nands = [], []
     for _in_tags, _ex_tags in in_ex_tag_groups:
         sub_ands = []

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -8,7 +8,7 @@ Retrieve Pipes' data from instances.
 
 from __future__ import annotations
 from datetime import datetime, timedelta
-from meerschaum.utils.typing import Optional, Dict, Any, Union, Generator
+from meerschaum.utils.typing import Optional, Dict, Any, Union, Generator, List, Tuple
 from meerschaum.config import get_config
 
 def get_data(
@@ -350,20 +350,20 @@ def get_backtrack_data(
         If begin is `None` (default), use the most recent observed datetime
         (AKA sync_time).
 
+        ```
+        E.g. begin = 02:00
+
+        Search this region.           Ignore this, even if there's data.
+        /  /  /  /  /  /  /  /  /  |
+        -----|----------|----------|----------|----------|----------|
+        00:00      01:00      02:00      03:00      04:00      05:00
+
+        ```
+
     params: Optional[Dict[str, Any]], default None
         The standard Meerschaum `params` query dictionary.
         
         
-    ```
-    E.g. begin = 02:00
-
-    Search this region.           Ignore this, even if there's data.
-    /  /  /  /  /  /  /  /  /  |
-    -----|----------|----------|----------|----------|----------|
-    00:00      01:00      02:00      03:00      04:00      05:00
-
-    ```
-
     fresh: bool, default False
         If `True`, Ignore local cache and pull directly from the instance connector.
         Only comes into effect if a pipe was created with `cache=True`.

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -15,8 +15,8 @@ from meerschaum.utils.warnings import warn
 
 def fetch(
         self,
-        begin: Optional[datetime.datetime, str] = '',
-        end: Optional[datetime.datetime] = None,
+        begin: Union[datetime, str, None] = '',
+        end: Optional[datetime] = None,
         check_existing: bool = True,
         sync_chunks: bool = False,
         debug: bool = False,
@@ -27,10 +27,10 @@ def fetch(
 
     Parameters
     ----------
-    begin: Optional[datetime.datetime, str], default '':
+    begin: Union[datetime, str, None], default '':
         If provided, only fetch data newer than or equal to `begin`.
 
-    end: Optional[datetime.datetime], default None:
+    end: Optional[datetime], default None:
         If provided, only fetch data older than or equal to `end`.
 
     check_existing: bool, default True

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -283,8 +283,8 @@ class Plugin:
         import tarfile
         import re
         import ast
-        from meerschaum.plugins import reload_plugins, sync_plugins_symlinks
-        from meerschaum.utils.packages import attempt_import, determine_version, reload_package
+        from meerschaum.plugins import sync_plugins_symlinks
+        from meerschaum.utils.packages import attempt_import, determine_version, reload_meerschaum
         from meerschaum.utils.venv import init_venv
         from meerschaum.utils.misc import safely_extract_tar
         old_cwd = os.getcwd()
@@ -415,8 +415,7 @@ class Plugin:
         if '_module' in self.__dict__:
             del self.__dict__['_module']
         init_venv(venv=self.name, force=True, debug=debug)
-        reload_package('meerschaum')
-        reload_plugins([self.name], debug=debug)
+        reload_meerschaum(debug=debug)
 
         ### if we've already failed, return here
         if not success or abort:
@@ -493,8 +492,8 @@ class Plugin:
         """
         Remove a plugin, its virtual environment, and archive file.
         """
-        from meerschaum.utils.packages import reload_package
-        from meerschaum.plugins import reload_plugins, sync_plugins_symlinks
+        from meerschaum.utils.packages import reload_meerschaum
+        from meerschaum.plugins import sync_plugins_symlinks
         from meerschaum.utils.warnings import warn, info
         warnings_thrown_count: int = 0
         max_warnings: int = 3
@@ -529,8 +528,7 @@ class Plugin:
         success = warnings_thrown_count < max_warnings
         sync_plugins_symlinks(debug=debug)
         self.deactivate_venv(force=True, debug=debug)
-        reload_package('meerschaum')
-        reload_plugins(debug=debug)
+        reload_meerschaum(debug=debug)
         return success, (
             f"Successfully uninstalled plugin '{self}'." if success
             else f"Failed to uninstall plugin '{self}'."

--- a/meerschaum/utils/__init__.py
+++ b/meerschaum/utils/__init__.py
@@ -8,10 +8,25 @@ These include tools from primary utilities (get_pipes)
 to miscellaneous helper functions.
 """
 
-### import_children will be depreciated in a future release.
-### Explicit is better than implicit (mostly).
-
-# from meerschaum.utils.packages import import_children
-# import_children()
-
+__all__ = (
+    'daemon',
+    'dataframe',
+    'debug',
+    'dtypes',
+    'formatting',
+    'interactive',
+    'misc',
+    'networking',
+    'packages',
+    'pool',
+    'process',
+    'prompt',
+    'schedule',
+    'sql',
+    'threading',
+    'typing',
+    'venv',
+    'warnings',
+    'yaml',
+)
 from meerschaum.utils.get_pipes import get_pipes

--- a/meerschaum/utils/daemon/__init__.py
+++ b/meerschaum/utils/daemon/__init__.py
@@ -3,7 +3,7 @@
 # vim:fenc=utf-8
 
 """
-Daemonize processes via daemoniker.
+Manage Daemons via the `Daemon` class.
 """
 
 from __future__ import annotations

--- a/meerschaum/utils/formatting/__init__.py
+++ b/meerschaum/utils/formatting/__init__.py
@@ -19,6 +19,7 @@ from meerschaum.utils.formatting._pipes import (
     format_pipe_success_tuple,
     print_pipes_results,
     extract_stats_from_message,
+    pipe_repr,
 )
 from meerschaum.utils.threading import Lock, RLock
 
@@ -39,6 +40,9 @@ __all__ = sorted([
     'highlight_pipes',
     'pprint_pipes',
     'make_header',
+    'pipe_repr',
+    'print_pipes_results',
+    'extract_stats_from_message',
 ])
 __pdoc__ = {}
 _locks = {

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -276,8 +276,8 @@ def pprint_pipe_columns(
 
 
 def pipe_repr(
-        pipe: 'meerschaum.Pipe',
-        as_rich_text: bool=False,
+        pipe: mrsm.Pipe,
+        as_rich_text: bool = False,
         ansi: Optional[bool] = None,
     ) -> Union[str, 'rich.text.Text']:
     """

--- a/meerschaum/utils/get_pipes.py
+++ b/meerschaum/utils/get_pipes.py
@@ -18,7 +18,7 @@ def get_pipes(
         connector_keys: Union[str, List[str], None] = None,
         metric_keys: Union[str, List[str], None] = None,
         location_keys: Union[str, List[str], None] = None,
-        tags: Optional[List[str], None] = None,
+        tags: Optional[List[str]] = None,
         params: Optional[Dict[str, Any]] = None,
         mrsm_instance: Union[str, InstanceConnector, None] = None,
         instance: Union[str, InstanceConnector, None] = None,

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -592,6 +592,7 @@ def is_valid_email(email: str) -> Union['re.Match', None]:
     regex = r'^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[.]\w{2,3}$'
     return re.search(regex, email)
 
+
 def string_width(string: str, widest: bool = True) -> int:
     """
     Calculate the width of a string, either by its widest or last line.
@@ -612,7 +613,7 @@ def string_width(string: str, widest: bool = True) -> int:
     --------
     >>> string_width('a')
     1
-    >>> string_width('a\nbc\nd')
+    >>> string_width('a\\nbc\\nd')
     2
 
     """

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -964,7 +964,7 @@ def run_python_package(
         capture_output: bool = False,
         debug: bool = False,
         **kw: Any,
-    ) -> Union[int, subprocess.Popen]:
+    ) -> Union[int, subprocess.Popen, None]:
     """
     Runs an installed python package.
     E.g. Translates to `/usr/bin/python -m [package]`
@@ -1001,7 +1001,7 @@ def run_python_package(
     Returns
     -------
     Either a return code integer or a `subprocess.Popen` object
-
+    (or `None` if a `KeyboardInterrupt` occurs and as_proc is `True`).
     """
     import sys, platform
     import subprocess
@@ -1060,7 +1060,7 @@ def attempt_import(
         check_is_installed: bool = True,
         color: bool = True,
         debug: bool = False
-    ) -> Union['ModuleType', Tuple['ModuleType']]:
+    ) -> Union[Any, Tuple[Any]]:
     """
     Raise a warning if packages are not installed; otherwise import and return modules.
     If `lazy` is `True`, return lazy-imported modules.

--- a/meerschaum/utils/schedule.py
+++ b/meerschaum/utils/schedule.py
@@ -18,7 +18,7 @@ def schedule_function(
     ) -> None:
     """
     Block the process and execute the function intermittently according to the frequency.
-    https://red-engine.readthedocs.io/en/stable/condition_syntax/index.html
+    https://rocketry.readthedocs.io/en/stable/condition_syntax/index.html
 
     Parameters
     ----------

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -362,7 +362,24 @@ def init_venv(
         return True
 
     import sys, platform, os, pathlib, shutil
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
+    venv_path = VIRTENV_RESOURCES_PATH / venv
+    docker_home_venv_path = pathlib.Path('/home/meerschaum/venvs/mrsm')
+
+    runtime_env_var = STATIC_CONFIG['environment']['runtime']
+    if (
+        not force
+        and venv == 'mrsm'
+        and os.environ.get(runtime_env_var, None) == 'docker'
+        and docker_home_venv_path.exists()
+    ):
+        shutil.move(docker_home_venv_path, venv_path)
+        if verify:
+            verify_venv(venv, debug=debug)
+            verified_venvs.add(venv)
+        return True
+
     from meerschaum.utils.packages import run_python_package, attempt_import
     global tried_virtualenv
     try:
@@ -372,7 +389,6 @@ def init_venv(
         _venv = None
         virtualenv = None
     
-    venv_path = VIRTENV_RESOURCES_PATH / venv
 
     _venv_success = False
     if _venv is not None:

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -285,8 +285,11 @@ def verify_venv(
         version = get_python_version(python_path)
         if version is None:
             continue
-        major_version = version.split('.', maxsplit=1)[0]
-        minor_version = version.split('.', maxsplit=2)[1]
+        try:
+            major_version = version.split('.', maxsplit=1)[0]
+            minor_version = version.split('.', maxsplit=2)[1]
+        except IndexError:
+            return
         python_versioned_name = (
             'python' + major_version + '.' + minor_version
             + ('' if platform.system() != 'Windows' else '.exe')

--- a/scripts/docker/buildx.sh
+++ b/scripts/docker/buildx.sh
@@ -11,6 +11,8 @@ cd "$PARENT"
 ### Run setup.sh to ensure everything is set up.
 
 mrsm_version=$($PYTHON_BIN -m meerschaum -V | sed 's/Meerschaum v//g')
+mrsm_uid=$(id -u $USER)
+mrsm_gid=$(id -g $USER)
 
 ./scripts/docker/update_requirements.sh
 
@@ -20,6 +22,8 @@ for tag in "${tags[@]}"; do
 
   docker buildx build ${push:-} \
     --build-arg dep_group="$tag" \
+    --build-arg mrsm_uid="$mrsm_uid" \
+    --build-arg mrsm_gid="$mrsm_gid" \
     --platform "$platforms" \
     -t "$image:$tag" -t "$image:$mrsm_version-$tag" ${tag_latest:-} \
     . || exit 1

--- a/scripts/docker/dev.sh
+++ b/scripts/docker/dev.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+pip install --user -e /app/
+/scripts/sleep_forever.sh

--- a/scripts/docker/image_setup.sh
+++ b/scripts/docker/image_setup.sh
@@ -1,8 +1,8 @@
 #! /usr/bin/env bash
 
 ### Create the user and home directory.
-groupadd -r $MRSM_USER \
-  && useradd -r -g $MRSM_USER $MRSM_USER \
+groupadd -r $MRSM_USER -g $MRSM_GID \
+  && useradd $MRSM_USER -u $MRSM_UID -g $MRSM_GID -m -s /bin/bash \
   && mkdir -p $MRSM_HOME \
   && mkdir -p $MRSM_WORK_DIR \
   && chown -R $MRSM_USER:$MRSM_USER $MRSM_HOME \
@@ -83,6 +83,8 @@ if ! shopt -oq posix; then
   fi
 fi
 
+alias sleep-forever="trap exit TERM; while true; do sleep 1; done"
+export PATH="$PATH:$HOME/.local/bin"
 
 RESET="\e[0m"
 export PS1="\n \[$(tput bold)\]\u\[$(tput sgr0)\]\[$(tput sgr0)\]\[\033[38;5;7m\]@\[$(tput sgr0)\]\[\033[38;5;183m\]\[$(tput bold)\]\H\[$(tput sgr0)\]\[$(tput sgr0)\]\[\033[38;5;15m\]\n \[$(tput sgr0)\]\[\033[38;5;2m\][\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;6m\]\W\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;2m\]]\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]\[\033[38;5;10m\]\\$\[$(tput sgr0)\]\[\033[38;5;15m\] \[$(tput sgr0)\]"

--- a/scripts/docker/sleep_forever.sh
+++ b/scripts/docker/sleep_forever.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+trap "exit" TERM; while true; do sleep 1; done

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -3,6 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "$DIR"/config.sh
 
+[ -z "$PYTHON_BIN" ] && PYTHON_BIN="python"
+
 cd "$PARENT"
 
 ### Update the root changelog to match the mkdocs changelog.
@@ -12,8 +14,8 @@ cat "$PARENT"/docs/mkdocs/news/changelog.md > "$PARENT"/CHANGELOG.md
 cat "$PARENT"/docs/mkdocs/news/acknowledgements.md > "$PARENT"/ACKNOWLEDGEMENTS.md
 
 ### Build technical documentation.
-python -m pdoc --html --output-dir docs/pdoc meerschaum -f
+PDOC_ALLOW_EXEC=1 $PYTHON_BIN -m pdoc -o docs/pdoc -d numpy -n --favicon https://meerschaum.io/assets/logo.ico --logo https://meerschaum.io/assets/logo_48x48.png ./meerschaum/
 
 ### Build general documentation.
 cd "$PARENT"/docs
-python -m mkdocs build
+$PYTHON_BIN -m mkdocs build

--- a/scripts/pdoc.sh
+++ b/scripts/pdoc.sh
@@ -3,7 +3,9 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "$DIR"/config.sh
 
+[ -z "$PYTHON_BIN" ] && PYTHON_BIN='python'
+[ -z "$PDOC_ALLOW_EXEC" ] && export PDOC_ALLOW_EXEC=1
+
 ### Build technical documentation
 cd "$PARENT"
-python -m pdoc --http : meerschaum
-
+$PYTHON_BIN -m pdoc -d numpy -n --favicon https://meerschaum.io/assets/logo.ico --logo https://meerschaum.io/assets/logo_48x48.png ./meerschaum/

--- a/tests/plugins/stress.py
+++ b/tests/plugins/stress.py
@@ -6,7 +6,7 @@
 Stress test for pipes.
 """
 
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 
 import datetime, random, math
 import meerschaum as mrsm


### PR DESCRIPTION
# v2.1.3

- **Add the decorators `@pre_sync_hook` and `@post_sync_hook`.**  
  The new decorators `@pre_sync_hook` and `@post_sync_hook` let you intercept a Pipe immediately before and after a sync, capturing its return tuple and the duration in seconds.

  ```python
  import meerschaum as mrsm
  from meerschaum.plugins import pre_sync_hook, post_sync_hook

  @pre_sync_hook
  def prepare_for_sync(pipe: mrsm.Pipe, **kwargs):
      print(f"About to sync {pipe} with kwargs:\n{kwargs}")

  @post_sync_hook
  def log_sync(
          pipe: mrsm.Pipe,
          return_tuple: mrsm.SuccessTuple,
          duration: float = 0.0
      ):
      print(f"It took {round(duration, 2)} seconds to sync {pipe} with result:")
      mrsm.pprint(return_tuple)
  ```

- **Add the action `show tags`.**  
  The action `show tags` will now display panels of pipes grouped together by common tags. This is useful for large deployments which share common tags.

- **Add dropdowns and inputs for flags with arguments to the Web Console.**  
  Leverage the full power of the Meerschaum CLI in the Web Console with the new dynamic flags dropdowns.

- **Fix shell crashes in Docker containers.**  
  Reloading the running Meerschaum session from an interactive shell via a Docker container will no longer cause crashes on custom commands.

- **Improve reloading times.**  
  Reloading the running Meerschaum session has been sped up by several seconds (due to skipping the internal shell modules).

- **Improve virtual environments in the Docker image.**  
  Initial startup of Docker containers on a fresh persistent volume has been sped up due to preloading the default virtual environment creation. Additionally, the environment variable `$MRSM_VENVS_DIR` has been unset, reverting the virtual environments to be stored under `/meerschaum/venvs`.