### PR TITLE
🐛 v2.2.7 Fix log file descriptors, improve `show jobs`, add announcements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+
+### v2.2.7
+
+- **Fix daemon stability.**  
+  Broken file handlers are now better handled, and this should keep background jobs from crashing.
+
+- **Improve `show jobs` output.**  
+  The `show jobs` table now includes the `SuccessTuple` of the most recent run (when jobs are stopped).
+
+- **Use a plugin's `__doc__` string as the default description.**  
+  When registering a new plugin, the `__doc__` string will be used as the default value for the description.
+
+- **Pipes without connectors are no longer considered errors when syncing.**  
+  When a pipe has an ordinary string in place of a connector (e.g. externally managed), return early and consider success rather than throwing an error.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync()
+  # (True, "Pipe('a', 'b') does not support fetching; nothing to do.")
+  ```
+
+- **Add update announcements.**  
+  When new Meerschaum releases become available, you will now be presented with an update message when starting the shell. Update checks may be disabled by setting `shell:updates:check_remote` to `false`.
+
+- **Enforce a 10-minute max timeout for `APIConnectors`.**
+
 ### v2.2.6
 
 - **Fix a critical login issue.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,33 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+
+### v2.2.7
+
+- **Fix daemon stability.**  
+  Broken file handlers are now better handled, and this should keep background jobs from crashing.
+
+- **Improve `show jobs` output.**  
+  The `show jobs` table now includes the `SuccessTuple` of the most recent run (when jobs are stopped).
+
+- **Use a plugin's `__doc__` string as the default description.**  
+  When registering a new plugin, the `__doc__` string will be used as the default value for the description.
+
+- **Pipes without connectors are no longer considered errors when syncing.**  
+  When a pipe has an ordinary string in place of a connector (e.g. externally managed), return early and consider success rather than throwing an error.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('a', 'b')
+  pipe.sync()
+  # (True, "Pipe('a', 'b') does not support fetching; nothing to do.")
+  ```
+
+- **Add update announcements.**  
+  When new Meerschaum releases become available, you will now be presented with an update message when starting the shell. Update checks may be disabled by setting `shell:updates:check_remote` to `false`.
+
+- **Enforce a 10-minute max timeout for `APIConnectors`.**
+
 ### v2.2.6
 
 - **Fix a critical login issue.**  

--- a/meerschaum/__main__.py
+++ b/meerschaum/__main__.py
@@ -19,9 +19,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import sys, os, copy
+import sys
+import os
+import copy
 
-def main(sysargs: list = None) -> None:
+from meerschaum.utils.typing import List, Optional
+from meerschaum.utils.formatting import print_tuple as _print_tuple
+
+
+def main(sysargs: Optional[List[str]] = None) -> None:
     """Main CLI entry point."""
     if sysargs is None:
         sysargs = copy.deepcopy(sys.argv[1:])
@@ -41,7 +47,7 @@ def main(sysargs: list = None) -> None:
 
     if ('-d' in sysargs or '--daemon' in sysargs) and ('stack' not in sysargs):
         from meerschaum.utils.daemon import daemon_entry
-        daemon_entry(sysargs)
+        _print_tuple(daemon_entry(sysargs), upper_padding=1)
         return _exit(old_cwd=old_cwd)
 
     from meerschaum._internal.entry import entry, get_shell
@@ -57,8 +63,7 @@ def main(sysargs: list = None) -> None:
     return_tuple = entry(sysargs)
     rc = 0
     if isinstance(return_tuple, tuple) and '--nopretty' not in sysargs:
-        from meerschaum.utils.formatting import print_tuple
-        print_tuple(return_tuple, upper_padding=1)
+        _print_tuple(return_tuple, upper_padding=1)
         rc = 0 if (return_tuple[0] is True) else 1
 
     return _exit(rc, old_cwd=old_cwd)

--- a/meerschaum/_internal/entry.py
+++ b/meerschaum/_internal/entry.py
@@ -8,20 +8,15 @@ The entry point for launching Meerschaum actions.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, List, Optional, Dict
+from meerschaum.utils.typing import SuccessTuple, List, Optional, Dict, Callable, Any
 
 def entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
-    """Parse arguments and launch a Meerschaum action.
-    The `action` list removes the first element.
-    
-    Examples of action:
-        'show actions' -> ['actions']
-        'show' -> []
+    """
+    Parse arguments and launch a Meerschaum action.
 
     Returns
     -------
