### PR TITLE
⚡️ Add `uuid` dtype, improve MSSQL support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.6
+
+- **Prefix temporary tables with `##`.**  
+  Temporary tables are now prefixed with `##` to take advantage of `tempdb` in MSSQL.
+
+- **Add the `uuid` dtype.**  
+  The `uuid` dtype adds support for Python `UUID` objects and maps to the appropriate `UUID` data type per SQL flavor (e.g. `UNIQUEIDENTIFIER` for `mssql`).
+
+- **Add `upsert` support to MSSQL.**  
+  Setting `upsert` in a pipe's parameters will now upsert rows in a single transaction (via a `MERGE` query).
+
+- **Add `SQLConnector.get_connection()`.**  
+  To simplify connection management, you may now obtain an active connection with `SQLConnector.get_connection()`. To force a new connection, pass `rebuild=True`.
+
+- **Improve session management for MSSQL.**  
+  Transactions and connections are now more gracefully handled when working with MSSQL.
+
 ### v2.4.2 — v2.4.5
 
 - **Fix `bootstrap connectors`.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,23 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.6
+
+- **Prefix temporary tables with `##`.**  
+  Temporary tables are now prefixed with `##` to take advantage of `tempdb` in MSSQL.
+
+- **Add the `uuid` dtype.**  
+  The `uuid` dtype adds support for Python `UUID` objects and maps to the appropriate `UUID` data type per SQL flavor (e.g. `UNIQUEIDENTIFIER` for `mssql`).
+
+- **Add `upsert` support to MSSQL.**  
+  Setting `upsert` in a pipe's parameters will now upsert rows in a single transaction (via a `MERGE` query).
+
+- **Add `SQLConnector.get_connection()`.**  
+  To simplify connection management, you may now obtain an active connection with `SQLConnector.get_connection()`. To force a new connection, pass `rebuild=True`.
+
+- **Improve session management for MSSQL.**  
+  Transactions and connections are now more gracefully handled when working with MSSQL.
+
 ### v2.4.2 — v2.4.5
 
 - **Fix `bootstrap connectors`.**  

--- a/docs/mkdocs/reference/pipes/.pages
+++ b/docs/mkdocs/reference/pipes/.pages
@@ -3,4 +3,5 @@ nav:
   - "🥾 Bootstrapping": bootstrapping.md
   - "📥 Syncing": syncing.md
   - "🔖 Tags": tags.md
+  - "🧩 Parameters": parameters.md
   - ...

