### PR TITLE
🔧 v2.1.6 Improve sync hooks, allow index-only upserts, and bugfixes.

### DIFF
--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"

--- a/meerschaum/connectors/sql/tables/__init__.py
+++ b/meerschaum/connectors/sql/tables/__init__.py
@@ -214,22 +214,6 @@ def create_tables(
     from meerschaum.utils.sql import get_rename_table_queries, table_exists
     _tables = tables if tables is not None else get_tables(conn)
 
-    rename_queries = []
-    for table_key, table in _tables.items():
-        if table_exists(
-            table_key,
-            conn,
-            schema = conn.instance_schema,
-        ):
-            rename_queries.extend(get_rename_table_queries(
-                table_key,
-                table.name,
-                schema = conn.instance_schema,
-                flavor = conn.flavor,
-            ))
-    if rename_queries:
-        conn.exec_queries(rename_queries)
-
     try:
         conn.metadata.create_all(bind=conn.engine)
     except Exception as e:

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -8,7 +8,7 @@ Retrieve Pipes' data from instances.
 
 from __future__ import annotations
 from datetime import datetime, timedelta
-from meerschaum.utils.typing import Optional, Dict, Any, Union, Generator, List, Tuple
+from meerschaum.utils.typing import Optional, Dict, Any, Union, Generator, List, Tuple, Iterator
 from meerschaum.config import get_config
 
 def get_data(
@@ -247,7 +247,7 @@ def _get_data_as_iterator(
         fresh: bool = False,
         debug: bool = False,
         **kw: Any
-    ) -> Generator['pd.DataFrame']:
+    ) -> Iterator['pd.DataFrame']:
     """
     Return a pipe's data as a generator.
     """
@@ -267,16 +267,17 @@ def _get_data_as_iterator(
 
     _ = kw.pop('as_chunks', None)
     _ = kw.pop('as_iterator', None)
+    dt_col = self.columns.get('datetime', None)
     min_dt = (
         begin
         if begin is not None
         else self.get_sync_time(round_down=False, newest=False, params=params, debug=debug)
-    )
+    ) if dt_col else None
     max_dt = (
         end
         if end is not None
         else self.get_sync_time(round_down=False, newest=True, params=params, debug=debug)
-    )
+    ) if dt_col else None
 
     ### We want to search just past the maximum value.
     if end is None:

--- a/meerschaum/utils/typing.py
+++ b/meerschaum/utils/typing.py
@@ -87,3 +87,14 @@ PipesDict = Dict[
     ]
 ]
 WebState = Dict[str, str]
+
+def is_success_tuple(x: Any) -> bool:
+    """
+    Determine whether an object is a `SuccessTuple`.
+    """
+    return (
+        isinstance(x, tuple)
+        and len(x) == 2
+        and isinstance(x[0], bool)
+        and isinstance(x[1], str)
+    )


### PR DESCRIPTION
# v2.1.6

- **Move `success_tuple` from arg to kwarg for `@post_sync_hook` functions.**  
  To match the signature of `@pre_sync_hook` functions, `@post_sync_hook` functions now only accept `pipe` as the positional argument. The return value of the sync will now be passed as the kwarg `success_tuple`. This allows you to use the same callback function as both the pre- and post-sync hooks.

  ```python
  import meerschaum as mrsm
  from meerschaum.plugins import pre_sync_hook, post_sync_hook

  @pre_sync_hook
  @post_sync_hook
  def log_sync(
          pipe: mrsm.Pipe,
          success_tuple: mrsm.SuccessTuple | None = None,
      ):
      if success_tuple is None:
          print(f"About to sync {pipe}!")
      else:
          success, msg = success_tuple
          print(f"Finished syncing {pipe} with message:\n{msg}")
  ```

- **Add `sync_timestamp` and `sync_complete_timestamp` to sync hooks.**  
  The UTC datetime right before the sync is added to the sync hook kwargs, allowing for linking the two callbacks to the same datetime. For convenience, the UTC datetime is also captured at the end of the sync and is passed as `sync_complete_timestamp`.

  ```python
  from datetime import datetime
  import meerschaum as mrsm
  from meerschaum.plugins import pre_sync_hook, post_sync_hook

  @pre_sync_hook
  @post_sync_hook
  def log_sync(
          pipe: mrsm.Pipe,
          sync_timestamp: datetime | None = None,
          sync_complete_timestamp: datetime | None = None,
          sync_duration: float | None = None,
      ) -> mrsm.SuccessTuple:

      if sync_complete_timestamp is None:
          print(f"About to sync {pipe} at {sync_timestamp}.")
          return True, "Success"

      msg = (
          f"It took {sync_duration} seconds to sync {pipe}:\n"
          + "({sync_timestamp} - {sync_complete_timestamp})"
      )
      return True, msg
  ```

- **Improved performance of sync hooks.**  
  Sync hooks are now called asynchronously in their own threads to avoid slowing down or crashing the main thread.

- **Rename `duration` to `sync_duration` for sync hooks.**  
  To avoid potential conflicts, the kwarg `duration` is prefixed with `sync_` to denote that it was specifically added to provide context on the sync.

- **Allow for sync hooks to return `SuccessTuple`.**  
  If a sync hook returns a `SuccessTuple` (`Tuple[bool, str]`), the result will be printed.

  ```python
  import meerschaum as mrsm
  from meerschaum.plugins import post_sync_hook

  @post_sync_hook
  def log_sync(pipe) -> mrsm.SuccessTuple:
      return True, f"Logged sync for {pipe}."
  ```

- **Add `is_success_tuple()` to `meerschaum.utils.typing`.**  
  You can now quickly check whether an object is a `SuccessTuple`:

  ```python
  from meerschaum.utils.typing import is_success_tuple
  assert is_success_tuple((True, "Success"))
  assert not is_success_tuple(("foo", "bar"))
  ```

- **Allow for index-only pipes when `upsert=True`.**  
  If all columns are indices and `upsert` is `True`, then the upsert will insert net-new rows (ignore duplicates).

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe(
      'a', 'b',
      columns = ['a', 'b'],
      parameters = {'upsert': True},
      instance = 'sql:local',
  )
  pipe.sync([{'a': 1, 'b': 2}])
  ```

- **Allow for prelimary null index support for `upsert=True` (inserts only, PostgreSQL only).**  
  Like with regular syncs, upsert syncs now coalesce indices to allow for syncing null values. **NOTE:** the transaction will fail if a null index is synced again, so this is only for the initial insert.

- **Remove automatic instance table renaming.**  
  This patch removes automatic detection and renaming of old instance tables to the new names (e.g. `users` -> `mrsm_users`). Users migrating from an old installation will need to rename the tables manually themselves.