-    A `SuccessTuple` indicating success. If `schedule` is provided, this will never return.
-
+    A `SuccessTuple` indicating success.
     """
     from meerschaum._internal.arguments import parse_arguments
     from meerschaum.config.static import STATIC_CONFIG
@@ -51,9 +46,9 @@ def entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
 
 
 def entry_with_args(
-        _actions: Optional[Dict[str, Callable[[Any], SuccessTuple]]] = None,
-        **kw
-    ) -> SuccessTuple:
+    _actions: Optional[Dict[str, Callable[[Any], SuccessTuple]]] = None,
+    **kw
+) -> SuccessTuple:
     """Execute a Meerschaum action with keyword arguments.
     Use `_entry()` for parsing sysargs before executing.
     """
@@ -96,7 +91,12 @@ def entry_with_args(
 
     kw['action'] = remove_leading_action(kw['action'], _actions=_actions)
 
-    do_action = functools.partial(_do_action_wrapper, action_function, plugin_name, **kw)
+    do_action = functools.partial(
+        _do_action_wrapper,
+        action_function,
+        plugin_name,
+        **kw
+    )
     if kw.get('schedule', None) and not skip_schedule:
         from meerschaum.utils.schedule import schedule_function
         from meerschaum.utils.misc import interval_str

--- a/meerschaum/_internal/shell/updates.py
+++ b/meerschaum/_internal/shell/updates.py
@@ -1,0 +1,175 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+If configured, check `api:mrsm` for announcement messages.
+"""
+
+import json
+from datetime import datetime, timezone, timedelta
+
+import meerschaum as mrsm
+from meerschaum.utils.typing import Union, SuccessTuple, Optional
+from meerschaum.config import get_config
+from meerschaum.utils.formatting import CHARSET, ANSI, colored
+from meerschaum.utils.misc import string_width, remove_ansi
+from meerschaum.config.paths import (
+    UPDATES_LOCK_PATH,
+    UPDATES_CACHE_PATH,
+)
+from meerschaum.utils.threading import Thread
+
+
+def cache_remote_version(debug: bool = False) -> SuccessTuple:
+    """
+    Fetch and cache the latest version if available.
+    """
+    allow_update_check = get_config('shell', 'updates', 'check_remote')
+    if not allow_update_check:
+        return True, "Update checks are disabled."
+
+    refresh_minutes = get_config('shell', 'updates', 'refresh_minutes')
+    update_delta = timedelta(minutes=refresh_minutes)
+
+    if UPDATES_CACHE_PATH.exists():
+        try:
+            with open(UPDATES_CACHE_PATH, 'r', encoding='utf8') as f:
+                cache_dict = json.load(f)
+        except Exception:
+            cache_dict = {}
+    else:
+        cache_dict = {}
+
+    now = datetime.now(timezone.utc)
+    last_check_ts_str = cache_dict.get('last_check_ts')
+    last_check_ts = datetime.fromisoformat(last_check_ts_str) if last_check_ts_str else None
+
+    need_update = (
+        last_check_ts_str is None
+        or ((now - last_check_ts) >= update_delta)
+    )
+
+    if not need_update:
+        return True, "No updates are needed."
+
+    try:
+        conn = mrsm.get_connector('api:mrsm')
+        remote_version = conn.get_mrsm_version(debug=debug, timeout=3)
+    except Exception:
+        remote_version = None
+
+    if remote_version is None:
+        return False, "Could not determine remote version."
+
+    with open(UPDATES_CACHE_PATH, 'w+', encoding='utf-8') as f:
+        json.dump(
+            {
+                'last_check_ts': now.isoformat(),
+                'remote_version': remote_version,
+            },
+            f,
+        )
+
+    return True, "Updated remote version cache."
+
+
+def run_version_check_thread(debug: bool = False) -> Union[Thread, None]:
+    """
+    Run the version update check in a separate thread.
+    """
+    allow_update_check = get_config('shell', 'updates', 'check_remote')
+    if not allow_update_check:
+        return None
+
+    thread = Thread(
+        target=cache_remote_version,
+        daemon=True,
+        kwargs={'debug': debug},
+    )
+    thread.start()
+    return thread
+
+
+_remote_version: Optional[str] = None
+def get_remote_version_from_cache() -> Optional[str]:
+    """
+    Return the version string from the local cache file.
+    """
+    global _remote_version
+    try:
+        with open(UPDATES_CACHE_PATH, 'r', encoding='utf-8') as f:
+            cache_dict = json.load(f)
+    except Exception:
+        return None
+
+    _remote_version = cache_dict.get('remote_version')
+    return _remote_version
+
+
+_out_of_date: Optional[bool] = None
+def mrsm_out_of_date() -> bool:
+    """
+    Determine whether to print the upgrade message.
+    """
+    global _out_of_date
+    if _out_of_date is not None:
+        return _out_of_date
+
+    ### NOTE: Remote version is cached asynchronously.
+    if not UPDATES_CACHE_PATH.exists():
+        return False
+
+    remote_version_str = get_remote_version_from_cache()
+
+    packaging_version = mrsm.attempt_import('packaging.version')
+    current_version = packaging_version.parse(mrsm.__version__)
+    remote_version = packaging_version.parse(remote_version_str)
+
+    _out_of_date = remote_version > current_version
+    return _out_of_date
+
+
+def get_update_message() -> str:
+    """
+    Return the formatted message for when the current version is behind the latest release.
+    """
+    if not mrsm_out_of_date():
+        return ''
+
+    intro = get_config('shell', CHARSET, 'intro')
+    update_message = get_config('shell', CHARSET, 'update_message')
+    remote_version = get_remote_version_from_cache()
+    if not remote_version:
+        return ''
+
+    intro_width = string_width(intro)
+    msg_width = string_width(update_message)
+    update_left_padding = ' ' * ((intro_width - msg_width) // 2)
+
+    update_line = (
+        colored(
+            update_message,
+            *get_config('shell', 'ansi', 'update_message', 'color')
+        ) if ANSI
+        else update_message
+    )
+    update_instruction = (
+        colored("Run ", 'white')
+        + colored("upgrade mrsm", 'green')
+        + colored(" to install ", 'white')
+        + colored(f'v{remote_version}', 'yellow')
+        + '.'
+    )
+    update_instruction_clean = remove_ansi(update_instruction)
+    instruction_width = string_width(update_instruction_clean)
+    instruction_left_padding = ' ' * ((intro_width - instruction_width) // 2)
+
+    return (
+        '\n\n'
+        + update_left_padding
+        + update_line
+        + '\n'
+        + instruction_left_padding
+        + update_instruction
+    )

--- a/meerschaum/actions/register.py
+++ b/meerschaum/actions/register.py
@@ -203,14 +203,23 @@ def _register_plugins(
     successes = {}
 
     for name, plugin in plugins_to_register.items():
-        desc = None
         plugin.attributes = repo_connector.get_plugin_attributes(plugin, debug=debug)
         if plugin.attributes is None:
             plugin.attributes = {}
+
+        try:
+            description_text = plugin.attributes.get('description', '')
+            doc_text = plugin.module.__doc__.lstrip().rstrip()
+        except Exception:
+            description_text = ''
+            doc_text = ''
+
+        desc = description_text or doc_text or ''
+
         question = f"Would you like to add a description to plugin '{name}'?"
-        if plugin.attributes.get('description', None):
+        if desc:
             info(f"Found existing description for plugin '{plugin}':")
-            print(plugin.attributes['description'])
+            print(desc)
             question = (
                 "Would you like to overwrite this description?\n"
                 + "To edit the existing text, visit /dash/plugins for this repository."
@@ -220,9 +229,14 @@ def _register_plugins(
             default='n',
             yes=yes
         ):
-            info('Press (Esc + Enter) to submit the description, (CTRL + C) to cancel.')
+            info('Press (Esc + Enter) to submit, (CTRL + C) to cancel.')
             try:
-                desc = prompt('', multiline=True, icon=False)
+                desc = prompt(
+                    '',
+                    multiline=True,
+                    icon=False,
+                    default_editable=desc.lstrip().rstrip(),
+                )
             except KeyboardInterrupt:
                 desc = None
             if desc == '':

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -14,9 +14,9 @@ import meerschaum as mrsm
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Tuple, Union
 
 def sync(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
     """
     Fetch and sync data for pipes.
 

--- a/meerschaum/actions/upgrade.py
+++ b/meerschaum/actions/upgrade.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Union
 
 def upgrade(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
     """
     Upgrade Meerschaum, plugins, or packages.
     
@@ -34,13 +34,13 @@ def upgrade(
 
 
 def _upgrade_meerschaum(
-        action: Optional[List[str]] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Upgrade the current Meerschaum instance.
     Optionally specify dependency groups.
@@ -109,26 +109,21 @@ class NoVenv:
     pass
 
 def _upgrade_packages(
-        action: Optional[List[str]] = None,
-        venv: Union[str, None, NoVenv] = NoVenv,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    venv: Union[str, None, NoVenv] = NoVenv,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Upgrade and install dependencies.
     If provided, upgrade only a dependency group, otherwise default to `full`.
     
     Examples:
-        ```
         upgrade packages
-        ```
-    
-        ```
-        upgrade packages docs
-        ```
+        upgrade packages full
     """
     from meerschaum.utils.packages import packages, pip_install, get_prerelease_dependencies
     from meerschaum.utils.warnings import info, warn
@@ -178,14 +173,15 @@ def _upgrade_packages(
         )
     return success, msg
 
+
 def _upgrade_plugins(
-        action: Optional[List[str]] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Upgrade all installed plugins to the latest versions.
     If no plugins are specified, attempt to upgrade all,
@@ -193,12 +189,8 @@ def _upgrade_plugins(
     
     Examples:
     
-    ```
     upgrade plugins
-    ```
-    ```
-    upgrade plugins testing
-    ```
+    upgrade plugins noaa
     """
     from meerschaum.actions import actions
     from meerschaum.plugins import get_plugins_names

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -44,14 +44,14 @@ pd = attempt_import('pandas')
 
 @app.post(pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/register', tags=['Pipes'])
 def register_pipe(
-        connector_keys: str,
-        metric_key: str,
-        location_key: str,
-        parameters: dict,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ):
+    connector_keys: str,
+    metric_key: str,
+    location_key: str,
+    parameters: dict,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+):
     """
     Register a new pipe.
     """
@@ -376,18 +376,18 @@ def sync_pipe(
 
 @app.get(pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/data', tags=['Pipes'])
 def get_pipe_data(
-        connector_keys: str,
-        metric_key: str,
-        location_key: str,
-        select_columns: Optional[str] = None,
-        omit_columns: Optional[str] = None,
-        begin: Union[str, int, None] = None,
-        end: Union[str, int, None] = None,
-        params: Optional[str] = None,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> str:
+    connector_keys: str,
+    metric_key: str,
+    location_key: str,
+    select_columns: Optional[str] = None,
+    omit_columns: Optional[str] = None,
+    begin: Union[str, int, None] = None,
+    end: Union[str, int, None] = None,
+    params: Optional[str] = None,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> str:
     """
     Get a pipe's data, applying any filtering.
 

--- a/meerschaum/config/_formatting.py
+++ b/meerschaum/config/_formatting.py
@@ -36,6 +36,7 @@ default_formatting_config = {
         'paused'           : '🟡',
         'stopped'          : '🔴',
         'tag'              : '🔖',
+        'announcement'     : '📢',
     },
     'pipes'                : {
         'unicode'          : {

--- a/meerschaum/config/_paths.py
+++ b/meerschaum/config/_paths.py
@@ -123,6 +123,10 @@ paths = {
     'PERMANENT_PATCH_DIR_PATH'       : ('{ROOT_DIR_PATH}', 'permanent_patch_config'),
     'INTERNAL_RESOURCES_PATH'        : ('{ROOT_DIR_PATH}', '.internal'),
 
+    'UPDATES_RESOURCES_PATH'         : ('{INTERNAL_RESOURCES_PATH}', 'updates'),
+    'UPDATES_CACHE_PATH'             : ('{UPDATES_RESOURCES_PATH}', 'cache.json'),
+    'UPDATES_LOCK_PATH'              : ('{UPDATES_RESOURCES_PATH}', '.updates.lock'),
+
     'STACK_RESOURCES_PATH'           : ('{ROOT_DIR_PATH}', 'stack'),
     'STACK_COMPOSE_FILENAME'         : 'docker-compose.yaml',
     'STACK_COMPOSE_PATH'             : ('{STACK_RESOURCES_PATH}', '{STACK_COMPOSE_FILENAME}'),

--- a/meerschaum/config/_shell.py
+++ b/meerschaum/config/_shell.py
@@ -6,127 +6,139 @@
 Default configuration for the Meerschaum shell.
 """
 
-#  import platform
-#  default_cmd = 'cmd' if platform.system() != 'Windows' else 'cmd2'
 default_cmd = 'cmd'
 
 default_shell_config = {
-    'ansi'             : {
-        'intro'        : {
-            'rich'     : {
-                'style' : "bold bright_blue",
+    'ansi'               : {
+        'intro'          : {
+            'rich'       : {
+                'style'  : "bold bright_blue",
             },
-            'color'    : [
+            'color'      : [
                 'bold',
                 'bright blue',
             ],
         },
-        'close_message': {
-            'rich' : {
-                'style' : 'bright_blue',
+        'close_message'  : {
+            'rich'       : {
+                'style'  : 'bright_blue',
             },
-            'color'    : [
+            'color'      : [
                 'bright blue',
             ],
         },
-        'doc_header': {
-            'rich' : {
-                'style' : 'bright_blue',
+        'doc_header'     : {
+            'rich'       : {
+                'style'  : 'bright_blue',
             },
-            'color'    : [
+            'color'      : [
                 'bright blue',
             ],
         },
-        'undoc_header': {
-            'rich' : {
-                'style' : 'bright_blue',
+        'undoc_header'   : {
+            'rich'       : {
+                'style'  : 'bright_blue',
             },
-            'color'    : [
+            'color'      : [
                 'bright blue',
             ],
         },
-        'ruler': {
-            'rich' : {
-                'style' : 'bold bright_blue',
+        'ruler'          : {
+            'rich'       : {
+                'style'  : 'bold bright_blue',
             },
-            'color'    : [
+            'color'      : [
                 'bold',
                 'bright blue',
             ],
         },
-        'prompt': {
-            'rich' : {
-                'style' : 'green',
+        'prompt'         : {
+            'rich'       : {
+                'style'  : 'green',
             },
-            'color'    : [
+            'color'      : [
                 'green',
             ],
         },
-        'instance' : {
-            'rich' : {
-                'style' : 'cyan',
+        'instance'       : {
+            'rich'       : {
+                'style'  : 'cyan',
             },
-            'color'    : [
+            'color'      : [
                 'cyan',
             ],
         },
-        'repo' : {
-            'rich': {
-                'style': 'magenta',
+        'repo'           : {
+            'rich'       : {
+                'style'  : 'magenta',
             },
-            'color': [
+            'color'      : [
                 'magenta',
             ],
         },
-        'username' : {
-            'rich' : {
-                'style' : 'white',
+        'username'       : {
+            'rich'       : {
+                'style'  : 'white',
             },
-            'color'    : [
+            'color'      : [
                 'white',
             ],
         },
-        'connected' : {
-            'rich' : {
-                'style' : 'green',
+        'connected'      : {
+            'rich'       : {
+                'style'  : 'green',
             },
-            'color'    : [
+            'color'      : [
                 'green',
             ],
         },
-        'disconnected' : {
-            'rich' : {
-                'style' : 'red',
+        'disconnected'   : {
+            'rich'       : {
+                'style'  : 'red',
             },
-            'color'    : [
+            'color'      : [
+                'red',
+            ],
+        },
+        'update_message' : {
+            'rich'       : {
+                'style'  : 'red',
+            },
+            'color'      : [
                 'red',
             ],
         },
     },
-    'ascii'            : {
-        'intro'        : """       ___  ___  __   __   __
+    'ascii'              : {
+        'intro'          : r"""       ___  ___  __   __   __
  |\/| |__  |__  |__) /__` /  ` |__|  /\  |  |  |\/|
  |  | |___ |___ |  \ .__/ \__, |  | /~~\ \__/  |  |\n""",
-        'prompt'       : '\n [ {username}@{instance} ] > ',
-        'ruler'        : '-',
-        'close_message': 'Thank you for using Meerschaum!',
-        'doc_header'   : 'Meerschaum actions (`help <action>` for usage):',
-        'undoc_header' : 'Unimplemented actions:',
+        'prompt'         : '\n [ {username}@{instance} ] > ',
+        'ruler'          : '-',
+        'close_message'  : 'Thank you for using Meerschaum!',
+        'doc_header'     : 'Meerschaum actions (`help <action>` for usage):',
+        'undoc_header'   : 'Unimplemented actions:',
+        'update_message' : "Update available!",
     },
-    'unicode'          : {
-        'intro'        : """
+    'unicode'            : {
+        'intro'          : """
  █▄ ▄█ ██▀ ██▀ █▀▄ ▄▀▀ ▄▀▀ █▄█ ▄▀▄ █ █ █▄ ▄█
  █ ▀ █ █▄▄ █▄▄ █▀▄ ▄██ ▀▄▄ █ █ █▀█ ▀▄█ █ ▀ █\n""",
-        'prompt'       : '\n [ {username}@{instance} ] ➤ ',
-        'ruler'        : '─',
-        'close_message': ' MRSM{formatting:emoji:hand} Thank you for using Meerschaum! ',
-        'doc_header'   : 'Meerschaum actions (`help <action>` for usage):',
-        'undoc_header' : 'Unimplemented actions:',
+        'prompt'         : '\n [ {username}@{instance} ] ➤ ',
+        'ruler'          : '─',
+        'close_message'  : ' MRSM{formatting:emoji:hand} Thank you for using Meerschaum! ',
+        'doc_header'     : 'Meerschaum actions (`help <action>` for usage):',
+        'undoc_header'   : 'Unimplemented actions:',
+        'update_message' : "MRSM{formatting:emoji:announcement} Update available!",
     },
-    'timeout'          : 60,
-    'max_history'      : 1000,
-    'clear_screen'     : True,
-    'bottom_toolbar'   : {
-        'enabled'      : True,
+    'timeout'            : 60,
+    'max_history'        : 1000,
+    'clear_screen'       : True,
+    'bottom_toolbar'     : {
+        'enabled'        : True,
+    },
+    'updates'            : {
+        'check_remote'   : True,
+        'refresh_minutes': 180,
     },
 }

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.2.6"
+__version__ = "2.2.7"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -39,6 +39,7 @@ STATIC_CONFIG: Dict[str, Any] = {
             'token_expires_minutes': 720,
         },
         'webterm_job_name': '_webterm',
+        'default_timeout': 600,
     },
     'sql': {
         'internal_schema': '_mrsm_internal',

--- a/meerschaum/connectors/api/_misc.py
+++ b/meerschaum/connectors/api/_misc.py
@@ -17,7 +17,7 @@ def get_mrsm_version(self, **kw) -> Optional[str]:
     try:
         j = self.get(
             STATIC_CONFIG['api']['endpoints']['version'] + '/mrsm',
-            use_token = True,
+            use_token=False,
             **kw
         ).json()
     except Exception as e:

--- a/meerschaum/connectors/api/_request.py
+++ b/meerschaum/connectors/api/_request.py
@@ -11,7 +11,7 @@ import urllib.parse
 import pathlib
 from meerschaum.utils.typing import Any, Optional, Dict, Union
 from meerschaum.utils.debug import dprint
-from meerschaum.utils.formatting import pprint
+from meerschaum.config.static import STATIC_CONFIG
 
 METHODS = {
     'GET',
@@ -23,15 +23,16 @@ METHODS = {
     'DELETE',
 }
 
+
 def make_request(
-        self,
-        method: str,
-        r_url: str,
-        headers: Optional[Dict[str, Any]] = None,
-        use_token: bool = True,
-        debug: bool = False,
-        **kwargs: Any
-    ) -> 'requests.Response':
+    self,
+    method: str,
+    r_url: str,
+    headers: Optional[Dict[str, Any]] = None,
+    use_token: bool = True,
+    debug: bool = False,
+    **kwargs: Any
+) -> 'requests.Response':
     """
     Make a request to this APIConnector's endpoint using the in-memory session.
 
@@ -83,6 +84,9 @@ def make_request(
 
     if use_token:
         headers.update({'Authorization': f'Bearer {self.token}'})
+
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = STATIC_CONFIG['api']['default_timeout']
 
     request_url = urllib.parse.urljoin(self.url, r_url)
     if debug:

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -194,6 +194,9 @@ def sync(
         if hasattr(df, 'MRSM_INFER_FETCH'):
             try:
                 if p.connector is None:
+                    if ':' not in p.connector_keys:
+                        return True, f"{p} does not support fetching; nothing to do."
+
                     msg = f"{p} does not have a valid connector."
                     if p.connector_keys.startswith('plugin:'):
                         msg += f"\n    Perhaps {p.connector_keys} has a syntax error?"

--- a/meerschaum/utils/daemon/FileDescriptorInterceptor.py
+++ b/meerschaum/utils/daemon/FileDescriptorInterceptor.py
@@ -93,7 +93,7 @@ class FileDescriptorInterceptor:
                     else data.replace(b'\n', b'\n' + injected_bytes)
                 )
                 os.write(self.new_file_descriptor, modified_data)
-            except BrokenPipeError:
+            except (BrokenPipeError, OSError):
                 break
             except Exception:
                 with open(DAEMON_ERROR_LOG_PATH, 'a+', encoding='utf-8') as f:

--- a/meerschaum/utils/daemon/FileDescriptorInterceptor.py
+++ b/meerschaum/utils/daemon/FileDescriptorInterceptor.py
@@ -9,6 +9,7 @@ Intercept OS-level file descriptors.
 import os
 import select
 import traceback
+import errno
 from threading import Event
 from datetime import datetime
 from meerschaum.utils.typing import Callable
@@ -68,6 +69,8 @@ class FileDescriptorInterceptor:
                 from meerschaum.utils.warnings import warn
                 if e.errno == errno.EBADF:
                     warn("File descriptor closed. Stopping interception.")
+                elif e.errno == errno.EINTR:
+                    continue  # Interrupted system call, just try again
                 else:
                     warn(f"OSError in FileDescriptorInterceptor: {e}")
                 break

--- a/meerschaum/utils/daemon/RotatingFile.py
+++ b/meerschaum/utils/daemon/RotatingFile.py
@@ -584,10 +584,14 @@ class RotatingFile(io.IOBase):
         if self.redirect_streams:
             try:
                 sys.stdout.flush()
+            except BrokenPipeError:
+                pass
             except Exception as e:
                 warn(f"Failed to flush STDOUT:\n{traceback.format_exc()}")
             try:
                 sys.stderr.flush()
+            except BrokenPipeError:
+                pass
             except Exception as e:
                 warn(f"Failed to flush STDERR:\n{traceback.format_exc()}")
 
@@ -599,7 +603,6 @@ class RotatingFile(io.IOBase):
         if not self.write_timestamps:
             return
 
-        threads = self.__dict__.get('_interceptor_threads', [])
         self._stdout_interceptor = FileDescriptorInterceptor(
             sys.stdout.fileno(),
             self.get_timestamp_prefix_str,
@@ -642,6 +645,7 @@ class RotatingFile(io.IOBase):
         """
         if not self.write_timestamps:
             return
+
         interceptors = self.__dict__.get('_interceptors', [])
         interceptor_threads = self.__dict__.get('_interceptor_threads', [])
 

--- a/meerschaum/utils/daemon/RotatingFile.py
+++ b/meerschaum/utils/daemon/RotatingFile.py
@@ -371,6 +371,9 @@ class RotatingFile(io.IOBase):
                 self._current_file_obj.write(data)
                 if suffix_str:
                     self._current_file_obj.write(suffix_str)
+            except BrokenPipeError:
+                warn("BrokenPipeError encountered. The daemon may have been terminated.")
+                return
             except Exception as e:
                 warn(f"Failed to write to subfile:\n{traceback.format_exc()}")
             self.flush()

--- a/meerschaum/utils/daemon/__init__.py
+++ b/meerschaum/utils/daemon/__init__.py
@@ -67,8 +67,8 @@ def daemon_entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
             if daemon.status == 'running':
                 return True, f"Daemon '{daemon}' is already running."
             return daemon.run(
-                debug = debug,
-                allow_dirty_run = True,
+                debug=debug,
+                allow_dirty_run=True,
             )
 
     success_tuple = run_daemon(
@@ -76,6 +76,7 @@ def daemon_entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
         filtered_sysargs,
         daemon_id=_args.get('name', None) if _args else None,
         label=label,
+        keep_daemon_output=('--rm' not in sysargs),
     )
     return success_tuple
 
@@ -106,25 +107,25 @@ def daemon_action(**kw) -> SuccessTuple:
 
 
 def run_daemon(
-        func: Callable[[Any], Any],
-        *args,
-        daemon_id: Optional[str] = None,
-        keep_daemon_output: bool = False,
-        allow_dirty_run: bool = False,
-        label: Optional[str] = None,
-        **kw
-    ) -> Any:
+    func: Callable[[Any], Any],
+    *args,
+    daemon_id: Optional[str] = None,
+    keep_daemon_output: bool = True,
+    allow_dirty_run: bool = False,
+    label: Optional[str] = None,
+    **kw
+) -> Any:
     """Execute a function as a daemon."""
     daemon = Daemon(
         func,
-        daemon_id = daemon_id,
-        target_args = [arg for arg in args],
-        target_kw = kw,
-        label = label,
+        daemon_id=daemon_id,
+        target_args=[arg for arg in args],
+        target_kw=kw,
+        label=label,
     )
     return daemon.run(
-        keep_daemon_output = keep_daemon_output,
-        allow_dirty_run = allow_dirty_run,
+        keep_daemon_output=keep_daemon_output,
+        allow_dirty_run=allow_dirty_run,
     )
 
 

--- a/meerschaum/utils/daemon/__init__.py
+++ b/meerschaum/utils/daemon/__init__.py
@@ -74,12 +74,9 @@ def daemon_entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
     success_tuple = run_daemon(
         entry,
         filtered_sysargs,
-        daemon_id = _args.get('name', None) if _args else None,
-        label = label,
-        keep_daemon_output = ('--rm' not in sysargs)
+        daemon_id=_args.get('name', None) if _args else None,
+        label=label,
     )
-    if not isinstance(success_tuple, tuple):
-        success_tuple = False, str(success_tuple)
     return success_tuple
 
 
@@ -268,3 +265,12 @@ def get_filtered_daemons(
             pass
         daemons.append(d)
     return daemons
+
+
+def running_in_daemon() -> bool:
+    """
+    Return whether the current thread is running in a Daemon context.
+    """
+    from meerschaum.config.static import STATIC_CONFIG
+    daemon_env_var = STATIC_CONFIG['environment']['daemon_id']
+    return daemon_env_var in os.environ

--- a/meerschaum/utils/formatting/_jobs.py
+++ b/meerschaum/utils/formatting/_jobs.py
@@ -7,7 +7,8 @@ Print jobs information.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import List, Optional, Any
+import meerschaum as mrsm
+from meerschaum.utils.typing import List, Optional, Any, is_success_tuple
 from meerschaum.utils.daemon import (
     Daemon,
     get_daemons,
@@ -17,9 +18,9 @@ from meerschaum.utils.daemon import (
 )
 
 def pprint_jobs(
-        daemons: List[Daemon],
-        nopretty: bool = False,
-    ):
+    daemons: List[Daemon],
+    nopretty: bool = False,
+):
     """Pretty-print a list of Daemons."""
     from meerschaum.utils.formatting import make_header
     
@@ -48,10 +49,12 @@ def pprint_jobs(
                 pprint_job(d, nopretty=nopretty)
 
     def _pretty_print():
-        from meerschaum.utils.formatting import get_console, UNICODE, ANSI
+        from meerschaum.utils.formatting import get_console, UNICODE, ANSI, format_success_tuple
         from meerschaum.utils.packages import import_rich, attempt_import
         rich = import_rich()
-        rich_table, rich_text, rich_box = attempt_import('rich.table', 'rich.text', 'rich.box')
+        rich_table, rich_text, rich_box, rich_json, rich_panel, rich_console = attempt_import(
+            'rich.table', 'rich.text', 'rich.box', 'rich.json', 'rich.panel', 'rich.console',
+        )
         table = rich_table.Table(
             title = rich_text.Text('Jobs'),
             box = (rich_box.ROUNDED if UNICODE else rich_box.ASCII),
@@ -62,13 +65,42 @@ def pprint_jobs(
         table.add_column("Command")
         table.add_column("Status")
 
+        def get_success_text(d):
+            success_tuple = d.properties.get('result', None)
+            if isinstance(success_tuple, list):
+                success_tuple = tuple(success_tuple)
+            if not is_success_tuple(success_tuple):
+                return rich_text.Text('')
+
+            success = success_tuple[0]
+            msg = success_tuple[1]
+            lines = msg.split('\n')
+            msg = '\n'.join(line.lstrip().rstrip() for line in lines)
+            success_tuple = success, msg
+            success_tuple_str = (
+                format_success_tuple(success_tuple, left_padding=1)
+                if success_tuple is not None
+                else None
+            )
+            success_tuple_text = (
+                rich_text.Text.from_ansi(success_tuple_str)
+            ) if success_tuple_str is not None else None
+
+            if success_tuple_text is None:
+                return rich_text.Text('')
+
+            return rich_text.Text('\n') + success_tuple_text
+
+
         for d in running_daemons:
             if d.hidden:
                 continue
             table.add_row(
                 d.daemon_id,
                 d.label,
-                rich_text.Text(d.status, style=('green' if ANSI else ''))
+                rich_console.Group(
+                    rich_text.Text(d.status, style=('green' if ANSI else '')),
+                ),
             )
 
         for d in paused_daemons:
@@ -77,16 +109,22 @@ def pprint_jobs(
             table.add_row(
                 d.daemon_id,
                 d.label,
-                rich_text.Text(d.status, style=('yellow' if ANSI else ''))
+                rich_console.Group(
+                    rich_text.Text(d.status, style=('yellow' if ANSI else '')),
+                ),
             )
 
         for d in stopped_daemons:
             if d.hidden:
                 continue
+
             table.add_row(
                 d.daemon_id,
                 d.label,
-                rich_text.Text(d.status, style=('red' if ANSI else ''))
+                rich_console.Group(
+                    rich_text.Text(d.status, style=('red' if ANSI else '')),
+                    get_success_text(d)
+                ),
             )
         get_console().print(table)
 

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1178,7 +1178,7 @@ def interval_str(delta: Union[timedelta, int]) -> str:
     A formatted string, fit for human eyes.
     """
     from meerschaum.utils.packages import attempt_import
-    humanfriendly = attempt_import('humanfriendly')
+    humanfriendly = attempt_import('humanfriendly', silent=True)
     delta_seconds = (
         delta.total_seconds()
         if isinstance(delta, timedelta)

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1178,7 +1178,7 @@ def interval_str(delta: Union[timedelta, int]) -> str:
     A formatted string, fit for human eyes.
     """
     from meerschaum.utils.packages import attempt_import
-    humanfriendly = attempt_import('humanfriendly', silent=True)
+    humanfriendly = attempt_import('humanfriendly')
     delta_seconds = (
         delta.total_seconds()
         if isinstance(delta, timedelta)

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -816,9 +816,9 @@ def pip_install(
     """
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
     from meerschaum.config import get_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.misc import is_android
-    from meerschaum.utils.daemon import running_in_daemon
     if args is None:
         args = ['--upgrade'] if not _uninstall else []
     if color:
@@ -827,7 +827,10 @@ def pip_install(
         ANSI, UNICODE = False, False
     if check_wheel:
         have_wheel = venv_contains_package('wheel', venv=venv, debug=debug)
-    if running_in_daemon:
+
+    daemon_env_var = STATIC_CONFIG['environment']['daemon_id']
+    inside_daemon = daemon_env_var in os.environ
+    if inside_daemon:
         silent = True
 
     _args = list(args)

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -818,6 +818,7 @@ def pip_install(
     from meerschaum.config import get_config
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.misc import is_android
+    from meerschaum.utils.daemon import running_in_daemon
     if args is None:
         args = ['--upgrade'] if not _uninstall else []
     if color:
@@ -826,6 +827,8 @@ def pip_install(
         ANSI, UNICODE = False, False
     if check_wheel:
         have_wheel = venv_contains_package('wheel', venv=venv, debug=debug)
+    if running_in_daemon:
+        silent = True
 
     _args = list(args)
     have_pip = venv_contains_package('pip', venv=None, debug=debug)
@@ -844,16 +847,16 @@ def pip_install(
     if have_pip and not have_uv_pip and _install_uv_pip and not is_android():
         if not pip_install(
             'uv',
-            venv = None,
-            debug = debug,
-            _install_uv_pip = False,
-            check_update = False,
-            check_pypi = False,
-            check_wheel = False,
-        ):
+            venv=None,
+            debug=debug,
+            _install_uv_pip=False,
+            check_update=False,
+            check_pypi=False,
+            check_wheel=False,
+        ) and not silent:
             warn(
                 f"Failed to install `uv` for virtual environment '{venv}'.",
-                color = False,
+                color=False,
             )
 
     use_uv_pip = (
@@ -909,13 +912,13 @@ def pip_install(
                     check_wheel = False,
                     debug = debug,
                     _install_uv_pip = False,
-                ):
+                ) and not silent:
                     warn(
                         (
                             "Failed to install `setuptools`, `wheel`, and `uv` for virtual "
                             + f"environment '{venv}'."
                         ),
-                        color = False,
+                        color=False,
                     )
 
         if requirements_file_path is not None:
@@ -975,7 +978,7 @@ def pip_install(
                 if not completely_uninstall_package(
                     _install_no_version,
                     venv=venv, debug=debug,
-                ):
+                ) and not silent:
                     warn(
                         f"Failed to clean up package '{_install_no_version}'.",
                     )
@@ -989,9 +992,9 @@ def pip_install(
         rc = run_python_package(
             ('pip' if not use_uv_pip else 'uv'),
             _args + _packages,
-            venv = None,
-            env = _get_pip_os_env(color=color),
-            debug = debug,
+            venv=None,
+            env=_get_pip_os_env(color=color),
+            debug=debug,
         )
         if debug:
             print(f"{rc=}")
@@ -1003,7 +1006,7 @@ def pip_install(
     )
     if not silent:
         print(msg)
-    if debug:
+    if debug and not silent:
         print('pip ' + ('un' if _uninstall else '') + 'install returned:', success)
     return success
 

--- a/meerschaum/utils/prompt.py
+++ b/meerschaum/utils/prompt.py
@@ -14,6 +14,7 @@ def prompt(
         question: str,
         icon: bool = True,
         default: Union[str, Tuple[str, str], None] = None,
+        default_editable: Optional[str] = None,
         detect_password: bool = True,
         is_password: bool = False,
         wrap_lines: bool = True,
@@ -36,6 +37,9 @@ def prompt(
 
     default: Union[str, Tuple[str, str], None], default None
         If the response is '', return the default value.
+
+    default_editable: Optional[str], default None
+        If provided, auto-type this user-editable string in the prompt.
 
     detect_password: bool, default True
         If `True`, set the input method to a censored password box if the word `password`
@@ -102,6 +106,7 @@ def prompt(
         prompt_toolkit.prompt(
             prompt_toolkit.formatted_text.ANSI(question),
             wrap_lines = wrap_lines,
+            default = default_editable or '',
             **filter_keywords(prompt_toolkit.prompt, **kw)
         ) if not noask else ''
     )

--- a/meerschaum/utils/schedule.py
+++ b/meerschaum/utils/schedule.py
@@ -110,21 +110,6 @@ def schedule_function(
     except RuntimeError:
         loop = asyncio.new_event_loop()
 
-    def sigint_handler(signum, frame):
-        """We need to re-raise KeyboardInterrupt SIGINT when daemonizing."""
-        print(f"{frame=}")
-        print('sigint in schedule')
-        from meerschaum.utils.daemon.Daemon import _daemons
-        print(f"{_daemons=}")
-        for daemon in _daemons:
-            try:
-                daemon._handle_interrupt(signum, frame)
-            except KeyboardInterrupt:
-                pass
-        raise KeyboardInterrupt
-
-    signal.signal(signal.SIGINT, sigint_handler)
-
 
     async def run_scheduler():
         async with _scheduler:


### PR DESCRIPTION
# v2.2.7

- **Fix daemon stability.**  
  Broken file handlers are now better handled, and this should keep background jobs from crashing.

- **Improve `show jobs` output.**  
  The `show jobs` table now includes the `SuccessTuple` of the most recent run (when jobs are stopped).

- **Use a plugin's `__doc__` string as the default description.**  
  When registering a new plugin, the `__doc__` string will be used as the default value for the description.

- **Pipes without connectors are no longer considered errors when syncing.**  
  When a pipe has an ordinary string in place of a connector (e.g. externally managed), return early and consider success rather than throwing an error.

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe('a', 'b')
  pipe.sync()
  # (True, "Pipe('a', 'b') does not support fetching; nothing to do.")
  ```

- **Add update announcements.**  
  When new Meerschaum releases become available, you will now be presented with an update message when starting the shell. Update checks may be disabled by setting `shell:updates:check_remote` to `false`.

- **Enforce a 10-minute max timeout for `APIConnectors`.**