### PR TITLE
v2.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pyodide-xbuildenv/
 *.pem
 file_system_*
 *Zone.Identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.2.6
 
 - **Fix a critical login issue.**  
-  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is recommended you upgrade immediately.
+  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is urgent that you upgrade immediately.
+
+- **Add environment variable `MRSM_CONFIG_DIR`.**  
+  You may now isolate your configuration directory outside of the root (like with `MRSM_PLUGINS_DIR`, and `MRSM_VENVS_DIR`). This will be useful in certain production deployments where secrets need to be segmented and isolated.
 
 - **Add `register connector`.**  
   Like `bootstrap connector`, you may now programmatically create connectors.
@@ -24,6 +27,12 @@ This is the current release cycle, so stay tuned for future releases!
   __version__: str = '0.0.1'
   required: list[str] = ['requests']
   ```
+
+- **Automatically include `--noask` and `--yes` in remote actions.**  
+  For your convenience, the flags `--noask` and `--yes` are included in remote actions sent by `APIConnector.do_action()`.
+
+- **Fixed an issue with URIs for `api` connectors.**  
+  Creating an `APIConnector` via a URI connection string now properly handles the protocol.
 
 - **Fixed a formatting issue with `show logs`.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.2.6
 
+- **Fix a critical login issue.**  
+  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is recommended you upgrade immediately.
+
 - **Add `register connector`.**  
   Like `bootstrap connector`, you may now programmatically create connectors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.2.6
+
+- **Add `register connector`.**  
+  Like `bootstrap connector`, you may now programmatically create connectors.
+
+- **Allow for job names to contain spaces and parentheses.**  
+  Jobs may now be created with more dynamic names. This issue in particular affected Meerschaum Compose.
+
+- **Allow for type annotations in `required`.**  
+  Plugins may now annotate `required`:
+
+  ```python
+  # plugins/example.py
+
+  __version__: str = '0.0.1'
+  required: list[str] = ['requests']
+  ```
+
+- **Fixed a formatting issue with `show logs`.**
+
 ### v2.2.5
 
 - **Add `bootstrap plugin`.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -7,7 +7,10 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.2.6
 
 - **Fix a critical login issue.**  
-  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is recommended you upgrade immediately.
+  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is urgent that you upgrade immediately.
+
+- **Add environment variable `MRSM_CONFIG_DIR`.**  
+  You may now isolate your configuration directory outside of the root (like with `MRSM_PLUGINS_DIR`, and `MRSM_VENVS_DIR`). This will be useful in certain production deployments where secrets need to be segmented and isolated.
 
 - **Add `register connector`.**  
   Like `bootstrap connector`, you may now programmatically create connectors.
@@ -24,6 +27,12 @@ This is the current release cycle, so stay tuned for future releases!
   __version__: str = '0.0.1'
   required: list[str] = ['requests']
   ```
+
+- **Automatically include `--noask` and `--yes` in remote actions.**  
+  For your convenience, the flags `--noask` and `--yes` are included in remote actions sent by `APIConnector.do_action()`.
+
+- **Fixed an issue with URIs for `api` connectors.**  
+  Creating an `APIConnector` via a URI connection string now properly handles the protocol.
 
 - **Fixed a formatting issue with `show logs`.**
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -6,6 +6,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.2.6
 
+- **Fix a critical login issue.**  
+  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is recommended you upgrade immediately.
+
 - **Add `register connector`.**  
   Like `bootstrap connector`, you may now programmatically create connectors.
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,26 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.2.6
+
+- **Add `register connector`.**  
+  Like `bootstrap connector`, you may now programmatically create connectors.
+
+- **Allow for job names to contain spaces and parentheses.**  
+  Jobs may now be created with more dynamic names. This issue in particular affected Meerschaum Compose.
+
+- **Allow for type annotations in `required`.**  
+  Plugins may now annotate `required`:
+
+  ```python
+  # plugins/example.py
+
+  __version__: str = '0.0.1'
+  required: list[str] = ['requests']
+  ```
+
+- **Fixed a formatting issue with `show logs`.**
+
 ### v2.2.5
 
 - **Add `bootstrap plugin`.**  

