### PR TITLE
🐛 v2.2.1 Minor bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.2.1
+
+- **Fix `--schedule` in the interactive shell.**  
+  The `--schedule` flag may now be used from both the CLI and the Shell.
+
+- **Fix the `SQLConnector` CLI.**  
+  The `sql` action now correctly opens an interactive CLI.
+
+- **Bumped `duckdb` to `>=1.0.0`.**  
+  The upstream breaking changes that required `duckdb` to be held back have to do with how indices behave. For now, index creation has been disabled so that `duckdb` may be upgraded to 1.0+.
+
 ### v2.2.0
 
 **New Features**

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,17 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.2.1
+
+- **Fix `--schedule` in the interactive shell.**  
+  The `--schedule` flag may now be used from both the CLI and the Shell.
+
+- **Fix the `SQLConnector` CLI.**  
+  The `sql` action now correctly opens an interactive CLI.
+
+- **Bumped `duckdb` to `>=1.0.0`.**  
+  The upstream breaking changes that required `duckdb` to be held back have to do with how indices behave. For now, index creation has been disabled so that `duckdb` may be upgraded to 1.0+.
+
 ### v2.2.0
 
 **New Features**

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/meerschaum/connectors/__init__.py
+++ b/meerschaum/connectors/__init__.py
@@ -23,7 +23,14 @@ from meerschaum.connectors.sql.SQLConnector import SQLConnector
 from meerschaum.connectors.api.APIConnector import APIConnector
 from meerschaum.connectors.sql._create_engine import flavor_configs as sql_flavor_configs
 
-__all__ = ("Connector", "SQLConnector", "APIConnector", "get_connector", "is_connected")
+__all__ = (
+    "Connector",
+    "SQLConnector",
+    "APIConnector",
+    "get_connector",
+    "is_connected",
+    "poll",
+)
 
 ### store connectors partitioned by
 ### type, label for reuse

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -385,6 +385,9 @@ def get_create_index_queries(
     -------
     A dictionary of column names mapping to lists of queries.
     """
+    ### NOTE: Due to recent breaking changes in DuckDB, indices don't behave properly.
+    if self.flavor == 'duckdb':
+        return {}
     from meerschaum.utils.sql import (
         sql_item_name,
         get_distinct_col_count,
@@ -554,6 +557,9 @@ def get_drop_index_queries(
     -------
     A dictionary of column names mapping to lists of queries.
     """
+    ### NOTE: Due to breaking changes within DuckDB, indices must be skipped.
+    if self.flavor == 'duckdb':
+        return {}
     if not pipe.exists(debug=debug):
         return {}
     from meerschaum.utils.sql import sql_item_name, table_exists, hypertable_queries

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -60,8 +60,8 @@ packages: Dict[str, Dict[str, str]] = {
         'pymysql'                    : 'PyMySQL>=0.9.0',
         'aiomysql'                   : 'aiomysql>=0.0.21',
         'sqlalchemy_cockroachdb'     : 'sqlalchemy-cockroachdb>=2.0.0',
-        'duckdb'                     : 'duckdb<0.10.3',
-        'duckdb_engine'              : 'duckdb-engine>=0.9.2',
+        'duckdb'                     : 'duckdb>=1.0.0',
+        'duckdb_engine'              : 'duckdb-engine>=0.13.0',
     },
     'drivers-extras': {
         'pyodbc'                     : 'pyodbc>=4.0.30',

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -21,8 +21,8 @@ psycopg[binary]>=3.1.18
 PyMySQL>=0.9.0
 aiomysql>=0.0.21
 sqlalchemy-cockroachdb>=2.0.0
-duckdb<0.10.3
-duckdb-engine>=0.9.2
+duckdb>=1.0.0
+duckdb-engine>=0.13.0
 wheel>=0.34.2
 setuptools>=63.3.0
 PyYAML>=5.3.1

--- a/requirements/full.txt
+++ b/requirements/full.txt
@@ -33,8 +33,8 @@ psycopg[binary]>=3.1.18
 PyMySQL>=0.9.0
 aiomysql>=0.0.21
 sqlalchemy-cockroachdb>=2.0.0
-duckdb<0.10.3
-duckdb-engine>=0.9.2
+duckdb>=1.0.0
+duckdb-engine>=0.13.0
 toga>=0.3.0-dev29
 pywebview>=3.6.3
 pycparser>=2.21.0


### PR DESCRIPTION
# v2.2.1

- **Fix `--schedule` in the interactive shell.**  
  The `--schedule` flag may now be used from both the CLI and the Shell.

- **Fix the `SQLConnector` CLI.**  
  The `sql` action now correctly opens an interactive CLI.

- **Bumped `duckdb` to `>=1.0.0`.**  
  The upstream breaking changes that required `duckdb` to be held back have to do with how indices behave. For now, index creation has been disabled so that `duckdb` may be upgraded to 1.0+.