### PR TITLE
✨ v2.1.7 Add `query_df()`, improve JSON filtering and shell startup time, and more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.1.7
+
+- **Add `query_df()` to `meerschaum.utils.dataframe`.**  
+  The function `query_df()` allows you to filter dataframes by `params`, `begin`, and `end`.
+
+  ```python
+  import pandas as pd
+  df = pd.DataFrame([
+      {'a': 1, 'color': 'red'},
+      {'a': 2, 'color': 'blue'},
+      {'a': 3, 'color': 'green'},
+      {'a': 4, 'color': 'yellow'},
+  ])
+
+  from meerschaum.utils.dataframe import query_df
+  query_df(df, {'color': ['red', 'yellow']})
+  #    a   color
+  # 0  1     red
+  # 3  4  yellow
+  query_df(df, {'color': '_blue'}, reset_index=True)
+  #    a   color
+  # 0  1     red
+  # 1  3   green
+  # 2  4  yellow
+  query_df(df, {'a': 2}, select_columns=['color'])
+  #   color
+  # 1  blue
+  ```
+- **Add `get_in_ex_params()` to `meerschaum.utils.misc`.**  
+  This function parses a standard `params` dictionary into tuples of include and exclude parameters.
+
+  ```python
+  from meerschaum.utils.misc import get_in_ex_params
+  params = {'color': ['red', '_blue', 'green']}
+  in_ex_params = get_in_ex_params(params)
+  in_ex_params
+  # {'color': (['red', 'green'], ['blue'])}
+  in_vals, ex_vals = in_ex_params['color']
+  ```
+- **Add `coerce_numeric` to `pipe.enforce_dtypes()`.**  
+  Setting this to `False` will not cast floats to `Decimal` if the corresponding dtype is `int`.
+- **Improve JSON serialization when filtering for updates.**
+- **Add `date_bound_only` to `pipe.filter_existing()`.**  
+  The argument `date_bound_only` means that samples retrieved by `pipe.get_data()` will only use `begin` and `end` for bounding. This may improve performance for custom instance connectors which have limited searchability.
+- **Add `safe_copy` to `pipe.enforce_types()`, `pipe.filter_existing()`, `filter_unseen_df()`.**  
+  By default, these functions will create copies of dataframes to avoid mutating the input dataframes. Setting `safe_copy` to `False` may be more memory efficient.
+- **Add multiline support to `extract_stats_from_message`.**  
+  Multiple messages separated by newlines may be parsed at once.
+  ```python
+  from meerschaum.utils.formatting import extract_stats_from_message
+  extract_stats_from_message("Inserted 10, upserted 3\ninserted 11, upserted 4")
+  # {'inserted': 21, 'updated': 0, 'upserted': 7}
+  ```
+- **Remove `order by` check in SQL queries.**
+- **Improve shell startup performance by removing support for `cmd2`.**  
+  The package `cmd2` never behaved properly, so support has been removed and only the built-in `cmd` powers the shell. As such, the configuration key `shell:cmd` has been removed.
+
 ### v2.1.6
 
 - **Move `success_tuple` from arg to kwarg for `@post_sync_hook` functions.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,63 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.1.7
+
+- **Add `query_df()` to `meerschaum.utils.dataframe`.**  
+  The function `query_df()` allows you to filter dataframes by `params`, `begin`, and `end`.
+
+  ```python
+  import pandas as pd
+  df = pd.DataFrame([
+      {'a': 1, 'color': 'red'},
+      {'a': 2, 'color': 'blue'},
+      {'a': 3, 'color': 'green'},
+      {'a': 4, 'color': 'yellow'},
+  ])
+
+  from meerschaum.utils.dataframe import query_df
+  query_df(df, {'color': ['red', 'yellow']})
+  #    a   color
+  # 0  1     red
+  # 3  4  yellow
+  query_df(df, {'color': '_blue'}, reset_index=True)
+  #    a   color
+  # 0  1     red
+  # 1  3   green
+  # 2  4  yellow
+  query_df(df, {'a': 2}, select_columns=['color'])
+  #   color
+  # 1  blue
+  ```
+- **Add `get_in_ex_params()` to `meerschaum.utils.misc`.**  
+  This function parses a standard `params` dictionary into tuples of include and exclude parameters.
+
+  ```python
+  from meerschaum.utils.misc import get_in_ex_params
+  params = {'color': ['red', '_blue', 'green']}
+  in_ex_params = get_in_ex_params(params)
+  in_ex_params
+  # {'color': (['red', 'green'], ['blue'])}
+  in_vals, ex_vals = in_ex_params['color']
+  ```
+- **Add `coerce_numeric` to `pipe.enforce_dtypes()`.**  
+  Setting this to `False` will not cast floats to `Decimal` if the corresponding dtype is `int`.
+- **Improve JSON serialization when filtering for updates.**
+- **Add `date_bound_only` to `pipe.filter_existing()`.**  
+  The argument `date_bound_only` means that samples retrieved by `pipe.get_data()` will only use `begin` and `end` for bounding. This may improve performance for custom instance connectors which have limited searchability.
+- **Add `safe_copy` to `pipe.enforce_types()`, `pipe.filter_existing()`, `filter_unseen_df()`.**  
+  By default, these functions will create copies of dataframes to avoid mutating the input dataframes. Setting `safe_copy` to `False` may be more memory efficient.
+- **Add multiline support to `extract_stats_from_message`.**  
+  Multiple messages separated by newlines may be parsed at once.
+  ```python
+  from meerschaum.utils.formatting import extract_stats_from_message
+  extract_stats_from_message("Inserted 10, upserted 3\ninserted 11, upserted 4")
+  # {'inserted': 21, 'updated': 0, 'upserted': 7}
+  ```
+- **Remove `order by` check in SQL queries.**
+- **Improve shell startup performance by removing support for `cmd2`.**  
+  The package `cmd2` never behaved properly, so support has been removed and only the built-in `cmd` powers the shell. As such, the configuration key `shell:cmd` has been removed.
+
 ### v2.1.6
 
 - **Move `success_tuple` from arg to kwarg for `@post_sync_hook` functions.**  

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -11,11 +11,7 @@ from copy import deepcopy
 from meerschaum.utils.typing import Union, SuccessTuple, Any, Callable, Optional, List, Dict
 from meerschaum.utils.packages import attempt_import
 from meerschaum.config import __doc__, __version__ as version, get_config