--- a/docs/mkdocs/reference/environment.md
+++ b/docs/mkdocs/reference/environment.md
@@ -80,9 +80,13 @@ MRSM_PATCH='baz:MRSM{foo:bar}' \
   mrsm show config baz
 ```
 
+## **`MRSM_PLUGINS_DIR`**
+
+Like `MRSM_PLUGINS_DIR`, you can designate a separate directory outside of the root to isolate your secrets and segment your configuration.
+
 ## **`MRSM_VENVS_DIR`**  
 
-Like `MRSM_PLUGINS_DIR`, you can designate a separate directory outside of the Meerschaum root to contain virtual environments. Generally you should not need to set this, but this is useful for sharing virtual environments between deployments as well as separating package data from user data (e.g. Kubernetes deployments).
+Like `MRSM_PLUGINS_DIR`, you can designate a separate directory outside of the Meerschaum root to contain virtual environments. This is useful for sharing virtual environments between deployments as well as separating package data from user data (e.g. Kubernetes deployments).
 
 ```bash
 MRSM_VENVS_DIR='venvs/' mrsm show plugins

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -61,6 +61,7 @@ def parse_datetime(dt_str: str) -> Union[datetime, int, str]:
         error(f"'{dt_str}' is not a valid datetime format.", stack=False)
     return dt
 
+
 def parse_help(sysargs : Union[List[str], Dict[str, Any]]) -> None:
     """Parse the `--help` flag to determine which help message to print."""
     from meerschaum._internal.arguments._parse_arguments import parse_arguments, parse_line
@@ -97,13 +98,23 @@ def parse_help(sysargs : Union[List[str], Dict[str, Any]]) -> None:
         doc = "No help available for '" + f"{args['action'][0]}" + "'."
     return print(textwrap.dedent(doc))
 
-def parse_version(sysargs : List[str]):
+
+def parse_version(sysargs: List[str]):
     """Print the Meerschaum version."""
     from meerschaum.config import __version__ as version
     from meerschaum.config import __doc__ as doc
     if '--nopretty' in sysargs:
         return print(version)
     return print(doc)
+
+
+def parse_name(name_str: str) -> str:
+    """
+    Ensure that `--name` is not an empty string.
+    """
+    if not name_str:
+        return None
+    return name_str
 
 def get_arguments_triggers() -> Dict[str, Tuple[str]]:
     """ """
