### PR TITLE
✨ v2.4.9 Add relative dates to `--begin`, `--end`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.9
+
+- **Add relative formats to `--begin` and `--end`.**  
+  The flags `--begin` and `--end` support values in the format `[N] [unit] ago`:
+  
+  ```bash
+  mrsm sync pipes --begin '3 days ago'
+  ```
+
+  Add a second delta format (recommended to be denoted by the keyword `rounded`) to round the timestamp to a clean value:
+
+  ```bash
+  mrsm clear pipes --end '1 month ago rounded 1 day'
+  ```
+
+  Supported units are `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` (`ago` only), and `years`.
+
+- **Respect `--begin`, `--end`, and `--params` in `show rowcounts`.**  
+  The flags `--begin`, `--end`, and `--params` are now handled in the action `show rowcounts`.
+
 ### v2.4.8
 
 - **Allow for syncing against `DATETIMEOFFSET` columns in MSSQL.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,26 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.9
+
+- **Add relative formats to `--begin` and `--end`.**  
+  The flags `--begin` and `--end` support values in the format `[N] [unit] ago`:
+  
+  ```bash
+  mrsm sync pipes --begin '3 days ago'
+  ```
+
+  Add a second delta format (recommended to be denoted by the keyword `rounded`) to round the timestamp to a clean value:
+
+  ```bash
+  mrsm clear pipes --end '1 month ago rounded 1 day'
+  ```
+
+  Supported units are `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` (`ago` only), and `years`.
+
+- **Respect `--begin`, `--end`, and `--params` in `show rowcounts`.**  
+  The flags `--begin`, `--end`, and `--params` are now handled in the action `show rowcounts`.
+
 ### v2.4.8
 
 - **Allow for syncing against `DATETIMEOFFSET` columns in MSSQL.**  

--- a/meerschaum/actions/show.py
+++ b/meerschaum/actions/show.py
@@ -7,6 +7,8 @@ This module contains functions for printing elements.
 """
 
 from __future__ import annotations
+
+from datetime import datetime
 import meerschaum as mrsm
 from meerschaum.utils.typing import SuccessTuple, Union, Sequence, Any, Optional, List, Dict, Tuple
 
@@ -274,8 +276,8 @@ def _show_arguments(
 def _show_data(
     action: Optional[List[str]] = None,
     gui: bool = False,
-    begin: Optional[datetime.datetime] = None,
-    end: Optional[datetime.datetime] = None,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
     params: Optional[Dict[str, Any]] = None,
     chunksize: Optional[int] = -1,
     nopretty: bool = False,
@@ -401,12 +403,15 @@ def _show_columns(
 def _show_rowcounts(
     action: Optional[List[str]] = None,
     workers: Optional[int] = None,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
     debug: bool = False,
     **kw: Any
 ) -> SuccessTuple:
     """
     Show the rowcounts for pipes.
-    
+
     To see remote rowcounts (execute `COUNT(*)` on the source server),
     execute `show rowcounts remote`.
     """
@@ -421,7 +426,13 @@ def _show_rowcounts(
     pipes = get_pipes(as_list=True, debug=debug, **kw)
     pool = get_pool(workers=workers)
     def _get_rc(_pipe):
-        return _pipe.get_rowcount(remote=remote, debug=debug)
+        return _pipe.get_rowcount(
+            begin=begin,
+            end=end,
+            params=params,
+            remote=remote,
+            debug=debug
+        )
 
     rowcounts = pool.map(_get_rc, pipes) if pool is not None else [_get_rc(p) for p in pipes]
 

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.8"
+__version__ = "2.4.9"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2075,7 +2075,7 @@ def get_pipe_rowcount(
     ----------
     pipe: mrsm.Pipe
         The pipe to query with.
-        
+
     begin: Union[datetime, int, None], default None
         The begin datetime value.
 
@@ -2124,14 +2124,14 @@ def get_pipe_rowcount(
                 warn(
                     f"No datetime could be determined for {pipe}."
                     + "\n    Ignoring begin and end...",
-                    stack = False,
+                    stack=False,
                 )
                 begin, end = None, None
             else:
                 warn(
                     f"A datetime wasn't specified for {pipe}.\n"
                     + f"    Using column \"{_dt}\" for datetime bounds...",
-                    stack = False,
+                    stack=False,
                 )
 
 
@@ -2187,6 +2187,8 @@ def get_pipe_rowcount(
         FROM ({src}) AS src
         """
     )