-cmd_import_name = get_config('shell', 'cmd')
-cmd_venv = None if cmd_import_name == 'cmd' else 'mrsm'
-cmd = attempt_import(cmd_import_name, venv=cmd_venv, warn=False, lazy=False)
-if cmd is None or isinstance(cmd, dict):
-    cmd = attempt_import('cmd', lazy=False, warn=False)
+import cmd
 _old_input = cmd.__builtins__['input']
 prompt_toolkit = attempt_import('prompt_toolkit', lazy=False, warn=False, install=True)
 (
@@ -53,7 +49,6 @@ hidden_commands = {
     'os',
     'sh',
     'pass',
-    'exit',
     'quit',
     'eof',
     'exit',

--- a/meerschaum/actions/api.py
+++ b/meerschaum/actions/api.py
@@ -44,7 +44,7 @@ def api(
         sysargs = []
     if len(action) == 0:
         info(api.__doc__)
-        return False, "Please provide a command to excecute (see above)."
+        return False, "Please provide a command to execute (see above)."
 
     boot_keywords = {'start', 'boot', 'init'}
     if action[0] in boot_keywords:

--- a/meerschaum/config/_shell.py
+++ b/meerschaum/config/_shell.py
@@ -126,7 +126,6 @@ default_shell_config = {
     'timeout'          : 60,
     'max_history'      : 1000,
     'clear_screen'     : True,
-    'cmd'              : default_cmd,
     'bottom_toolbar'   : {
         'enabled'      : True,
     },

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.6"
+__version__ = "2.1.7dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.1.7dev2"
+__version__ = "2.1.7"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1182,7 +1182,12 @@ def sync_pipe(
         dprint("Fetched data:\n" + str(df))
 
     if not isinstance(df, pd.DataFrame):
-        df = pipe.enforce_dtypes(df, chunksize=chunksize, debug=debug)
+        df = pipe.enforce_dtypes(
+            df,
+            chunksize = chunksize,
+            safe_copy = kw.get('safe_copy', False),
+            debug = debug,
+        )
 
     ### if table does not exist, create it with indices
     is_new = False
@@ -1226,6 +1231,7 @@ def sync_pipe(
     upsert = pipe.parameters.get('upsert', False) and (self.flavor + '-upsert') in update_queries
     if upsert:
         check_existing = False
+    kw['safe_copy'] = kw.get('safe_copy', False)
 
     unseen_df, update_df, delta_df = (
         pipe.filter_existing(

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -14,6 +14,7 @@ def enforce_dtypes(
         self,
         df: 'pd.DataFrame',
         chunksize: Optional[int] = -1,
+        safe_copy: bool = True,
         debug: bool = False,
     ) -> 'pd.DataFrame':
     """
@@ -71,7 +72,7 @@ def enforce_dtypes(
             )
         return df
 
-    return _enforce_dtypes(df, pipe_dtypes, debug=debug)
+    return _enforce_dtypes(df, pipe_dtypes, safe_copy=safe_copy, debug=debug)
 
 
 def infer_dtypes(self, persist: bool=False, debug: bool=False) -> Dict[str, Any]:

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1234,7 +1234,7 @@ def truncate_string_sections(item: str, delimeter: str = '_', max_len: int = 128
 
 
 def separate_negation_values(
-        vals: List[str],
+        vals: Union[List[str], Tuple[str]],
         negation_prefix: Optional[str] = None,
     ) -> Tuple[List[str], List[str]]:
     """
@@ -1243,7 +1243,7 @@ def separate_negation_values(
 
     Parameters
     ----------
-    vals: List[str]
+    vals: Union[List[str], Tuple[str]]
         A list of strings to parse.
 
     negation_prefix: Optional[str], default None
@@ -1261,6 +1261,38 @@ def separate_negation_values(
             _in_vals.append(v)
 
     return _in_vals, _ex_vals
+
+
+def get_in_ex_params(params: Optional[Dict[str, Any]]) -> Dict[str, Tuple[List[Any], List[Any]]]:
+    """
+    Translate a params dictionary into lists of include- and exclude-values.
+
+    Parameters
+    ----------
+    params: Optional[Dict[str, Any]]
+        A params query dictionary.
+
+    Returns
+    -------
+    A dictionary mapping keys to a tuple of lists for include and exclude values.
+
+    Examples
+    --------
+    >>> get_in_ex_params({'a': ['b', 'c', '_d', 'e', '_f']})
+    {'a': (['b', 'c', 'e'], ['d', 'f'])}
+    """
+    if not params:
+        return {}
+    return {
+        col: separate_negation_values(
+            (
+                val
+                if isinstance(val, (list, tuple))
+                else [val]
+            )
+        )
+        for col, val in params.items()
+    }
 
 
 def flatten_list(list_: List[Any]) -> List[Any]:

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -350,6 +350,7 @@ def determine_version(
     with _locks['import_versions']:
         if venv not in import_versions:
             import_versions[venv] = {}
+    import importlib.metadata
     import re, os
     old_cwd = os.getcwd()
     if debug:
@@ -1379,13 +1380,13 @@ def get_modules_from_package(
     Returns
     -------
     Either list of modules or tuple of lists.
-
     """
     from os.path import dirname, join, isfile, isdir, basename
     import glob
 
     pattern = '*' if recursive else '*.py'
-    module_names = glob.glob(join(dirname(package.__file__), pattern), recursive=recursive)
+    package_path = dirname(package.__file__ or package.__path__[0])
+    module_names = glob.glob(join(package_path, pattern), recursive=recursive)
     _all = [
         basename(f)[:-3] if isfile(f) else basename(f)
         for f in module_names
@@ -1410,7 +1411,7 @@ def get_modules_from_package(
             modules.append(m)
         except Exception as e:
             if debug:
-                dprint(e)
+                dprint(str(e))
         finally:
             if modules_venvs:
                 deactivate_venv(module_name.split('.')[-1], debug=debug)


### PR DESCRIPTION
# v2.1.7

- **Add `query_df()` to `meerschaum.utils.dataframe`.**  
  The function `query_df()` allows you to filter dataframes by `params`, `begin`, and `end`.

  ```python
  import pandas as pd
  df = pd.DataFrame([
      {'a': 1, 'color': 'red'},
      {'a': 2, 'color': 'blue'},
      {'a': 3, 'color': 'green'},
      {'a': 4, 'color': 'yellow'},
  ])

  from meerschaum.utils.dataframe import query_df
  query_df(df, {'color': ['red', 'yellow']})
  #    a   color
  # 0  1     red
  # 3  4  yellow
  query_df(df, {'color': '_blue'}, reset_index=True)
  #    a   color
  # 0  1     red
  # 1  3   green
  # 2  4  yellow
  query_df(df, {'a': 2}, select_columns=['color'])
  #   color
  # 1  blue
  ```
- **Add `get_in_ex_params()` to `meerschaum.utils.misc`.**  
  This function parses a standard `params` dictionary into tuples of include and exclude parameters.

  ```python
  from meerschaum.utils.misc import get_in_ex_params
  params = {'color': ['red', '_blue', 'green']}
  in_ex_params = get_in_ex_params(params)
  in_ex_params
  # {'color': (['red', 'green'], ['blue'])}
  in_vals, ex_vals = in_ex_params['color']
  ```
- **Add `coerce_numeric` to `pipe.enforce_dtypes()`.**  
  Setting this to `False` will not cast floats to `Decimal` if the corresponding dtype is `int`.
- **Improve JSON serialization when filtering for updates.**
- **Add `date_bound_only` to `pipe.filter_existing()`.**  
  The argument `date_bound_only` means that samples retrieved by `pipe.get_data()` will only use `begin` and `end` for bounding. This may improve performance for custom instance connectors which have limited searchability.
- **Add `safe_copy` to `pipe.enforce_types()`, `pipe.filter_existing()`, `filter_unseen_df()`.**  
  By default, these functions will create copies of dataframes to avoid mutating the input dataframes. Setting `safe_copy` to `False` may be more memory efficient.
- **Add multiline support to `extract_stats_from_message`.**  
  Multiple messages separated by newlines may be parsed at once.
  ```python
  from meerschaum.utils.formatting import extract_stats_from_message
  extract_stats_from_message("Inserted 10, upserted 3\ninserted 11, upserted 4")
  # {'inserted': 21, 'updated': 0, 'upserted': 7}
  ```
- **Remove `order by` check in SQL queries.**
- **Improve shell startup performance by removing support for `cmd2`.**  
  The package `cmd2` never behaved properly, so support has been removed and only the built-in `cmd` powers the shell. As such, the configuration key `shell:cmd` has been removed.