@@ -162,7 +173,7 @@ groups['actions'].add_argument(
     '--rm', action='store_true', help="Delete a job once it has finished executing."
 )
 groups['actions'].add_argument(
-    '--name', '--job-name', type=str, help=(
+    '--name', '--job-name', type=parse_name, help=(
         "Assign a name to a job. If no name is provided, a random name will be assigned."
     ),
 )

--- a/meerschaum/_internal/term/__init__.py
+++ b/meerschaum/_internal/term/__init__.py
@@ -22,7 +22,7 @@ tornado, tornado_ioloop, terminado = attempt_import(
 
 def get_webterm_app_and_manager() -> Tuple[
         tornado.web.Application,
-        terminado.UniqueTermManager, 
+        terminado.UniqueTermManager,
     ]:
     """
     Construct the Tornado web app and term manager from the provided sysargs.
@@ -47,7 +47,7 @@ def get_webterm_app_and_manager() -> Tuple[
             {'term_manager': term_manager}
         ),
         (
-            r"/", 
+            r"/",
             TermPageHandler
         ),
     ]

--- a/meerschaum/actions/bootstrap.py
+++ b/meerschaum/actions/bootstrap.py
@@ -221,18 +221,17 @@ def _bootstrap_pipes(
     return (successes > 0), msg
 
 def _bootstrap_connectors(
-        action : Optional[List[str]] = None,
-        connector_keys : Optional[List[str]] = None,
-        yes : bool = False,
-        force : bool = False,
-        noask : bool = False,
-        debug : bool = False,
-        return_keys : bool = False,
-        **kw : Any
-    ) -> Union[SuccessTuple, Tuple[str, str]]:
+    action: Optional[List[str]] = None,
+    connector_keys: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    return_keys: bool = False,
+    **kw: Any
+) -> Union[SuccessTuple, Tuple[str, str]]:
     """
     Prompt the user for the details necessary to create a Connector.
-
     """
     from meerschaum.connectors.parse import is_valid_connector_keys
     from meerschaum.connectors import connectors, get_connector, types, custom_types
@@ -386,10 +385,10 @@ def _bootstrap_connectors(
 
 
 def _bootstrap_plugins(
-        action: Optional[List[str]] = None,
-        debug: bool = False,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    debug: bool = False,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Launch an interactive wizard to guide the user to creating a new plugin.
     """

--- a/meerschaum/actions/python.py
+++ b/meerschaum/actions/python.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional
 
 def python(
-        action: Optional[List[str]] = None,
-        sub_args: Optional[List[str]] = None,
-        nopretty: bool = False,
-        noask: bool = False,
-        venv: Optional[str] = None,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    sub_args: Optional[List[str]] = None,
+    nopretty: bool = False,
+    noask: bool = False,
+    venv: Optional[str] = None,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Launch a virtual environment's Python interpreter with Meerschaum imported.
     You may pass flags to the Python binary by surrounding each flag with `[]`.
@@ -55,6 +55,9 @@ def python(
 
     if action is None:
         action = []
+
+    if noask:
+        nopretty = True
 
     joined_actions = (
         ["import meerschaum as mrsm"]

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -48,9 +48,9 @@ def show(
 
 
 def _complete_show(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> List[str]:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> List[str]:
     """
     Override the default Meerschaum `complete_` function.
     """
@@ -253,16 +253,16 @@ def _show_connectors(
 
 
 def _complete_show_connectors(
-        action: Optional[List[str]] = None, **kw: Any
-    ) -> List[str]:
+    action: Optional[List[str]] = None, **kw: Any
+) -> List[str]:
     from meerschaum.utils.misc import get_connector_labels
     _text = action[0] if action else ""
     return get_connector_labels(search_term=_text, ignore_exact_match=True)
 
 
 def _show_arguments(
-        **kw: Any
-    ) -> SuccessTuple:
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the parsed keyword arguments.
     """
@@ -272,16 +272,16 @@ def _show_arguments(
 
 
 def _show_data(
-        action: Optional[List[str]] = None,
-        gui: bool = False,
-        begin: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
-        params: Optional[Dict[str, Any]] = None,
-        chunksize: Optional[int] = -1,
-        nopretty: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    gui: bool = False,
+    begin: Optional[datetime.datetime] = None,
+    end: Optional[datetime.datetime] = None,
+    params: Optional[Dict[str, Any]] = None,
+    chunksize: Optional[int] = -1,
+    nopretty: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show pipes data as Pandas DataFrames.
     
@@ -380,11 +380,11 @@ def _show_data(
 
 
 def _show_columns(
-        action: Optional[List[str]] = None,
-        debug: bool = False,
-        nopretty: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    debug: bool = False,
+    nopretty: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the registered and table columns for pipes.
     """
@@ -398,11 +398,11 @@ def _show_columns(
 
 
 def _show_rowcounts(
-        action: Optional[List[str]] = None,
-        workers: Optional[int] = None,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    workers: Optional[int] = None,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the rowcounts for pipes.
     
@@ -439,12 +439,12 @@ def _show_rowcounts(
     return True, "Success"
 
 def _show_plugins(
-        action: Optional[List[str]] = None,
-        repository: Optional[str] = None,
-        nopretty: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    repository: Optional[str] = None,
+    nopretty: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the installed plugins.
     """
@@ -481,10 +481,10 @@ def _show_plugins(
     return True, "Success"
 
 def _show_users(
-        mrsm_instance: Optional[str] = None,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    mrsm_instance: Optional[str] = None,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the registered users in a Meerschaum instance (default is the current instance).
     """
@@ -504,10 +504,10 @@ def _show_users(
     return True, "Success"
 
 def _show_packages(
-        action: Optional[List[str]] = None,
-        nopretty: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    nopretty: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the packages in dependency groups, or as a list with `--nopretty`.
     """
@@ -536,9 +536,9 @@ def _show_packages(
     return True, "Success"
 
 def _complete_show_packages(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> List[str]:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> List[str]:
     from meerschaum.utils.packages import packages
     if not action:
         return sorted(list(packages.keys()))
@@ -551,10 +551,10 @@ def _complete_show_packages(
     return possibilities
 
 def _show_jobs(
-        action: Optional[List[str]] = None,
-        nopretty: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    nopretty: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Show the currently running and stopped jobs.
     """
@@ -578,10 +578,10 @@ def _show_jobs(
 
 
 def _show_logs(
-        action: Optional[List[str]] = None,
-        nopretty: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    nopretty: bool = False,
+    **kw
+) -> SuccessTuple:
     """
     Show the logs for jobs.
     
@@ -613,13 +613,15 @@ def _show_logs(
     now_follow_str = now.strftime(follow_timestamp_format)
 
     def build_buffer_spaces(daemons) -> Dict[str, str]:
-        max_len_id = max(len(d.daemon_id) for d in daemons) if daemons else 0
+        max_len_id = (
+            max(len(d.daemon_id) for d in daemons) + 1
+        ) if daemons else 0
         buffer_len = max(
             get_config('jobs', 'logs', 'min_buffer_len'),
-            max_len_id 
+            max_len_id
         )
         return {
-            d.daemon_id: ''.join([' ' for i in range(buffer_len - len(d.daemon_id))])
+            d.daemon_id: ''.join([' '] * (buffer_len - len(d.daemon_id)))
             for d in daemons
         }
 
@@ -769,9 +771,9 @@ def _show_logs(
 
 
 def _show_environment(
-        nopretty: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    nopretty: bool = False,
+    **kw
+) -> SuccessTuple:
     """
     Show all of the current environment variables with begin with `'MRSM_'`.
     """
@@ -789,12 +791,12 @@ def _show_environment(
 
 
 def _show_tags(
-        action: Optional[List[str]] = None,
-        tags: Optional[List[str]] = None,
-        workers: Optional[int] = None,
-        nopretty: bool = False,
-        **kwargs
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    tags: Optional[List[str]] = None,
+    workers: Optional[int] = None,
+    nopretty: bool = False,
+    **kwargs
+) -> SuccessTuple:
     """
     Show the existing tags and their associated pipes.
     """
@@ -869,10 +871,10 @@ def _show_tags(
 
 
 def _show_schedules(
-        action: Optional[List[str]] = None,
-        nopretty: bool = False,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    nopretty: bool = False,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Print the upcoming timestamps according to the given schedule.
 
@@ -920,8 +922,8 @@ def _show_schedules(
         
 
 def _show_venvs(
-        **kwargs: Any    
-    ):
+    **kwargs: Any    
+):
     """
     Print the available virtual environments in the current MRSM_ROOT_DIR.
     """

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -91,7 +91,13 @@ def _show_actions(**kw: Any) -> SuccessTuple:
     from meerschaum.utils.misc import print_options
     from meerschaum._internal.shell.Shell import hidden_commands
     _actions = [ _a for _a in actions if _a not in hidden_commands ]
-    print_options(options=_actions, name='actions', actions=False, **kw)
+    print_options(
+        options=_actions,
+        name='actions',
+        actions=False,
+        sort_options=True,
+        **kw
+    )
     return True, "Success"
 
 

--- a/meerschaum/actions/stop.py
+++ b/meerschaum/actions/stop.py
@@ -21,9 +21,9 @@ def stop(action: Optional[List[str]] = None, **kw) -> SuccessTuple:
 
 
 def _complete_stop(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> List[str]:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> List[str]:
     """
     Override the default Meerschaum `complete_` function.
     """
@@ -49,14 +49,14 @@ def _complete_stop(
 
 
 def _stop_jobs(
-        action: Optional[List[str]] = None,
-        timeout_seconds: Optional[int] = None,
-        noask: bool = False,
-        force: bool = False,
-        yes: bool = False,
-        nopretty: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    timeout_seconds: Optional[int] = None,
+    noask: bool = False,
+    force: bool = False,
+    yes: bool = False,
+    nopretty: bool = False,
+    **kw
+) -> SuccessTuple:
     """
     Stop running jobs that were started with `-d` or `start job`.
     

--- a/meerschaum/api/dash/pages/login.py
+++ b/meerschaum/api/dash/pages/login.py
@@ -31,7 +31,7 @@ registration_div = html.Div(
         else [
             dcc.Markdown("""
                 #### **Web registration is disabled for security.**
-                You can still register users on this instance with a SQL connector.
+                You can register users via the CLI with `mrsm register user`.
             """),
             dbc.Button(
                 'More information.',
@@ -80,6 +80,7 @@ layout = dbc.Container([
     html.Br(),
     dbc.Container([
         dcc.Location(id='location-login', refresh=True),
+        html.Div(id="login-alert-div"),
         html.Div([
             dbc.Container(
                 html.Img(
@@ -129,4 +130,3 @@ layout = dbc.Container([
         ]),
     ], className='jumbotron')
 ])
-

--- a/meerschaum/api/routes/_login.py
+++ b/meerschaum/api/routes/_login.py
@@ -39,9 +39,9 @@ def login(
     Login and set the session token.
     """
     username, password = (
-        (data.username, data.password)
-        if hasattr(data, 'username')
-        else (data['username'], data['password'])
+        (data['username'], data['password'])
+        if isinstance(data, dict)
+        else (data.username, data.password)
     ) if not no_auth else ('no-auth', 'no-auth')
 
     user = User(username, password)

--- a/meerschaum/api/routes/_login.py
+++ b/meerschaum/api/routes/_login.py
@@ -32,16 +32,16 @@ def load_user(
 
 
 @app.post(endpoints['login'], tags=['Users'])
-async def login(
+def login(
         data: CustomOAuth2PasswordRequestForm = fastapi.Depends()
-        #  data: dict[str, str],
-        #  request: Request
     ) -> Dict[str, Any]:
     """
     Login and set the session token.
     """
     username, password = (
         (data.username, data.password)
+        if hasattr(data, 'username')
+        else (data['username'], data['password'])
     ) if not no_auth else ('no-auth', 'no-auth')
 
     user = User(username, password)
@@ -62,7 +62,7 @@ async def login(
     return {
         'access_token': access_token,
         'token_type': 'bearer',
-        'expires' : expires_dt,
+        'expires': expires_dt,
     }
 
 

--- a/meerschaum/config/__init__.py
+++ b/meerschaum/config/__init__.py
@@ -26,7 +26,14 @@ from meerschaum.config._paths import (
 from meerschaum.config._patch import (
     apply_patch_to_config,
 )
-__all__ = ('get_plugin_config', 'write_plugin_config', 'get_config', 'write_config', 'set_config',)
+__all__ = (
+    'get_plugin_config',
+    'write_plugin_config',
+    'get_config',
+    'write_config',
+    'set_config',
+    'paths',
+)
 __pdoc__ = {'static': False, 'resources': False, 'stack': False, }
 _locks = {'config': RLock()}
 

--- a/meerschaum/config/_paths.py
+++ b/meerschaum/config/_paths.py
@@ -34,11 +34,28 @@ if ENVIRONMENT_ROOT_DIR in os.environ:
             f"Invalid root directory '{str(_ROOT_DIR_PATH)}' set for " +
             f"environment variable '{ENVIRONMENT_ROOT_DIR}'.\n" +
             f"Please enter a valid path for {ENVIRONMENT_ROOT_DIR}.",
-            file = sys.stderr,
+            file=sys.stderr,
         )
         sys.exit(1)
 else:
     _ROOT_DIR_PATH = DEFAULT_ROOT_DIR_PATH
+
+
+ENVIRONMENT_CONFIG_DIR = STATIC_CONFIG['environment']['config_dir']
+if ENVIRONMENT_CONFIG_DIR in os.environ:
+    _CONFIG_DIR_PATH = Path(os.environ[ENVIRONMENT_CONFIG_DIR]).resolve()
+    if not _CONFIG_DIR_PATH.exists():
+        print(
+            (
+                f"Invalid configuration directory '{_CONFIG_DIR_PATH}' set"
+                + f" for environment variable '{ENVIRONMENT_CONFIG_DIR}'\n"
+                + f"Please enter a valid path for {ENVIRONMENT_CONFIG_DIR}."
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+else:
+    _CONFIG_DIR_PATH = _ROOT_DIR_PATH / 'config'
 
 ENVIRONMENT_PLUGINS_DIR = STATIC_CONFIG['environment']['plugins']
 if ENVIRONMENT_PLUGINS_DIR in os.environ:
@@ -100,7 +117,7 @@ paths = {
     'PACKAGE_ROOT_PATH'              : Path(__file__).parent.parent.resolve().as_posix(),
     'ROOT_DIR_PATH'                  : _ROOT_DIR_PATH.as_posix(),
     'VIRTENV_RESOURCES_PATH'         : _VENVS_DIR_PATH.as_posix(),
-    'CONFIG_DIR_PATH'                : ('{ROOT_DIR_PATH}', 'config'),
+    'CONFIG_DIR_PATH'                : _CONFIG_DIR_PATH.as_posix(),
     'DEFAULT_CONFIG_DIR_PATH'        : ('{ROOT_DIR_PATH}', 'default_config'),
     'PATCH_DIR_PATH'                 : ('{ROOT_DIR_PATH}', 'patch_config'),
     'PERMANENT_PATCH_DIR_PATH'       : ('{ROOT_DIR_PATH}', 'permanent_patch_config'),
@@ -167,6 +184,7 @@ def set_root(root: Union[Path, str]):
     for path_name, path_parts in paths.items():
         if isinstance(path_parts, tuple) and path_parts[0] == '{ROOT_DIR_PATH}':
             globals()[path_name] = __getattr__(path_name)
+
 
 def __getattr__(name: str) -> Path:
     if name not in paths:

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.2.5"
+__version__ = "2.2.6.dev0"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.2.6rc1"
+__version__ = "2.2.6"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.2.6.dev0"
+__version__ = "2.2.6rc1"

--- a/meerschaum/config/paths.py
+++ b/meerschaum/config/paths.py
@@ -6,5 +6,24 @@
 External API for importing Meerschaum paths.
 """
 
-from meerschaum.config._paths import __getattr__, paths
-__all__ = tuple(paths.keys())
+import pathlib
+import inspect
+import meerschaum.config._paths as _paths
+
+
+def __getattr__(*args, **kwargs):
+    return _paths.__getattr__(*args, **kwargs)
+
+
+_globals_dict = inspect.getmembers(
+    _paths,
+    lambda member: not inspect.isroutine(member)
+)
+_all_caps_globals = [
+    name
+    for name, value in _globals_dict
+    if ('PATH' in name or 'FILE' in name) and not name.startswith('_')
+    and isinstance(value, pathlib.Path)
+]
+
+__all__ = tuple(_all_caps_globals + list(_paths.paths.keys()))

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -46,6 +46,7 @@ STATIC_CONFIG: Dict[str, Any] = {
     },
     'environment': {
         'config': 'MRSM_CONFIG',
+        'config_dir': 'MRSM_CONFIG_DIR',
         'patch': 'MRSM_PATCH',
         'root': 'MRSM_ROOT_DIR',
         'plugins': 'MRSM_PLUGINS_DIR',

--- a/meerschaum/connectors/api/APIConnector.py
+++ b/meerschaum/connectors/api/APIConnector.py
@@ -87,9 +87,9 @@ class APIConnector(Connector):
             kw.update(from_uri_params)
 
         super().__init__('api', label=label, **kw)
-        if 'protocol' not in self.__dict__:
-            self.protocol = 'http'
         if 'uri' not in self.__dict__:
+            if 'protocol' not in self.__dict__:
+                self.protocol = 'http'
             self.verify_attributes(required_attributes)
         else:
             from meerschaum.connectors.sql import SQLConnector
@@ -97,6 +97,7 @@ class APIConnector(Connector):
             if 'host' not in conn_attrs:
                 raise Exception(f"Invalid URI for '{self}'.")
             self.__dict__.update(conn_attrs)
+
         self.url = (
             self.protocol + '://' +
             self.host
@@ -105,7 +106,7 @@ class APIConnector(Connector):
                 if self.__dict__.get('port', None)
                 else ''
             )
-        )
+        ) if not self.__dict__.get('uri') else self.uri
         self._token = None
         self._expires = None
         self._session = None
@@ -116,6 +117,9 @@ class APIConnector(Connector):
         """
         Return the fully qualified URI.
         """
+        if 'uri' in self.__dict__:
+            return self.uri
+
         username = self.__dict__.get('username', None)
         password = self.__dict__.get('password', None)
         creds = (username + ':' + password + '@') if username and password else ''

--- a/meerschaum/connectors/api/APIConnector.py
+++ b/meerschaum/connectors/api/APIConnector.py
@@ -83,13 +83,17 @@ class APIConnector(Connector):
         if 'uri' in kw:
             from_uri_params = self.from_uri(kw['uri'], as_dict=True)
             label = label or from_uri_params.get('label', None)
-            from_uri_params.pop('label', None)
+            _ = from_uri_params.pop('label', None)
             kw.update(from_uri_params)
 
         super().__init__('api', label=label, **kw)
+        if 'protocol' not in self.__dict__:
+            self.protocol = (
+                'https' if self.__dict__.get('uri', '').startswith('https')
+                else 'http'
+            )
+
         if 'uri' not in self.__dict__:
-            if 'protocol' not in self.__dict__:
-                self.protocol = 'http'
             self.verify_attributes(required_attributes)
         else:
             from meerschaum.connectors.sql import SQLConnector
@@ -106,7 +110,7 @@ class APIConnector(Connector):
                 if self.__dict__.get('port', None)
                 else ''
             )
-        ) if not self.__dict__.get('uri') else self.uri
+        )
         self._token = None
         self._expires = None
         self._session = None
@@ -117,9 +121,6 @@ class APIConnector(Connector):
         """
         Return the fully qualified URI.
         """
-        if 'uri' in self.__dict__:
-            return self.uri
-
         username = self.__dict__.get('username', None)
         password = self.__dict__.get('password', None)
         creds = (username + ':' + password + '@') if username and password else ''

--- a/meerschaum/connectors/api/_actions.py
+++ b/meerschaum/connectors/api/_actions.py
@@ -9,27 +9,31 @@ Functions to interact with /mrsm/actions
 from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Optional, List
 
-def get_actions(
-        self,
-    ) -> list:
-    """Get available actions from the API server"""
+def get_actions(self) -> list:
+    """Get available actions from the API instance."""
     from meerschaum.config.static import STATIC_CONFIG
     return self.get(STATIC_CONFIG['api']['endpoints']['actions'])
 
 
 def do_action(
-        self,
-        action: Optional[List[str]] = None,
-        sysargs: Optional[List[str]] = None,
-        debug: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    self,
+    action: Optional[List[str]] = None,
+    sysargs: Optional[List[str]] = None,
+    debug: bool = False,
+    **kw
+) -> SuccessTuple:
     """Execute a Meerschaum action remotely.
-    
-    If sysargs is provided, parse those instead. Otherwise infer everything from keyword arguments.
-    
-    NOTE: The first index of `action` should NOT be removed!
-    Example: action = ['show', 'config']
+
+    If `sysargs` are provided, parse those instead.
+    Otherwise infer everything from keyword arguments.
+
+    Examples
+    --------
+    >>> conn = mrsm.get_connector('api:main')
+    >>> conn.do_action(['show', 'pipes'])
+    (True, "Success")
+    >>> conn.do_action(['show', 'arguments'], name='test')
+    (True, "Success")
     """
     import sys, json
     from meerschaum.utils.debug import dprint
@@ -46,7 +50,12 @@ def do_action(
     else:
         json_dict = kw
         json_dict['action'] = action
-        json_dict['debug'] = debug
+        if 'noask' not in kw:
+            json_dict['noask'] = True
+        if 'yes' not in kw:
+            json_dict['yes'] = True
+        if debug:
+            json_dict['debug'] = debug
 
     root_action = json_dict['action'][0]
     del json_dict['action'][0]

--- a/meerschaum/connectors/api/_actions.py
+++ b/meerschaum/connectors/api/_actions.py
@@ -30,23 +30,6 @@ def do_action(
     
     NOTE: The first index of `action` should NOT be removed!
     Example: action = ['show', 'config']
-    
-    Returns: tuple (succeeded : bool, message : str)
-
-    Parameters
-    ----------
-    action: Optional[List[str]] :
-         (Default value = None)
-    sysargs: Optional[List[str]] :
-         (Default value = None)
-    debug: bool :
-         (Default value = False)
-    **kw :
-        
-
-    Returns
-    -------
-
     """
     import sys, json
     from meerschaum.utils.debug import dprint

--- a/meerschaum/connectors/api/_uri.py
+++ b/meerschaum/connectors/api/_uri.py
@@ -11,11 +11,11 @@ from meerschaum.utils.warnings import warn, error
 
 @classmethod
 def from_uri(
-        cls,
-        uri: str,
-        label: Optional[str] = None,
-        as_dict: bool = False,
-    ) -> Union[
+    cls,
+    uri: str,
+    label: Optional[str] = None,
+    as_dict: bool = False,
+) -> Union[
         'meerschaum.connectors.APIConnector',
         Dict[str, Union[str, int]],
     ]:

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -50,6 +50,7 @@ with correct credentials, as well as a network connection and valid permissions.
 """
 
 from __future__ import annotations
+import sys
 import copy
 from meerschaum.utils.typing import Optional, Dict, Any, Union, InstanceConnector, List
 from meerschaum.utils.formatting._pipes import pipe_repr
@@ -433,13 +434,16 @@ class Pipe:
             + str(self.instance_keys) + sep
         )
 
-    def __repr__(self, **kw) -> str:
-        return pipe_repr(self, **kw)
+    def __repr__(self, ansi: bool=True, **kw) -> str:
+        if not hasattr(sys, 'ps1'):
+            ansi = False
+
+        return pipe_repr(self, ansi=ansi, **kw)
 
     def __pt_repr__(self):
         from meerschaum.utils.packages import attempt_import
         prompt_toolkit_formatted_text = attempt_import('prompt_toolkit.formatted_text', lazy=False)
-        return prompt_toolkit_formatted_text.ANSI(self.__repr__())
+        return prompt_toolkit_formatted_text.ANSI(pipe_repr(self, ansi=True))
 
     def __getstate__(self) -> Dict[str, Any]:
         """

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -654,17 +654,18 @@ class Plugin:
             import ast, re
             ### NOTE: This technically would break 
             ### if `required` was the very first line of the file.
-            req_start_match = re.search(r'\nrequired(\s?)=', text)
+            req_start_match = re.search(r'required(:\s*)?.*=', text)
             if not req_start_match:
                 return []
             req_start = req_start_match.start()
+            equals_sign = req_start + text[req_start:].find('=')
 
             ### Dependencies may have brackets within the strings, so push back the index.
-            first_opening_brace = req_start + 1 + text[req_start:].find('[')
+            first_opening_brace = equals_sign + 1 + text[equals_sign:].find('[')
             if first_opening_brace == -1:
                 return []
 
-            next_closing_brace = req_start + 1 + text[req_start:].find(']')
+            next_closing_brace = equals_sign + 1 + text[equals_sign:].find(']')
             if next_closing_brace == -1:
                 return []
 
@@ -681,12 +682,11 @@ class Plugin:
 
             req_end = end_ix + 1
             req_text = (
-                text[req_start:req_end]
-                .lstrip()
-                .replace('required', '', 1)
+                text[(first_opening_brace-1):req_end]
                 .lstrip()
                 .replace('=', '', 1)
                 .lstrip()
+                .rstrip()
             )
             try:
                 required = ast.literal_eval(req_text)

--- a/meerschaum/utils/formatting/__init__.py
+++ b/meerschaum/utils/formatting/__init__.py
@@ -291,16 +291,16 @@ def print_tuple(
 
 
 def print_options(
-        options: Optional[Dict[str, Any]] = None,
-        nopretty: bool = False,
-        no_rich: bool = False,
-        name: str = 'options',
-        header: Optional[str] = None,
-        num_cols: Optional[int] = None,
-        adjust_cols: bool = True,
-        sort_options: bool = False,
-        **kw
-    ) -> None:
+    options: Optional[Dict[str, Any]] = None,
+    nopretty: bool = False,
+    no_rich: bool = False,
+    name: str = 'options',
+    header: Optional[str] = None,
+    num_cols: Optional[int] = None,
+    adjust_cols: bool = True,
+    sort_options: bool = False,
+    **kw
+) -> None:
     """
     Print items in an iterable as a fancy table.
 
@@ -342,7 +342,7 @@ def print_options(
         _options.append(str(o))
     if sort_options:
         _options = sorted(_options)
-    _header = f"Available {name}" if header is None else header
+    _header = f"\nAvailable {name}" if header is None else header
 
     if num_cols is None:
         num_cols = 8
@@ -388,7 +388,7 @@ def print_options(
 
     if _header is not None:
         table = Table(
-            title = ('\n' + _header) if header else header,
+            title = _header,
             box = box.SIMPLE,
             show_header = False,
             show_footer = False,

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1849,10 +1849,16 @@ def _get_pip_os_env(color: bool = True):
     Return the environment variables context in which `pip` should be run.
     See PEP 668 for why we are overriding the environment.
     """
-    import os
+    import os, sys, platform
+    python_bin_path = pathlib.Path(sys.executable)
     pip_os_env = os.environ.copy()
+    path_str = pip_os_env.get('PATH', '') or ''
+    path_sep = ':' if platform.system() != 'Windows' else ';'
     pip_os_env.update({
         'PIP_BREAK_SYSTEM_PACKAGES': 'true',
         ('FORCE_COLOR' if color else 'NO_COLOR'): '1',
     })
+    if str(python_bin_path) not in path_str:
+        pip_os_env['PATH'] = str(python_bin_path.parent) + path_sep + path_str
+
     return pip_os_env

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -616,7 +616,11 @@ def venv_target_path(
             return site_packages_path
 
         if not inside_venv():
-            site_path = pathlib.Path(site.getusersitepackages())
+            user_site_packages = site.getusersitepackages()
+            if user_site_packages is None:
+                raise EnvironmentError("Could not determine user site packages.")
+
+            site_path = pathlib.Path(user_site_packages)
             if not site_path.exists():
 
                 ### Windows does not have `os.geteuid()`.

--- a/meerschaum/utils/yaml.py
+++ b/meerschaum/utils/yaml.py
@@ -10,7 +10,7 @@ This is so switching between PyYAML and ruamel.yaml is smoother.
 
 from meerschaum.utils.misc import filter_keywords
 from meerschaum.utils.packages import attempt_import, all_packages, _import_module
-from meerschaum.utils.warnings import error, warn
+from meerschaum.utils.warnings import error
 from meerschaum.utils.threading import Lock
 
 _lib = None
@@ -49,7 +49,7 @@ class yaml:
     """
     global _yaml, _lib, _dumper
     if _import_name is None:
-        error(f"No YAML library declared.")
+        error("No YAML library declared.")
     with _locks['_lib']:
         try:
             _lib = _import_module(_import_name)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -590,7 +590,6 @@ def test_nested_chunks(flavor: str):
     assert len(df) == num_docs
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Dask / Numpy 2.0 failing on Python 3.12")
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_sync_dask_dataframe(flavor: str):
     """


### PR DESCRIPTION
# v2.2.6

- **Fix a critical login issue.**  
  The previous release (v2.2.5) broke the login functionality of the Web UI and has been yanked. If you are running v2.2.5, it is urgent that you upgrade immediately.

- **Add environment variable `MRSM_CONFIG_DIR`.**  
  You may now isolate your configuration directory outside of the root (like with `MRSM_PLUGINS_DIR`, and `MRSM_VENVS_DIR`). This will be useful in certain production deployments where secrets need to be segmented and isolated.

- **Add `register connector`.**  
  Like `bootstrap connector`, you may now programmatically create connectors.

- **Allow for job names to contain spaces and parentheses.**  
  Jobs may now be created with more dynamic names. This issue in particular affected Meerschaum Compose.

- **Allow for type annotations in `required`.**  
  Plugins may now annotate `required`:

  ```python
  # plugins/example.py

  __version__: str = '0.0.1'
  required: list[str] = ['requests']
  ```

- **Automatically include `--noask` and `--yes` in remote actions.**  
  For your convenience, the flags `--noask` and `--yes` are included in remote actions sent by `APIConnector.do_action()`.

- **Fixed an issue with URIs for `api` connectors.**  
  Creating an `APIConnector` via a URI connection string now properly handles the protocol.

- **Fixed a formatting issue with `show logs`.**