+    print(f"{begin=}")
+    print(f"{end=}")
     if begin is not None or end is not None:
         query += "WHERE"
     if begin is not None:

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -515,15 +515,14 @@ def get_backtrack_data(
     )
 
 
-
 def get_rowcount(
-        self,
-        begin: Optional[datetime] = None,
-        end: Optional['datetime'] = None,
-        params: Optional[Dict[str, Any]] = None,
-        remote: bool = False,
-        debug: bool = False
-    ) -> int:
+    self,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    remote: bool = False,
+    debug: bool = False
+) -> int:
     """
     Get a Pipe's instance or remote rowcount.
 
@@ -556,11 +555,11 @@ def get_rowcount(
         with Venv(get_connector_plugin(connector)):
             rowcount = connector.get_pipe_rowcount(
                 self,
-                begin = begin,
-                end = end,
-                params = params,
-                remote = remote,
-                debug = debug,
+                begin=begin,
+                end=end,
+                params=params,
+                remote=remote,
+                debug=debug,
             )
             if rowcount is None:
                 return 0

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -627,12 +627,12 @@ def get_numeric_cols(df: 'pd.DataFrame') -> List[str]:
 
 def get_uuid_cols(df: 'pd.DataFrame') -> List[str]:
     """
-    Get the columns which contain `decimal.Decimal` objects from a Pandas DataFrame.
+    Get the columns which contain `uuid.UUID` objects from a Pandas DataFrame.
 
     Parameters
     ----------
     df: pd.DataFrame
-        The DataFrame which may contain decimal objects.
+        The DataFrame which may contain UUID objects.
 
     Returns
     -------

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -276,10 +276,10 @@ def pprint_pipe_columns(
 
 
 def pipe_repr(
-        pipe: mrsm.Pipe,
-        as_rich_text: bool = False,
-        ansi: Optional[bool] = None,
-    ) -> Union[str, 'rich.text.Text']:
+    pipe: mrsm.Pipe,
+    as_rich_text: bool = False,
+    ansi: Optional[bool] = None,
+) -> Union[str, 'rich.text.Text']:
     """
     Return a formatted string for representing a `meerschaum.Pipe`.
     """

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -390,10 +390,10 @@ def flatten_pipes_dict(pipes_dict: PipesDict) -> List[Pipe]:
 
 
 def round_time(
-        dt: Optional[datetime] = None,
-        date_delta: Optional[timedelta] = None,
-        to: 'str' = 'down'
-    ) -> datetime:
+    dt: Optional[datetime] = None,
+    date_delta: Optional[timedelta] = None,
+    to: 'str' = 'down'
+) -> datetime:
     """
     Round a datetime object to a multiple of a timedelta.
     http://stackoverflow.com/questions/3463930/how-to-round-the-minute-of-a-datetime-object-python

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -10,7 +10,8 @@ valkey>=6.0.0
 numpy>=1.18.5
 pandas[parquet]>=2.0.1
 pyarrow>=16.1.0
-dask[dataframe]>=2024.5.1
+dask[complete]>=2024.5.1
+partd>=1.4.2
 pytz
 joblib>=0.17.0
 SQLAlchemy>=2.0.5

--- a/requirements/full.txt
+++ b/requirements/full.txt
@@ -46,7 +46,8 @@ pycparser>=2.21.0
 numpy>=1.18.5
 pandas[parquet]>=2.0.1
 pyarrow>=16.1.0
-dask[dataframe]>=2024.5.1
+dask[complete]>=2024.5.1
+partd>=1.4.2
 pytz
 joblib>=0.17.0
 SQLAlchemy>=2.0.5


### PR DESCRIPTION
# v2.4.9

- **Add relative formats to `--begin` and `--end`.**  
  The flags `--begin` and `--end` support values in the format `[N] [unit] ago`:
  
  ```bash
  mrsm sync pipes --begin '3 days ago'
  ```

  Add a second delta format (recommended to be denoted by the keyword `rounded`) to round the timestamp to a clean value:

  ```bash
  mrsm clear pipes --end '1 month ago rounded 1 day'
  ```

  Supported units are `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` (`ago` only), and `years`.

- **Respect `--begin`, `--end`, and `--params` in `show rowcounts`.**  
  The flags `--begin`, `--end`, and `--params` are now handled in the action `show rowcounts`.