--- a/docs/mkdocs/reference/pipes/parameters.md
+++ b/docs/mkdocs/reference/pipes/parameters.md
@@ -1,0 +1,150 @@
+# 🧩 Parameters
+
+This page catalogs useful keys in the `parameters` dictionary.
+
+!!! tip "Custom Keys"
+
+    Remember that you have complete control of the `parameters` dictionary to store metadata in your pipes. It's a common pattern to set values under a custom key for your plugin.
+
+    ```python
+    pipe = mrsm.Pipe('a', 'b', parameters={'a': 1})
+    pipe.parameters.update({'a': 2})
+    pipe.edit() # alias: pipe.update()
+
+
+    print(mrsm.Pipe('a', 'b').parameters['a'])
+    # 2
+    ```
+
+---------------
+
+## `columns`
+
+The values of the `columns` dictionary are columns to be treated as a composite primary key. For example, the following would be used for a table with the index columns `ts` and `stationId`:
+
+
+!!! note inline end ""
+    Index columns **must be** immutable and unique as a collection.
+
+```yaml
+columns:
+  datetime: "ts"
+  id: "stationId"
+```
+
+### The `datetime` Index
+
+The naming of the keys does not matter with notable exception of the `datetime` key. The column specified as the `datetime` index will be used as the datetime axis for bounding.
+
+You may specify an integer column as the `datetime` axis if you explictly set its `dtype` as `int` (see below).
+
+## `dtypes`
+
+Meerschaum data types allow you to specify how columns should be parsed, deserialized, and stored. With the exception of special types like `numeric`, `uuid`, and `json`, you may specify other Pandas data types (e.g. `datetime64[ns]` for `datetime`).
+
+Below are the supported Meerschaum data types. See the [SQL dtypes source](https://github.com/bmeares/Meerschaum/blob/main/meerschaum/utils/dtypes/sql.py) to see which types map to specific database types.
+
+| Data Type  | Example                                        | Python, Pandas Types                         | SQL Types Notes                                                                  |
+|------------|------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------------------|
+| `int`      | `1`                                            | `int`, `Int64`, `int64[pyarrow]`, etc.       | `BIGINT`                                                                         |
+| `float`    | `1.1`                                          | `float`, `float64`, `float64[pyarrow]`, etc. | `DOUBLE PRECISION`, `FLOAT`                                                      |
+| `string`   | `'foo'`                                        | `str`, `string[python]`                      | `TEXT`. `NVARCHAR(MAX)` for MSSQL, `NVARCHAR2(2000)` for Oracle.                 |
+| `datetime` | `Timestamp('2024-01-01 00:00:00')`             | `datetime`, `Timestamp`                      | `TIMESTAMP`. Offsets are applied and stripped. All datetimes are treated as UTC. |
+| `numeric`  | `Decimal('1.000')`                             | `Decimal`                                    | `NUMERIC`, `DECIMAL`                                                             |
+| `uuid`     | `UUID('df2572b5-e42e-410d-a624-a14519f73e00')` | `UUID`                                       | `UUID` where supported. `UNIQUEIDENTIFIER` for MSSQL.                            |
+| `bool`     | `True`                                         | `boolean[pyarrow]`                           | `INT` for Oracle, MSSQL, MySQL / MariaDB. `FLOAT` for SQLite.                    |
+| `json`     | `{"foo": "bar"}`                               | `dict`, `list`                               | `JSONB` for PostgreSQL-like flavors, otherwise `TEXT`.                           |
+
+## `fetch`
+
+The `fetch` key contains parameters concerning the [fetch stage](/reference/pipes/syncing/) of the syncing process.
+
+### `fetch:backtrack_minutes`
+
+How many minutes of overlap to request when fetching new rows ― see [Backtracking](/reference/pipes/syncing/#backtracking). Defaults to 1440.
+
+### `fetch:definition`
+
+!!! example inline end ""
+    ```yaml
+    fetch:
+      definition: |-
+        SELECT *
+        FROM foo
+    ```
+    
+The base SQL query to be run when fetching new rows. Aliased as `sql` for convenience. This only applies to pipes with [`SQLConnectors`](/reference/connectors/sql-connectors/) as connectors.
+
+## `tags`
+
+A list of a pipe's [tags](/reference/pipes/tags/), e.g.:
+
+```yaml
+tags:
+- production
+- foo
+```
+
+## `schema`
+
+When syncing a pipe via a `SQLConnector`, you may override the connector's configured schema for the given pipe. This is useful when syncing against multiple schemas on the same database with a single `SQLConnector`.
+
+```yaml
+schema: production
+```
+
+## `sql`, `query`
+
+Aliases for `fetch:definition`.
+
+## `upsert`
+
+Setting `upsert` to `true` enables high-performance syncs by combining inserts and updates into a single transaction.
+
+Upserts rely on unique constraints on indices and as such should be used in situations where a table's schema is fixed. See the [upsert SQL source](https://github.com/bmeares/Meerschaum/blob/main/meerschaum/utils/sql.py) for further details.
+
+```python
+import meerschaum as mrsm
+
+pipe = mrsm.Pipe(
+    'demo', 'upsert',
+    instance = 'sql:local',
+    columns = ['datetime', 'id'],
+    parameters = {'upsert': True},
+)
+
+mrsm.pprint(
+    pipe.sync(
+        [
+            {'datetime': '2023-01-01', 'id': 1, 'val': 1.1},
+            {'datetime': '2023-01-02', 'id': 2, 'val': 2.2},
+        ]
+    )
+)
+#  🎉 Upserted 2 rows.
+```
+
+## `valkey`
+
+The `valkey` key is used internally to keep internal metadata separate from user configuration when syncing against a `ValkeyConnector`.
+
+## `verify`
+
+The `verify` key contains parameters concerning [verification syncs](/reference/pipes/syncing/#verification-syncs).
+
+### `verify:bound_days`
+
+The key `verify:bound_days` specifies the interval when determining the bound time, which is limit at which long-running verfication syncs should stop.
+
+In addition to days, alias keys are allowed to specify other units of time. In order of priority, the supported keys are the following:
+
+- `bound_minutes`
+- `bound_hours`
+- `bound_days`
+- `bound_weeks`
+- `bound_years`
+- `bound_seconds`
+
+### `verify:chunk_minutes`
+
+The key `verify:chunk_minutes` specifies the size of chunk intervals when verifying a pipe. See [`Pipe.get_chunk_bounds()`](https://docs.meerschaum.io/meerschaum.html#Pipe.get_chunk_bounds).

--- a/meerschaum/_internal/docs/index.py
+++ b/meerschaum/_internal/docs/index.py
@@ -545,6 +545,7 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.dataframe.get_unhashable_cols()</code></li>
       <li><code>meerschaum.utils.dataframe.parse_df_datetimes()</code></li>
       <li><code>meerschaum.utils.dataframe.query_df()</code></li>
+      <li><code>meerschaum.utils.dataframe.to_json()</code></li>
     </ul>
   </details>
   </ul>

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -309,6 +309,7 @@ def _show_data(
     from meerschaum.utils.packages import attempt_import, import_pandas
     from meerschaum.utils.warnings import warn, info
     from meerschaum.utils.formatting import pprint
+    from meerschaum.utils.dataframe import to_json
     pd = import_pandas()
 
     if action is None:
@@ -372,7 +373,7 @@ def _show_data(
             info(info_msg)
         else:
             print(json.dumps(p.__getstate__()))
-            df = df.fillna(pd.NA).to_json(orient='columns')
+            df = to_json(df, orient='columns')
 
         pprint(df, nopretty=nopretty)
 

--- a/meerschaum/actions/sql.py
+++ b/meerschaum/actions/sql.py
@@ -15,12 +15,12 @@ exec_methods = {
 }
 
 def sql(
-        action: Optional[List[str]] = None,
-        gui: bool = False,
-        nopretty: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ):
+    action: Optional[List[str]] = None,
+    gui: bool = False,
+    nopretty: bool = False,
+    debug: bool = False,
+    **kw: Any
+):
     """Execute a SQL query or launch an interactive CLI. All positional arguments are optional.
     
     Usage:
@@ -59,6 +59,7 @@ def sql(
         - `sql local exec "INSERT INTO table (id) VALUES (1)"
             Execute the above query on `sql:local`.
     """
+    from meerschaum.utils.dataframe impor to_json
 
     if action is None:
         action = []
@@ -135,11 +136,10 @@ def sql(
             pprint(result)
         else:
             print(
-                result.fillna(pd.NA).to_json(
-                    date_format = 'iso',
-                    orient = 'split',
-                    index = False,
-                    date_unit = 'us'
+                to_json(
+                    result,
+                    orient='split',
+                    index=False,
                 )
             )
 

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -18,6 +18,7 @@ from meerschaum.utils.misc import string_to_dict
 from meerschaum.utils.packages import attempt_import, import_dcc, import_html, import_pandas
 from meerschaum.utils.sql import get_pd_type
 from meerschaum.utils.yaml import yaml
+from meerschaum.utils.dataframe import to_json
 from meerschaum.connectors.sql._fetch import get_pipe_query
 from meerschaum.api import CHECK_UPDATE
 from meerschaum.api.dash import debug, _get_pipes
@@ -563,12 +564,13 @@ def accordion_items_from_pipe(
     if 'sync-data' in active_items:
         backtrack_df = pipe.get_backtrack_data(debug=debug, limit=1)
         try:
-            json_text = backtrack_df.fillna(pd.NA).to_json(
+            json_text = to_json(
+                backtrack_df,
                 orient='records',
                 date_format='iso',
                 force_ascii=False,
                 indent=4,
-                date_unit='ns',
+                date_unit='us',
             ) if backtrack_df is not None else '[]'
         except Exception as e:
             warn(e)

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -27,7 +27,7 @@ from decimal import Decimal
 from meerschaum import Pipe
 from meerschaum.api.models import MetaPipe
 from meerschaum.utils.packages import attempt_import, import_pandas
-from meerschaum.utils.dataframe import get_numeric_cols
+from meerschaum.utils.dataframe import get_numeric_cols, to_json
 from meerschaum.utils.misc import (
     is_pipe_registered, round_time, is_int, parse_df_datetimes,
     replace_pipes_in_dict,
@@ -473,15 +473,10 @@ def get_pipe_data(
     for col in numeric_cols:
         df[col] = df[col].apply(lambda x: f'{x:f}' if isinstance(x, Decimal) else x)
 
-    json_content = df.to_json(
-        date_format='iso',
-        orient='records',
-        date_unit='us',
-    )
-
+    json_content = to_json(df)
     return fastapi.Response(
         json_content,
-        media_type = 'application/json',
+        media_type='application/json',
     )
 
 

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.6rc2"
+__version__ = "2.4.6rc3"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.6rc1"
+__version__ = "2.4.6rc2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.6rc3"
+__version__ = "2.4.6"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.5"
+__version__ = "2.4.6rc1"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -171,8 +171,8 @@ def sync_pipe(
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.misc import json_serialize_datetime, items_str
     from meerschaum.config import get_config
-    from meerschaum.utils.packages import attempt_import, import_pandas
-    from meerschaum.utils.dataframe import get_numeric_cols
+    from meerschaum.utils.packages import attempt_import
+    from meerschaum.utils.dataframe import get_numeric_cols, to_json
     begin = time.time()
     more_itertools = attempt_import('more_itertools')
     if df is None:
@@ -183,8 +183,7 @@ def sync_pipe(
         ### allow syncing dict or JSON without needing to import pandas (for IOT devices)
         if isinstance(c, (dict, list)):
             return json.dumps(c, default=json_serialize_datetime)
-        pd = import_pandas()
-        return c.fillna(pd.NA).to_json(date_format='iso', date_unit='ns')
+        return to_json(c, orient='columns')
 
     df = json.loads(df) if isinstance(df, str) else df
 
@@ -202,6 +201,7 @@ def sync_pipe(
             if not is_dask
             else [partition.compute() for partition in df.partitions]
         )
+
         numeric_cols = get_numeric_cols(df)
         if numeric_cols:
             for col in numeric_cols:

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -35,6 +35,7 @@ class SQLConnector(Connector):
         to_sql,
         exec_queries,
         get_connection,
+        _cleanup_connections,
     )
     from meerschaum.utils.sql import test_connection
     from ._fetch import fetch, get_pipe_metadef

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -13,6 +13,7 @@ from meerschaum.utils.typing import Optional, Any, Union
 from meerschaum.connectors import Connector
 from meerschaum.utils.warnings import error
 
+
 class SQLConnector(Connector):
     """
     Connect to SQL databases via `sqlalchemy`.
@@ -26,7 +27,15 @@ class SQLConnector(Connector):
     IS_INSTANCE: bool = True
 
     from ._create_engine import flavor_configs, create_engine
-    from ._sql import read, value, exec, execute, to_sql, exec_queries
+    from ._sql import (
+        read,
+        value,
+        exec,
+        execute,
+        to_sql,
+        exec_queries,
+        get_connection,
+    )
     from meerschaum.utils.sql import test_connection
     from ._fetch import fetch, get_pipe_metadef
     from ._cli import cli, _cli_exit
@@ -85,7 +94,7 @@ class SQLConnector(Connector):
         _drop_temporary_tables,
         _drop_old_temporary_tables,
     )
-    
+
     def __init__(
         self,
         label: Optional[str] = None,

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -71,7 +71,13 @@ flavor_configs = {
         'requirements': default_requirements,
         'defaults': {
             'port': 1433,
-            'options': "driver=ODBC Driver 18 for SQL Server&UseFMTONLY=Yes&TrustServerCertificate=yes&Encrypt=no",
+            'options': (
+                "driver=ODBC Driver 18 for SQL Server"
+                "&UseFMTONLY=Yes"
+                "&TrustServerCertificate=yes"
+                "&Encrypt=no"
+                "&MARS_Connection=yes"
+            ),
         },
     },
     'mysql': {
@@ -167,12 +173,13 @@ flavor_dialects = {
     'duckdb': ('duckdb', 'duckdb_engine', 'Dialect'),
 }
 
+
 def create_engine(
-        self,
-        include_uri: bool = False,
-        debug: bool = False,
-        **kw
-    ) -> 'sqlalchemy.engine.Engine':
+    self,
+    include_uri: bool = False,
+    debug: bool = False,
+    **kw
+) -> 'sqlalchemy.engine.Engine':
     """Create a sqlalchemy engine by building the engine string."""
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.warnings import error, warn

--- a/meerschaum/connectors/valkey/_ValkeyConnector.py
+++ b/meerschaum/connectors/valkey/_ValkeyConnector.py
@@ -202,11 +202,8 @@ class ValkeyConnector(Connector):
         -------
         The current index counter value (how many docs have been pushed).
         """
-        docs_str = df.to_json(
-            date_format='iso',
-            orient='records',
-            date_unit='us',
-        )
+        from meerschaum.utils.dataframe import to_json
+        docs_str = to_json(df)
         docs = json.loads(docs_str)
         return self.push_docs(
             docs,

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -123,6 +123,7 @@ class Pipe:
         get_num_workers,
         _persist_new_json_columns,
         _persist_new_numeric_columns,
+        _persist_new_uuid_columns,
     )
     from ._verify import (
         verify,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -298,7 +298,7 @@ def get_val_column(self, debug: bool = False) -> Union[str, None]:
                 break
     if not candidates:
         if debug:
-            dprint(f"No value column could be determined.")
+            dprint("No value column could be determined.")
         return None
 
     return candidates[0]

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -574,10 +574,10 @@ def get_rowcount(
 
 
 def get_chunk_interval(
-        self,
-        chunk_interval: Union[timedelta, int, None] = None,
-        debug: bool = False,
-    ) -> Union[timedelta, int]:
+    self,
+    chunk_interval: Union[timedelta, int, None] = None,
+    debug: bool = False,
+) -> Union[timedelta, int]:
     """
     Get the chunk interval to use for this pipe.
 
@@ -615,18 +615,18 @@ def get_chunk_interval(
 
 
 def get_chunk_bounds(
-        self,
-        begin: Union[datetime, int, None] = None,
-        end: Union[datetime, int, None] = None,
-        bounded: bool = False,
-        chunk_interval: Union[timedelta, int, None] = None,
-        debug: bool = False,
-    ) -> List[
-        Tuple[
-            Union[datetime, int, None],
-            Union[datetime, int, None],
-        ]
-    ]:
+    self,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    bounded: bool = False,
+    chunk_interval: Union[timedelta, int, None] = None,
+    debug: bool = False,
+) -> List[
+    Tuple[
+        Union[datetime, int, None],
+        Union[datetime, int, None],
+    ]
+]:
     """
     Return a list of datetime bounds for iterating over the pipe's `datetime` axis.
 

--- a/meerschaum/core/Pipe/_deduplicate.py
+++ b/meerschaum/core/Pipe/_deduplicate.py
@@ -12,17 +12,17 @@ from meerschaum.utils.typing import SuccessTuple, Any, Optional, Dict, Tuple, Un
 
 
 def deduplicate(
-        self,
-        begin: Union[datetime, int, None] = None,
-        end: Union[datetime, int, None] = None,
-        params: Optional[Dict[str, Any]] = None,
-        chunk_interval: Union[datetime, int, None] = None,
-        bounded: Optional[bool] = None,
-        workers: Optional[int] = None,
-        debug: bool = False,
-        _use_instance_method: bool = True,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    self,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    chunk_interval: Union[datetime, int, None] = None,
+    bounded: Optional[bool] = None,
+    workers: Optional[int] = None,
+    debug: bool = False,
+    _use_instance_method: bool = True,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Call the Pipe's instance connector's `delete_duplicates` method to delete duplicate rows.
 
@@ -158,10 +158,10 @@ def deduplicate(
         chunk_msg_body = ""
 
         full_chunk = self.get_data(
-            begin = chunk_begin,
-            end = chunk_end,
-            params = params,
-            debug = debug,
+            begin=chunk_begin,
+            end=chunk_end,
+            params=params,
+            debug=debug,
         )
         if full_chunk is None or len(full_chunk) == 0:
             return bounds, (True, f"{chunk_msg_header}\nChunk is empty, skipping...")
@@ -171,10 +171,10 @@ def deduplicate(
             return bounds, (False, f"None of {items_str(indices)} were present in chunk.")
         try:
             full_chunk = full_chunk.drop_duplicates(
-                subset = chunk_indices,
-                keep = 'last'
+                subset=chunk_indices,
+                keep='last'
             ).reset_index(
-                drop = True,
+                drop=True,
             )
         except Exception as e:
             return (
@@ -183,10 +183,10 @@ def deduplicate(
             )
 
         clear_success, clear_msg = self.clear(
-            begin = chunk_begin,
-            end = chunk_end,
-            params = params,
-            debug = debug,
+            begin=chunk_begin,
+            end=chunk_end,
+            params=params,
+            debug=debug,
         )
         if not clear_success:
             chunk_msg_body += f"Failed to clear chunk while deduplicating:\n{clear_msg}\n"
@@ -195,13 +195,13 @@ def deduplicate(
         sync_success, sync_msg = self.sync(full_chunk, debug=debug)
         if not sync_success:
             chunk_msg_body += f"Failed to sync chunk while deduplicating:\n{sync_msg}\n"
-         
+
         ### Finally check if the deduplication worked.
         chunk_rowcount = self.get_rowcount(
-            begin = chunk_begin,
-            end = chunk_end,
-            params = params,
-            debug = debug,
+            begin=chunk_begin,
+            end=chunk_end,
+            params=params,
+            debug=debug,
         )
         if chunk_rowcount != deduped_chunk_len:
             return bounds, (

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -281,9 +281,9 @@ def verify(
 
 
 def get_chunks_success_message(
-        chunk_success_tuples: Dict[Tuple[Any, Any], SuccessTuple],
-        header: str = '',
-    ) -> str:
+    chunk_success_tuples: Dict[Tuple[Any, Any], SuccessTuple],
+    header: str = '',
+) -> str:
     """
     Sum together all of the inserts and updates from the chunks.
 
@@ -323,8 +323,8 @@ def get_chunks_success_message(
             + ([f'updated {num_updated}'] if num_updated else [])
             + ([f'upserted {num_upserted}'] if num_upserted else [])
         ) or ['synced 0'],
-        quotes = False,
-        and_ = False,
+        quotes=False,
+        and_=False,
     )
 
     success_msg = (

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1306,5 +1306,49 @@ def query_df(
 
     _process_select_columns(result_df)
     _process_omit_columns(result_df)
-    
+
     return result_df
+
+
+def to_json(
+    df: 'pd.DataFrame',
+    safe_copy: bool = True,
+    orient: str = 'records',
+    date_format: str = 'iso',
+    date_unit: str = 'us',
+    **kwargs: Any
+) -> str:
+    """
+    Serialize the given dataframe as a JSON string.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The DataFrame to be serialized.
+
+    safe_copy: bool, default True
+        If `False`, modify the DataFrame inplace.
+
+    date_format: str, default 'iso'
+        The default format for timestamps.
+
+    date_unit: str, default 'us'
+        The precision of the timestamps.
+
+    Returns
+    -------
+    A JSON string.
+    """
+    from meerschaum.utils.packages import import_pandas
+    pd = import_pandas()
+    uuid_cols = get_uuid_cols(df)
+    if uuid_cols and safe_copy:
+        df = df.copy()
+    for col in uuid_cols:
+        df[col] = df[col].astype(str)
+    return df.fillna(pd.NA).to_json(
+        date_format=date_format,
+        date_unit=date_unit,
+        orient=orient,
+        **kwargs
+    )

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -55,6 +55,7 @@ DB_FLAVORS_CAST_DTYPES = {
         'NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS"': 'NVARCHAR(MAX)',
         'VARCHAR COLLATE "SQL Latin1 General CP1 CI AS"': 'NVARCHAR(MAX)',
         'VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS"': 'NVARCHAR(MAX)',
+        'NVARCHAR': 'NVARCHAR(MAX)',
     },
 }
 for _flavor, (_precision, _scale) in NUMERIC_PRECISION_FLAVORS.items():
@@ -92,6 +93,8 @@ DB_TO_PD_DTYPES: Dict[str, Union[str, Dict[str, str]]] = {
     'BIT(1)': 'bool[pyarrow]',
     'JSON': 'json',
     'JSONB': 'json',
+    'UUID': 'uuid',
+    'UNIQUEIDENTIFIER': 'uuid',
     'substrings': {
         'CHAR': 'string[pyarrow]',
         'TIMESTAMP': 'datetime64[ns]',
@@ -239,6 +242,19 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'cockroachdb': 'NUMERIC',
         'default': 'NUMERIC',
     },
+    'uuid': {
+        'timescaledb': 'UUID',
+        'postgresql': 'UUID',
+        'mariadb': 'CHAR(36)',
+        'mysql': 'CHAR(36)',
+        'mssql': 'UNIQUEIDENTIFIER',
+        'oracle': 'VARCHAR2(36)',
+        'sqlite': 'TEXT',
+        'duckdb': 'UUID',
+        'citus': 'UUID',
+        'cockroachdb': 'UUID',
+        'default': 'TEXT',
+    },
 }
 PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
     'int': {
@@ -357,6 +373,19 @@ PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'citus': 'Numeric',
         'cockroachdb': 'Numeric',
         'default': 'Numeric',
+    },
+    'uuid': {
+        'timescaledb': 'Uuid',
+        'postgresql': 'Uuid',
+        'mariadb': 'Uuid',
+        'mysql': 'Uuid',
+        'mssql': 'Uuid',
+        'oracle': 'Uuid',
+        'sqlite': 'Uuid',
+        'duckdb': 'Uuid',
+        'citus': 'Uuid',
+        'cockroachdb': 'Uuid',
+        'default': 'Uuid',
     },
 }
 

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -248,7 +248,8 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'mariadb': 'CHAR(36)',
         'mysql': 'CHAR(36)',
         'mssql': 'UNIQUEIDENTIFIER',
-        'oracle': 'VARCHAR2(36)',
+        ### I know this is too much space, but erring on the side of caution.
+        'oracle': 'NVARCHAR(2000)',
         'sqlite': 'TEXT',
         'duckdb': 'UUID',
         'citus': 'UUID',
@@ -380,7 +381,7 @@ PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'mariadb': 'Uuid',
         'mysql': 'Uuid',
         'mssql': 'Uuid',
-        'oracle': 'Uuid',
+        'oracle': 'UnicodeText',
         'sqlite': 'Uuid',
         'duckdb': 'Uuid',
         'citus': 'Uuid',

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -245,8 +245,8 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
     'uuid': {
         'timescaledb': 'UUID',
         'postgresql': 'UUID',
-        'mariadb': 'CHAR(36)',
-        'mysql': 'CHAR(36)',
+        'mariadb': 'CHAR(32)',
+        'mysql': 'CHAR(32)',
         'mssql': 'UNIQUEIDENTIFIER',
         ### I know this is too much space, but erring on the side of caution.
         'oracle': 'NVARCHAR(2000)',

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -959,7 +959,7 @@ def get_connector_labels(
 def json_serialize_datetime(dt: datetime) -> Union[str, None]:
     """
     Serialize a datetime object into JSON (ISO format string).
-    
+
     Examples
     --------
     >>> import json

--- a/meerschaum/utils/yaml.py
+++ b/meerschaum/utils/yaml.py
@@ -61,7 +61,6 @@ class yaml:
             _yaml.add_representer(str, _string_presenter)
             _yaml.representer.SafeRepresenter.add_representer(str, _string_presenter)
 
-
     @staticmethod
     def safe_load(*args, **kw):
         """
@@ -71,7 +70,6 @@ class yaml:
             return _yaml.load(*args, **filter_keywords(_yaml.load, **kw))
         return _yaml.safe_load(*args, **filter_keywords(_yaml.safe_load, **kw))
 
-
     @staticmethod
     def load(*args, **kw):
         """
@@ -80,15 +78,14 @@ class yaml:
         (added `yaml.Loader` as a positional argument).
         """
         packaging_version = attempt_import('packaging.version')
-        _args = list(args)
         if (
             _import_name == 'yaml'
             and packaging_version.parse(_yaml.__version__) >= packaging_version.parse('6.0')
+            and 'Loader' not in kw
         ):
-            _args += [_yaml.Loader]
-        
-        return _yaml.load(*_args, **filter_keywords(_yaml.load, **kw))
+            kw['Loader'] = _yaml.FullLoader
 
+        return _yaml.load(*args, **filter_keywords(_yaml.load, **kw))
 
     @staticmethod
     def dump(data, stream=None, **kw):

--- a/meerschaum/utils/yaml.py
+++ b/meerschaum/utils/yaml.py
@@ -83,7 +83,7 @@ class yaml:
             and packaging_version.parse(_yaml.__version__) >= packaging_version.parse('6.0')
             and 'Loader' not in kw
         ):
-            kw['Loader'] = _yaml.FullLoader
+            kw['Loader'] = _yaml.Loader
 
         return _yaml.load(*args, **filter_keywords(_yaml.load, **kw))
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -23,7 +23,7 @@ def test_create_job():
     success, msg = job.start()
     assert success, msg
 
-    duration = 0.3
+    duration = 1.0
     time.sleep(duration)
 
     success, msg = job.stop()

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -583,7 +583,6 @@ def test_sync_uuids_inplace(flavor: str):
     assert 'uuid' in inplace_pipe.dtypes['uuid_col']
     assert inplace_pipe.get_rowcount() == len(docs)
     db_col = inplace_pipe.get_columns_types()['uuid_col']
-    print(f"{db_col=}")
     if flavor in PD_TO_DB_DTYPES_FLAVORS['uuid']:
         uuid_typ = PD_TO_DB_DTYPES_FLAVORS['uuid'][flavor]
         assert db_col == uuid_typ

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -5,6 +5,7 @@
 import pytest
 import datetime
 from decimal import Decimal
+from uuid import UUID
 from tests import debug
 from tests.connectors import conns, get_flavors
 from tests.test_users import test_register_user
@@ -12,6 +13,7 @@ import meerschaum as mrsm
 from meerschaum import Pipe
 from meerschaum.utils.dtypes import are_dtypes_equal
 from meerschaum.utils.sql import sql_item_name
+from meerschaum.utils.dtypes.sql import PD_TO_DB_DTYPES_FLAVORS
 
 @pytest.fixture(autouse=True)
 def run_before_and_after(flavor: str):
@@ -66,6 +68,7 @@ def test_dtype_enforcement(flavor: str):
             'json': 'json',
             'numeric': 'numeric',
             'str': 'str',
+            'uuid': 'uuid',
         },
         instance=conn,
     )
@@ -76,9 +79,10 @@ def test_dtype_enforcement(flavor: str):
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'str': 'bar'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'json': '{"a": {"b": 1}}'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'numeric': '1'}], debug=debug)
+    pipe.sync([{'dt': '2022-01-01', 'id': 1, 'uuid': '00000000-1234-5678-0000-000000000000'}], debug=debug)
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
-    assert len(df.columns) == 9
+    assert len(df.columns) == 10
     for col, typ in df.dtypes.items():
         pipe_dtype = pipe.dtypes[col]
         if pipe_dtype == 'json':
@@ -86,6 +90,9 @@ def test_dtype_enforcement(flavor: str):
             pipe_dtype = 'object'
         elif pipe_dtype == 'numeric':
             assert isinstance(df[col][0], Decimal)
+            pipe_dtype = 'object'
+        elif pipe_dtype == 'uuid':
+            assert isinstance(df[col][0], UUID)
             pipe_dtype = 'object'
         elif pipe_dtype == 'str':
             assert isinstance(df[col][0], str)
@@ -144,7 +151,7 @@ def test_force_json_dtype(flavor: str):
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_infer_numeric_dtype(flavor: str):
     """
-    Ensure that `Decimal` objects are persisted as `numeric`. 
+    Ensure that `Decimal` objects are persisted as `numeric`.
     """
     from meerschaum.utils.formatting import pprint
     from meerschaum.utils.misc import generate_password
@@ -176,6 +183,31 @@ def test_infer_numeric_dtype(flavor: str):
     assert df['a'][0] == Decimal('1')
     assert isinstance(df['a'][1], Decimal)
     assert df['a'][1] == Decimal(numeric_str)
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_infer_uuid_dtype(flavor: str):
+    """
+    Ensure that `UUID` objects are persisted as `uuid`.
+    """
+    from meerschaum.utils.formatting import pprint
+    conn = conns[flavor]
+    pipe = Pipe('infer', 'uuid', instance=conn)
+    _ = pipe.delete(debug=debug)
+    pipe = Pipe('infer', 'uuid', instance=conn)
+    uuid_str = "e6f3a4ea-f1af-4e93-8da9-716b57672206"
+    success, msg = pipe.sync(
+        [
+            {'a': UUID(uuid_str)},
+        ],
+        debug=debug,
+    )
+    assert success, msg
+    pprint(pipe.get_columns_types())
+    df = pipe.get_data(debug=debug)
+    print(df)
+    assert isinstance(df['a'][0], UUID)
+    assert df['a'][0] == UUID(uuid_str)
 
 
 @pytest.mark.parametrize("flavor", get_flavors())
@@ -502,3 +534,71 @@ def test_sync_bools_inplace(flavor: str):
     assert success, msg
     df = inplace_pipe.get_data(params={'id': 3})
     assert 'na' in str(df['is_bool'][0]).lower()
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_sync_uuids_inplace(flavor: str):
+    """
+    Test that pipes are able to sync UUIDs in-place.
+    """
+    conn = conns[flavor]
+    if conn.type not in ('api', 'sql'):
+        return
+    pipe = mrsm.Pipe('test', 'uuid', 'inplace', instance=conn)
+    _ = pipe.delete()
+    pipe = mrsm.Pipe(
+        'test', 'uuid', 'inplace',
+        instance=conn,
+        columns={'datetime': 'dt', 'id': 'id'},
+    )
+    pipe_table = sql_item_name(pipe.target, conn.flavor) if conn.type == 'sql' else pipe.target
+    inplace_pipe = mrsm.Pipe(conn, 'uuid', 'inplace', instance=conn)
+    _ = inplace_pipe.delete()
+    inplace_pipe = mrsm.Pipe(
+        conn, 'uuid', 'inplace',
+        instance=conn,
+        columns=pipe.columns,
+        dtypes={
+            'uuid_col': 'uuid',
+        },
+        parameters={
+            'fetch': {
+                'definition': f"SELECT * FROM {pipe_table}",
+                'pipe': pipe.keys(),
+            },
+        },
+    )
+    _ = pipe.drop()
+    docs = [
+        {'dt': '2023-01-01', 'id': 1, 'uuid_col': UUID('77e704d2-7513-45c7-b806-7b5cb0badc37')},
+        {'dt': '2023-01-02', 'id': 2, 'uuid_col': UUID('2854eeed-2911-4641-8d67-6ecd217392cc')},
+        {'dt': '2023-01-03', 'id': 3},
+    ]
+    success, msg = pipe.sync(docs)
+    assert success, msg
+
+    success, msg = inplace_pipe.sync(debug=debug)
+    assert success, msg
+
+    assert 'uuid' in inplace_pipe.dtypes['uuid_col']
+    assert inplace_pipe.get_rowcount() == len(docs)
+    db_col = inplace_pipe.get_columns_types()['uuid_col']
+    print(f"{db_col=}")
+    if flavor in PD_TO_DB_DTYPES_FLAVORS['uuid']:
+        uuid_typ = PD_TO_DB_DTYPES_FLAVORS['uuid'][flavor]
+        assert db_col == uuid_typ
+
+    df = inplace_pipe.get_data()
+
+    update_uuid = UUID('a12bbc7c-4595-4bfe-a9b6-8b81c6e329c8')
+    pipe.sync([{'dt': '2023-01-03', 'id': 3, 'uuid_col': update_uuid}])
+    success, msg = inplace_pipe.sync(debug=debug)
+    assert success, msg
+    df = inplace_pipe.get_data(params={'id': 3})
+    assert df['uuid_col'][0] == update_uuid
+
+    pipe.sync([{'dt': '2023-01-03', 'id': 3, 'uuid_col': None}])
+    success, msg = inplace_pipe.sync(debug=debug)
+    assert success, msg
+    df = inplace_pipe.get_data(params={'id': 3})
+    assert df['uuid_col'][0] is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -211,9 +211,9 @@ def test_sync_new_columns(flavor: str):
     Test that new columns are added.
     """
     conn = conns[flavor]
-    pipe = Pipe('foo', 'bar', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
+    pipe = Pipe('new', 'cols', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
     pipe.delete(debug=debug)
-    pipe = Pipe('foo', 'bar', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
+    pipe = Pipe('new', 'cols', columns={'datetime': 'dt', 'id': 'id'}, instance=conn)
     docs = [
         {'dt': '2022-01-01', 'id': 1, 'a': 10},
     ]
@@ -478,17 +478,17 @@ def test_sync_inplace(flavor: str):
     source_pipe.delete()
     source_pipe = Pipe(
         'test', 'inplace', 'src',
-        instance = conn,
-        columns = {'datetime': 'dt'}
+        instance=conn,
+        columns={'datetime': 'dt'}
     )
     dest_pipe = Pipe(str(conn), 'inplace', 'dest', instance=conn)
     dest_pipe.delete()
     query = f"SELECT * FROM {sql_item_name(source_pipe.target, flavor)}"
     dest_pipe = Pipe(
         str(conn), 'inplace', 'dest',
-        instance = conn,
-        columns = {'datetime': 'dt'},
-        parameters = {
+        instance=conn,
+        columns={'datetime': 'dt'},
+        parameters={
             "fetch": {
                 "definition": query,
                 "backtrack_minutes": 1440,

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -16,6 +16,7 @@ import meerschaum as mrsm
 from meerschaum import Pipe
 from meerschaum.actions import actions
 
+
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_verify_backfill_simple(flavor: str):
     """
@@ -87,7 +88,7 @@ def test_verify_backfill_inplace(flavor: str):
     source_rowcount = source_pipe.get_rowcount()
     target_rowcount = target_pipe.get_rowcount()
     assert source_rowcount == target_rowcount
-    
+
     backfill_begin = datetime(2022, 12, 24)
     backfill_end = datetime(2022, 12, 26)
     _ = source_pipe.sync(begin=backfill_begin, end=backfill_end)

--- a/tests/utils/test_dtypes.py
+++ b/tests/utils/test_dtypes.py
@@ -6,7 +6,6 @@
 Test functions from `meerschaum.utils.misc`.
 """
 
-import datetime
 import pytest
 from meerschaum.utils.packages import import_pandas
 DEBUG: bool = True
@@ -27,6 +26,7 @@ pd = import_pandas(debug=DEBUG)
         ('json', 'object', True),
         ('float', 'object', False),
         ('datetime', 'object', False),
+        ('uuid', 'object', True),
     ]
 )
 def test_are_dtypes_equal(ldtype: str, rdtype: str, are_equal: bool):


### PR DESCRIPTION
# v2.4.6

- **Prefix temporary tables with `##`.**  
  Temporary tables are now prefixed with `##` to take advantage of `tempdb` in MSSQL.

- **Add the `uuid` dtype.**  
  The `uuid` dtype adds support for Python `UUID` objects and maps to the appropriate `UUID` data type per SQL flavor (e.g. `UNIQUEIDENTIFIER` for `mssql`).

- **Add `upsert` support to MSSQL.**  
  Setting `upsert` in a pipe's parameters will now upsert rows in a single transaction (via a `MERGE` query).

- **Add `SQLConnector.get_connection()`.**  
  To simplify connection management, you may now obtain an active connection with `SQLConnector.get_connection()`. To force a new connection, pass `rebuild=True`.

- **Improve session management for MSSQL.**  
  Transactions and connections are now more gracefully handled when working with MSSQL.
