### PR TITLE
v2.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.12
+
+- **Add the action `edit jobs`.**  
+  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs.
+
+- **Fix nested CTEs for MSSQL.**  
+  Pipes may now use definitions containing a `WITH` clause for Microsoft SQL Server.
+
+- **Added `wrap_query_with_cte` to `meerschaum.utils.sql`.**  
+  Reference a subquery in an encapsulating parent query, even if the subquery contains CTEs itself.
+
+  ```python
+  from meerschaum.utils.sql import wrap_query_with_cte
+  
+  sub_query = """
+  WITH [foo] AS (
+    SELECT 1 AS [val]
+  )
+  SELECT ([val] * 2) AS [newval]
+  FROM [foo]
+  """
+
+  parent_query = "SELECT (newval * 3) FROM [src]"
+
+  query = wrap_query_with_cte(
+      sub_query,
+      parent_query,
+      'mssql',
+      cte_name='src',
+  )
+  print(query)
+  # WITH [foo] AS (
+  #   SELECT 1 AS [val]
+  # ),
+  # [src] AS (
+  # SELECT ([val] * 2) AS [newval]
+  # FROM [foo]
+  #
+  # )
+  # SELECT (newval * 3) FROM [src] 
+  ```
+
+- **Fix `--yes` when running in background jobs.**  
+  The flags `--yes` and `--noask` are now properly handled when running a background job which contains prompts.
+
+- **Add an external page for jobs to the Web Console.**  
+  Like the shareable `/pipes/` links, you may now link to a specific job at the path `/dash/job/{name}`. Click the name of the job on the card to open a job in a new tab.
+
+- **Preserve the original values for `--begin` and `--end`.**  
+  When creating jobs in the shell, the original string values for `--begin` and `--end` will be preserved, such as in the case of `--begin 1 month ago`.
+  
+- **Fix `Pipe` formatting for small terminals.**  
+  Pipes with long names are now properly rendered in small terminal windows.
+  
+
 ### v2.4.9 – v2.4.11
 
 - **Add relative formats to `--begin` and `--end`.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.4.12
 
-- **Add the action `edit jobs`.**  
-  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs.
+- **Add the actions `edit jobs` and `bootstrap jobs`.**  
+  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs. The `bootstrap jobs` wizard also gives you a chance to review your changes before starting a job.
 
 - **Fix nested CTEs for MSSQL.**  
   Pipes may now use definitions containing a `WITH` clause for Microsoft SQL Server.
@@ -57,6 +57,9 @@ This is the current release cycle, so stay tuned for future releases!
   
 - **Fix `Pipe` formatting for small terminals.**  
   Pipes with long names are now properly rendered in small terminal windows.
+
+- **Enable shell suggestions for chained actions.**  
+  The shell auto-complete now works with chained actions.
   
 
 ### v2.4.9 – v2.4.11

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,61 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.12
+
+- **Add the action `edit jobs`.**  
+  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs.
+
+- **Fix nested CTEs for MSSQL.**  
+  Pipes may now use definitions containing a `WITH` clause for Microsoft SQL Server.
+
+- **Added `wrap_query_with_cte` to `meerschaum.utils.sql`.**  
+  Reference a subquery in an encapsulating parent query, even if the subquery contains CTEs itself.
+
+  ```python
+  from meerschaum.utils.sql import wrap_query_with_cte
+  
+  sub_query = """
+  WITH [foo] AS (
+    SELECT 1 AS [val]
+  )
+  SELECT ([val] * 2) AS [newval]
+  FROM [foo]
+  """
+
+  parent_query = "SELECT (newval * 3) FROM [src]"
+
+  query = wrap_query_with_cte(
+      sub_query,
+      parent_query,
+      'mssql',
+      cte_name='src',
+  )
+  print(query)
+  # WITH [foo] AS (
+  #   SELECT 1 AS [val]
+  # ),
+  # [src] AS (
+  # SELECT ([val] * 2) AS [newval]
+  # FROM [foo]
+  #
+  # )
+  # SELECT (newval * 3) FROM [src] 
+  ```
+
+- **Fix `--yes` when running in background jobs.**  
+  The flags `--yes` and `--noask` are now properly handled when running a background job which contains prompts.
+
+- **Add an external page for jobs to the Web Console.**  
+  Like the shareable `/pipes/` links, you may now link to a specific job at the path `/dash/job/{name}`. Click the name of the job on the card to open a job in a new tab.
+
+- **Preserve the original values for `--begin` and `--end`.**  
+  When creating jobs in the shell, the original string values for `--begin` and `--end` will be preserved, such as in the case of `--begin 1 month ago`.
+  
+- **Fix `Pipe` formatting for small terminals.**  
+  Pipes with long names are now properly rendered in small terminal windows.
+  
+
 ### v2.4.9 – v2.4.11
 
 - **Add relative formats to `--begin` and `--end`.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -6,8 +6,8 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.4.12
 
-- **Add the action `edit jobs`.**  
-  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs.
+- **Add the actions `edit jobs` and `bootstrap jobs`.**  
+  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs. The `bootstrap jobs` wizard also gives you a chance to review your changes before starting a job.
 
 - **Fix nested CTEs for MSSQL.**  
   Pipes may now use definitions containing a `WITH` clause for Microsoft SQL Server.
@@ -57,6 +57,9 @@ This is the current release cycle, so stay tuned for future releases!
   
 - **Fix `Pipe` formatting for small terminals.**  
   Pipes with long names are now properly rendered in small terminal windows.
+
+- **Enable shell suggestions for chained actions.**  
+  The shell auto-complete now works with chained actions.
   
 
 ### v2.4.9 – v2.4.11

--- a/meerschaum/_internal/arguments/_parse_arguments.py
+++ b/meerschaum/_internal/arguments/_parse_arguments.py
@@ -256,7 +256,8 @@ def parse_synonyms(
 
 
 def parse_dict_to_sysargs(
-    args_dict: Dict[str, Any]
+    args_dict: Dict[str, Any],
+    coerce_dates: bool = True,
 ) -> List[str]:
     """Revert an arguments dictionary back to a command line list."""
     import shlex
@@ -303,6 +304,19 @@ def parse_dict_to_sysargs(
             elif isinstance(args_dict[a], dict):
                 if len(args_dict[a]) > 0:
                     sysargs += [t[0], json.dumps(args_dict[a], separators=(',', ':'))]
+
+            ### Preserve the original datetime strings if possible
+            elif a in ('begin', 'end') and 'sysargs' in args_dict:
+                flag = t[0]
+                flag_ix = args_dict['sysargs'].index(flag)
+                if flag_ix < 0:
+                    continue
+                try:
+                    flag_val = args_dict['sysargs'][flag_ix + 1]
+                except IndexError:
+                    flag_val = str(args_dict[a])
+
+                sysargs += [flag, str(flag_val)]
 
             ### Account for None and other values
             elif (args_dict[a] is not None) or (args_dict[a] is None and a in allow_none_args):

--- a/meerschaum/_internal/docs/index.py
+++ b/meerschaum/_internal/docs/index.py
@@ -742,6 +742,7 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.sql.get_db_version()</code></li>
       <li><code>meerschaum.utils.sql.get_rename_table_queries()</code></li>
       <li><code>meerschaum.utils.sql.get_create_table_query()</code></li>
+      <li><code>meerschaum.utils.sql.wrap_query_with_cte()</code></li>
       <li><code>meerschaum.utils.sql.format_cte_subquery()</code></li>
       <li><code>meerschaum.utils.sql.session_execute()</code></li>
     </ul>

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -626,7 +626,7 @@ class Shell(cmd.Cmd):
             step_action_name = step_action[0] if step_action else None
             ### NOTE: For `stack`, revert argument parsing.
             step_sysargs = (
-                parse_dict_to_sysargs(step_kwargs)
+                parse_dict_to_sysargs(step_kwargs, coerce_dates=False)
                 if step_action_name != 'stack'
                 else chained_sysargs[i]
             )

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -235,6 +235,23 @@ def get_shell_intro(with_color: bool = True) -> str:
         **get_config('shell', 'ansi', 'intro', 'rich')
     )
 
+def get_shell_session():
+    """
+    Return the `prompt_toolkit` prompt session.
+    """
+    from meerschaum.config._paths import SHELL_HISTORY_PATH
+    if 'session' in shell_attrs:
+        return shell_attrs['session']
+
+    shell_attrs['session'] = prompt_toolkit_shortcuts.PromptSession(
+        history=prompt_toolkit_history.FileHistory(SHELL_HISTORY_PATH.as_posix()),
+        auto_suggest=ValidAutoSuggest(),
+        completer=ShellCompleter(),
+        complete_while_typing=True,
+        reserve_space_for_menu=False,
+    )
+    return shell_attrs['session']
+
 
 class Shell(cmd.Cmd):
     """
@@ -264,14 +281,7 @@ class Shell(cmd.Cmd):
         except AttributeError:
             pass
 
-        from meerschaum.config._paths import SHELL_HISTORY_PATH
-        shell_attrs['session'] = prompt_toolkit_shortcuts.PromptSession(
-            history=prompt_toolkit_history.FileHistory(SHELL_HISTORY_PATH.as_posix()),
-            auto_suggest=ValidAutoSuggest(),
-            completer=ShellCompleter(),
-            complete_while_typing=True,
-            reserve_space_for_menu=False,
-        )
+        _ = get_shell_session()
 
         super().__init__()
 

--- a/meerschaum/_internal/shell/ShellCompleter.py
+++ b/meerschaum/_internal/shell/ShellCompleter.py
@@ -31,7 +31,6 @@ class ShellCompleter(Completer):
         ensure_readline()
         parts = document.text.split('-')
         ends_with_space = parts[0].endswith(' ')
-        #  print(f"{parts=}")
         last_action_line = parts[0].split('+')[-1]
         part_0_subbed_spaces = last_action_line.replace(' ', '_')
         parsed_text = (part_0_subbed_spaces + '-'.join(parts[1:]))

--- a/meerschaum/_internal/shell/ShellCompleter.py
+++ b/meerschaum/_internal/shell/ShellCompleter.py
@@ -31,15 +31,19 @@ class ShellCompleter(Completer):
         ensure_readline()
         parts = document.text.split('-')
         ends_with_space = parts[0].endswith(' ')
-        part_0_subbed_spaces = parts[0].replace(' ', '_')
-        parsed_text = part_0_subbed_spaces + '-'.join(parts[1:])
+        #  print(f"{parts=}")
+        last_action_line = parts[0].split('+')[-1]
+        part_0_subbed_spaces = last_action_line.replace(' ', '_')
+        parsed_text = (part_0_subbed_spaces + '-'.join(parts[1:]))
 
+        if not parsed_text:
+            return
 
         ### Index is the rank order (0 is closest match).
         ### Break when no results are returned.
         for i, a in enumerate(shell_actions):
             try:
-                poss = shell.complete(parsed_text, i)
+                poss = shell.complete(parsed_text.lstrip('_'), i)
                 if poss:
                     poss = poss.replace('_', ' ')
             ### Having issues with readline on portable Windows.
@@ -50,7 +54,9 @@ class ShellCompleter(Completer):
             yield Completion(poss, start_position=(-1 * len(poss)))
             yielded.append(poss)
 
-        args = parse_line(document.text)
+        line = document.text
+        current_action_line = line.split('+')[-1].lstrip()
+        args = parse_line(current_action_line)
         action_function = get_action(args['action'], _actions=shell_attrs.get('_actions', None))
         if action_function is None:
             return
@@ -74,8 +80,8 @@ class ShellCompleter(Completer):
                 shell,
                 complete_function_name
             )(
-                document.text.split(' ')[-1],
-                document.text,
+                current_action_line.split(' ')[-1],
+                current_action_line,
                 0,
                 0
             )

--- a/meerschaum/actions/clear.py
+++ b/meerschaum/actions/clear.py
@@ -6,12 +6,16 @@ Functions for clearing pipes.
 """
 
 from __future__ import annotations
+
+from datetime import datetime
+import meerschaum as mrsm
 from meerschaum.utils.typing import List, SuccessTuple, Any, Optional
 
+
 def clear(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
     """
     Clear pipes of their data, or clear the screen.
 
@@ -34,24 +38,25 @@ def clear(
 
 
 def _clear_pipes(
-        action: Optional[List[str]] = None,
-        begin: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
-        connector_keys: Optional[List[str]] = None,
-        metric_keys: Optional[List[str]] = None,
-        mrsm_instance: Optional[str] = None,
-        location_keys: Optional[List[str]] = None,
-        force: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    begin: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    connector_keys: Optional[List[str]] = None,
+    metric_keys: Optional[List[str]] = None,
+    mrsm_instance: Optional[str] = None,
+    location_keys: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Clear pipes' data without dropping any tables.
 
     """
     from meerschaum import get_pipes
     from meerschaum.utils.formatting import print_tuple
-    
+
     successes = {}
     fails = {}
 
@@ -61,13 +66,19 @@ def _clear_pipes(
     )
 
     if not force:
-        if not _ask_with_rowcounts(pipes, begin=begin, end=end, debug=debug, **kw):
+        if not _ask_with_rowcounts(pipes, begin=begin, end=end, debug=debug, yes=yes, **kw):
             return False, "No rows were deleted."
 
     for pipe in pipes:
-        success, msg = pipe.clear(begin=begin, end=end, debug=debug, **kw)
-        print_tuple((success, msg))
-        (successes if success else fails)[pipe] = msg
+        clear_success, clear_msg = pipe.clear(
+            begin=begin,
+            end=end,
+            yes=yes,
+            debug=debug,
+            **kw
+        )
+        print_tuple((clear_success, clear_msg))
+        (successes if clear_success else fails)[pipe] = clear_msg
 
     success = len(successes) > 0
     msg = (
@@ -79,15 +90,15 @@ def _clear_pipes(
 
 
 def _ask_with_rowcounts(
-        pipes: List[meerschaum.Pipe],
-        begin: Optional[datetime.datetime] = None,
-        end: Optional[datetime.datetime] = None,
-        yes: bool = False,
-        nopretty: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw
-    ) -> bool:
+    pipes: List[mrsm.Pipe],
+    begin: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    yes: bool = False,
+    nopretty: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw
+) -> bool:
     """
     Count all of the pipes' rowcounts and confirm with the user that these rows need to be deleted.
 
@@ -109,13 +120,13 @@ def _ask_with_rowcounts(
                     warn(
                         f"No datetime could be determined for {pipe}!\n"
                         + "    THIS WILL DELETE THE ENTIRE TABLE!",
-                        stack = False
+                        stack=False
                     )
                 else:
                     warn(
                         f"A datetime wasn't specified for {pipe}.\n"
                         + f"    Using column \"{_dt}\" for datetime bounds...",
-                        stack = False
+                        stack=False
                     )
 
 

--- a/meerschaum/actions/start.py
+++ b/meerschaum/actions/start.py
@@ -9,6 +9,7 @@ Start subsystems (API server, logging daemon, etc.).
 from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Optional, List, Any, Union, Dict
 
+
 def start(
     action: Optional[List[str]] = None,
     **kw: Any,
@@ -375,8 +376,8 @@ def _start_gui(
         webview.create_window(
             'Meerschaum Shell', 
             f'http://127.0.0.1:{port}',
-            height = 650,
-            width = 1000
+            height=650,
+            width=1000
         )
         webview.start(debug=debug)
     except Exception as e:

--- a/meerschaum/api/dash/callbacks/dashboard.py
+++ b/meerschaum/api/dash/callbacks/dashboard.py
@@ -98,6 +98,7 @@ _paths = {
     'plugins' : pages.plugins.layout,
     'register': pages.register.layout,
     'pipes'   : pages.pipes.layout,
+    'job'     : pages.job.layout,
 }
 _required_login = {''}
 
@@ -121,7 +122,7 @@ def update_page_layout_div(
     ----------
     pathname: str
         The path in the browser.
-        
+
     session_store_data: Dict[str, Any]:
         The stored session data.
 

--- a/meerschaum/api/dash/callbacks/jobs.py
+++ b/meerschaum/api/dash/callbacks/jobs.py
@@ -12,6 +12,7 @@ import json
 import time
 import traceback
 from datetime import datetime, timezone
+
 from meerschaum.utils.typing import Optional, Dict, Any
 from meerschaum.api import CHECK_UPDATE
 from meerschaum.api.dash import dash_app
@@ -19,17 +20,19 @@ from meerschaum.api.dash.sessions import get_username_from_session
 from meerschaum.utils.packages import attempt_import, import_dcc, import_html
 from meerschaum.api.dash.components import alert_from_success_tuple
 from meerschaum.api.dash.jobs import (
+    build_job_card,
     build_manage_job_buttons_div_children,
     build_status_children,
     build_process_timestamps_children,
 )
-from meerschaum.jobs import Job
+from meerschaum.api.routes._jobs import _get_job
 from meerschaum.api.dash.sessions import is_session_authenticated
 dash = attempt_import('dash', lazy=False, check_update=CHECK_UPDATE)
 html, dcc = import_html(check_update=CHECK_UPDATE), import_dcc(check_update=CHECK_UPDATE)
 from dash.exceptions import PreventUpdate
 from dash.dependencies import Input, Output, State, ALL, MATCH
 import dash_bootstrap_components as dbc
+from dash import no_update
 
 
 @dash_app.callback(
@@ -53,6 +56,13 @@ def download_job_logs(n_clicks):
 
     component_dict = json.loads(ctx[0]['prop_id'].split('.' + 'n_clicks')[0])
     job_name = component_dict['index']
+    try:
+        job = _get_job(job_name)
+    except Exception:
+        job = None
+    if job is None or not job.exists():
+        raise PreventUpdate
+
     now = datetime.now(timezone.utc)
     filename = job_name + '_' + str(int(now.timestamp())) + '.log'
     return {
@@ -69,7 +79,7 @@ def download_job_logs(n_clicks):
     Input({'type': 'manage-job-button', 'action': ALL, 'index': MATCH}, 'n_clicks'),
     State('session-store', 'data'),
     State({'type': 'job-label-p', 'index': MATCH}, 'children'),
-    prevent_initial_call = True,
+    prevent_initial_call=True,
 )
 def manage_job_button_click(
     n_clicks: Optional[int] = None,
@@ -102,10 +112,10 @@ def manage_job_button_click(
     job_name = component_dict['index']
     manage_job_action = component_dict['action']
     try:
-        job = Job(job_name, job_label.replace('\n', ' ') if job_label else None)
-    except Exception as e:
+        job = _get_job(job_name, job_label.replace('\n', ' ') if job_label else None)
+    except Exception:
         job = None
-    if job is None:
+    if job is None or not job.exists():
         raise PreventUpdate
 
     manage_functions = {
@@ -191,7 +201,7 @@ dash_app.clientside_callback(
     Output({'type': 'process-timestamps-div', 'index': ALL}, 'children'),
     Input('refresh-jobs-interval', 'n_intervals'),
     State('session-store', 'data'),
-    prevent_initial_call = True,
+    prevent_initial_call=True,
 )
 def refresh_jobs_on_interval(
     n_intervals: Optional[int] = None,
@@ -209,7 +219,7 @@ def refresh_jobs_on_interval(
     ]
 
     ### NOTE: The job may have been deleted, but the card may still exist.
-    jobs = [Job(name) for name in job_names]
+    jobs = [_get_job(name) for name in job_names]
 
     return (
         [
@@ -229,3 +239,39 @@ def refresh_jobs_on_interval(
             for job in jobs
         ],
     )
+
+
+@dash_app.callback(
+    Output('job-output-div', 'children'),
+    Input('job-location', 'pathname'),
+    State('session-store', 'data'),
+)
+def render_job_page_from_url(
+    pathname: str,
+    session_data: Optional[Dict[str, Any]],
+):
+    """
+    Load the `/job/{name}` page.
+    """
+    if not str(pathname).startswith('/dash/job'):
+        return no_update
+
+    session_id = (session_data or {}).get('session-id', None)
+    authenticated = is_session_authenticated(str(session_id))
+
+    job_name = pathname.replace('/dash/job', '').lstrip('/').rstrip('/')
+    if not job_name:
+        return no_update
+
+    job = _get_job(job_name)
+    if not job.exists():
+        return [
+            html.Br(),
+            html.H2("404: Job does not exist."),
+        ]
+
+    return [
+        html.Br(),
+        build_job_card(job, authenticated=authenticated, include_follow=False),
+        html.Br(),
+    ]

--- a/meerschaum/api/dash/callbacks/pipes.py
+++ b/meerschaum/api/dash/callbacks/pipes.py
@@ -26,7 +26,7 @@ html, dcc = import_html(check_update=CHECK_UPDATE), import_dcc(check_update=CHEC
     State('pipes-location', 'search'),
     State('session-store', 'data'),
 )
-def render_page_from_url(
+def render_pipe_page_from_url(
     pathname: str,
     pipe_search: str,
     session_data: Optional[Dict[str, Any]],

--- a/meerschaum/api/dash/pages/__init__.py
+++ b/meerschaum/api/dash/pages/__init__.py
@@ -11,3 +11,4 @@ import meerschaum.api.dash.pages.dashboard
 import meerschaum.api.dash.pages.plugins
 import meerschaum.api.dash.pages.register
 import meerschaum.api.dash.pages.pipes
+import meerschaum.api.dash.pages.job

--- a/meerschaum/api/dash/pages/job.py
+++ b/meerschaum/api/dash/pages/job.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+# vim:fenc=utf-8
+
+"""
+Display pipes via a shareable URL.
+"""
+
+from meerschaum.api import CHECK_UPDATE
+from meerschaum.utils.packages import import_html, import_dcc
+
+html, dcc = import_html(check_update=CHECK_UPDATE), import_dcc(check_update=CHECK_UPDATE)
+import dash_bootstrap_components as dbc
+
+from meerschaum.api.dash.components import download_logs, refresh_jobs_interval
+
+layout = dbc.Container([
+    dcc.Location('job-location'),
+    html.Div(id='job-output-div'),
+    download_logs,
+    refresh_jobs_interval,
+])

--- a/meerschaum/api/routes/_jobs.py
+++ b/meerschaum/api/routes/_jobs.py
@@ -39,12 +39,12 @@ NONINTERACTIVE_ENV: str = STATIC_CONFIG['environment']['noninteractive']
 EXECUTOR_KEYS: str = 'local'
 
 
-def _get_job(name: str):
-    systemd_job = Job(name, executor_keys='systemd')
+def _get_job(name: str, sysargs: Union[str, List[str], None] = None):
+    systemd_job = Job(name, sysargs, executor_keys='systemd')
     if systemd_job.exists():
         return systemd_job
 
-    job = Job(name, executor_keys=EXECUTOR_KEYS)
+    job = Job(name, sysargs, executor_keys=EXECUTOR_KEYS)
     return job
 
 

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.11"
+__version__ = "2.4.12.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.12.dev1"
+__version__ = "2.4.12"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2178,7 +2178,7 @@ def get_pipe_rowcount(
     parent_query = f"SELECT COUNT(*)\nFROM {sql_item_name('src', self.flavor)}"
     query = wrap_query_with_cte(src, parent_query, self.flavor)
     if begin is not None or end is not None:
-        query += "WHERE"
+        query += "\nWHERE"
     if begin is not None:
         query += f"""
         {dt} >= {dateadd_str(self.flavor, datepart='minute', number=0, begin=begin)}

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2320,10 +2320,10 @@ def clear_pipe(
 
 
 def get_pipe_table(
-        self,
-        pipe: mrsm.Pipe,
-        debug: bool = False,
-    ) -> sqlalchemy.Table:
+    self,
+    pipe: mrsm.Pipe,
+    debug: bool = False,
+) -> Union['sqlalchemy.Table', None]:
     """
     Return the `sqlalchemy.Table` object for a `mrsm.Pipe`.
 
@@ -2342,18 +2342,18 @@ def get_pipe_table(
         return None
     return get_sqlalchemy_table(
         pipe.target,
-        connector = self,
-        schema = self.get_pipe_schema(pipe),
-        debug = debug,
-        refresh = True,
+        connector=self,
+        schema=self.get_pipe_schema(pipe),
+        debug=debug,
+        refresh=True,
     )
 
 
 def get_pipe_columns_types(
-        self,
-        pipe: mrsm.Pipe,
-        debug: bool = False,
-    ) -> Dict[str, str]:
+    self,
+    pipe: mrsm.Pipe,
+    debug: bool = False,
+) -> Dict[str, str]:
     """
     Get the pipe's columns and types.
 
@@ -2384,8 +2384,8 @@ def get_pipe_columns_types(
         return get_table_cols_types(
             pipe.target,
             self,
-            flavor = self.flavor,
-            schema = self.schema,
+            flavor=self.flavor,
+            schema=self.get_pipe_schema(pipe),
         )
 
     table_columns = {}
@@ -2438,6 +2438,7 @@ def get_add_columns_queries(
     from meerschaum.utils.sql import (
         sql_item_name,
         SINGLE_ALTER_TABLE_FLAVORS,
+        get_table_cols_types,
     )
     from meerschaum.utils.dtypes.sql import (
         get_pd_type_from_db_type,
@@ -2470,6 +2471,14 @@ def get_add_columns_queries(
     db_cols_types = {
         col: get_pd_type_from_db_type(str(typ.type))
         for col, typ in table_obj.columns.items()
+    } if table_obj is not None else {
+        col: get_pd_type_from_db_type(typ)
+        for col, typ in get_table_cols_types(
+            pipe.target,
+            self,
+            schema=self.get_pipe_schema(pipe),
+            debug=debug,
+        ).items()
     }
     new_cols = set(df_cols_types) - set(db_cols_types)
     if not new_cols:
@@ -2542,7 +2551,7 @@ def get_alter_columns_queries(
     """
     if not pipe.exists(debug=debug):
         return []
-    from meerschaum.utils.sql import sql_item_name, DROP_IF_EXISTS_FLAVORS
+    from meerschaum.utils.sql import sql_item_name, DROP_IF_EXISTS_FLAVORS, get_table_cols_types
     from meerschaum.utils.dataframe import get_numeric_cols
     from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.dtypes.sql import (
@@ -2573,6 +2582,14 @@ def get_alter_columns_queries(
     db_cols_types = {
         col: get_pd_type_from_db_type(str(typ.type))
         for col, typ in table_obj.columns.items()
+    } if table_obj is not None else {
+        col: get_pd_type_from_db_type(typ)
+        for col, typ in get_table_cols_types(
+            pipe.target,
+            self,
+            schema=self.get_pipe_schema(pipe),
+            debug=debug,
+        ).items()
     }
     pipe_bool_cols = [col for col, typ in pipe.dtypes.items() if are_dtypes_equal(str(typ), 'bool')]
     pd_db_df_aliases = {

--- a/meerschaum/utils/formatting/__init__.py
+++ b/meerschaum/utils/formatting/__init__.py
@@ -322,14 +322,14 @@ def format_success_tuple(
     from meerschaum.config import get_config
     status_config = get_config('formatting', status, patch=True)
 
-    msg = (' ' * left_padding) + status_config[CHARSET]['icon'] + ' ' + str(tup[1])
+    msg = (' ' * left_padding) + status_config[CHARSET]['icon'] + ' ' + str(highlight_pipes(tup[1]))
     lines = msg.split('\n')
     lines = [lines[0]] + [
         (('    ' + line if not line.startswith(' ') else line))
         for line in lines[1:]
     ]
     if ANSI:
-        lines[0] = fill_ansi(highlight_pipes(lines[0]), **status_config['ansi']['rich'])
+        lines[0] = fill_ansi(lines[0], **status_config['ansi']['rich'])
 
     msg = '\n'.join(lines)
     msg = ('\n' * upper_padding) + msg + ('\n' * lower_padding)

--- a/meerschaum/utils/formatting/__init__.py
+++ b/meerschaum/utils/formatting/__init__.py
@@ -11,7 +11,7 @@ import platform
 import os
 import sys
 import meerschaum as mrsm
-from meerschaum.utils.typing import Optional, Union, Any, Dict
+from meerschaum.utils.typing import Optional, Union, Any, Dict, Iterable
 from meerschaum.utils.formatting._shell import make_header
 from meerschaum.utils.formatting._pprint import pprint
 from meerschaum.utils.formatting._pipes import (
@@ -337,7 +337,7 @@ def format_success_tuple(
 
 
 def print_options(
-    options: Optional[Dict[str, Any]] = None,
+    options: Optional[Iterable[Any]] = None,
     nopretty: bool = False,
     no_rich: bool = False,
     name: str = 'options',
@@ -345,6 +345,7 @@ def print_options(
     num_cols: Optional[int] = None,
     adjust_cols: bool = True,
     sort_options: bool = False,
+    number_options: bool = False,
     **kw
 ) -> None:
     """
@@ -373,6 +374,12 @@ def print_options(
     adjust_cols: bool, default True
         If `True`, adjust the number of columns depending on the terminal size.
 
+    sort_options: bool, default False
+        If `True`, print the options in sorted order.
+
+    number_options: bool, default False
+        If `True`, print the option's number in the list (1 index).
+
     """
     import os
     from meerschaum.utils.packages import import_rich
@@ -398,9 +405,10 @@ def print_options(
             print()
             print(make_header(_header))
         ### print actions
-        for option in _options:
+        for i, option in enumerate(_options):
+            marker = '-' if not number_options else (str(i + 1) + '.')
             if not nopretty:
-                print("  - ", end="")
+                print(f"  {marker} ", end="")
             print(option)
         if not nopretty:
             print()
@@ -434,11 +442,11 @@ def print_options(
 
     if _header is not None:
         table = Table(
-            title = _header,
-            box = box.SIMPLE,
-            show_header = False,
-            show_footer = False,
-            title_style = '',
+            title=_header,
+            box=box.SIMPLE,
+            show_header=False,
+            show_footer=False,
+            title_style='',
             expand = True,
         )
     else:
@@ -447,18 +455,26 @@ def print_options(
         table.add_column()
 
     if len(_options) < 12:
-        # If fewer than 12 items, use a single column
-        for option in _options:
-            table.add_row(Text.from_ansi(highlight_pipes(option)))
+        ### If fewer than 12 items, use a single column
+        for i, option in enumerate(_options):
+            item = highlight_pipes(option)
+            if number_options:
+                item = str(i + 1) + '. ' + item
+            table.add_row(Text.from_ansi(item))
     else:
-        # Otherwise, use multiple columns as before
+        ### Otherwise, use multiple columns as before
         num_rows = (len(_options) + num_cols - 1) // num_cols
+        item_ix = 0
         for i in range(num_rows):
             row = []
             for j in range(num_cols):
                 index = i + j * num_rows
                 if index < len(_options):
-                    row.append(Text.from_ansi(highlight_pipes(_options[index])))
+                    item = highlight_pipes(_options[index])
+                    if number_options:
+                        item = str(i + 1) + '. ' + item
+                    row.append(Text.from_ansi(item))
+                    item_ix += 1
                 else:
                     row.append('')
             table.add_row(*row)

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -323,7 +323,7 @@ def pipe_repr(
     )
     if as_rich_text:
         return text_obj
-    return rich_text_to_str(text_obj)
+    return rich_text_to_str(text_obj).replace('\n', '')
 
 
 def highlight_pipes(message: str) -> str:

--- a/meerschaum/utils/formatting/_shell.py
+++ b/meerschaum/utils/formatting/_shell.py
@@ -10,10 +10,11 @@ from re import sub
 from meerschaum.utils.threading import Lock
 _locks = {'_tried_clear_command': Lock()}
 
+
 def make_header(
-        message : str,
-        ruler : str = '─',
-    ) -> str:
+    message: str,
+    ruler: str = '─',
+) -> str:
     """Format a message string with a ruler.
     Length of the ruler is the length of the longest word.
     

--- a/meerschaum/utils/prompt.py
+++ b/meerschaum/utils/prompt.py
@@ -10,17 +10,18 @@ from __future__ import annotations
 import os
 from meerschaum.utils.typing import Any, Union, Optional, Tuple, List
 
+
 def prompt(
-        question: str,
-        icon: bool = True,
-        default: Union[str, Tuple[str, str], None] = None,
-        default_editable: Optional[str] = None,
-        detect_password: bool = True,
-        is_password: bool = False,
-        wrap_lines: bool = True,
-        noask: bool = False,
-        **kw: Any
-    ) -> str:
+    question: str,
+    icon: bool = True,
+    default: Union[str, Tuple[str, str], None] = None,
+    default_editable: Optional[str] = None,
+    detect_password: bool = True,
+    is_password: bool = False,
+    wrap_lines: bool = True,
+    noask: bool = False,
+    **kw: Any
+) -> str:
     """
     Ask the user a question and return the answer.
     Wrapper around `prompt_toolkit.prompt()` with modified behavior.
@@ -75,7 +76,7 @@ def prompt(
     ### if a default is provided, append it to the question.
     default_answer = default
     if default is not None:
-        question += f" (default: "
+        question += " (default: "
         if isinstance(default, tuple) and len(default) > 1:
             question += f"{default[0]} [{default[1]}]"
             default_answer = default[0]
@@ -86,7 +87,7 @@ def prompt(
     ### detect password
     if (detect_password and 'password' in question.lower()) or is_password:
         kw['is_password'] = True
-  
+
     ### Add the icon and only color the first line.
     lines = question.split('\n')
     first_line = lines[0]
@@ -107,15 +108,15 @@ def prompt(
         answer = (
             prompt_toolkit.prompt(
                 prompt_toolkit.formatted_text.ANSI(question),
-                wrap_lines = wrap_lines,
-                default = default_editable or '',
+                wrap_lines=wrap_lines,
+                default=default_editable or '',
                 **filter_keywords(prompt_toolkit.prompt, **kw)
             ) if not noask else ''
         )
     else:
         print(question, end='\n', flush=True)
         try:
-            answer = input()
+            answer = input() if not noask else ''
         except EOFError:
             answer = ''
     if noask:

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1333,11 +1333,11 @@ def get_rename_table_queries(
 
 
 def get_create_table_query(
-        query: str,
-        new_table: str,
-        flavor: str,
-        schema: Optional[str] = None,
-    ) -> str:
+    query: str,
+    new_table: str,
+    flavor: str,
+    schema: Optional[str] = None,
+) -> str:
     """
     Return a query to create a new table from a `SELECT` query.
 
@@ -1365,10 +1365,8 @@ def get_create_table_query(
     new_table_name = sql_item_name(new_table, flavor, schema)
     if flavor in ('mssql',):
         query = query.lstrip()
-        original_query = query
         if 'with ' in query.lower():
             final_select_ix = query.lower().rfind('select')
-            def_name = query[len('WITH '):].split(' ', maxsplit=1)[0]
             return (
                 query[:final_select_ix].rstrip() + ',\n'
                 + f"{create_cte_name} AS (\n"
@@ -1405,12 +1403,81 @@ def get_create_table_query(
     return textwrap.dedent(create_table_query)
 
 
+def wrap_query_with_cte(
+    sub_query: str,
+    parent_query: str,
+    flavor: str,
+    cte_name: str = "src",
+) -> str:
+    """
+    Wrap a subquery in a CTE and append an encapsulating query.
+
+    Parameters
+    ----------
+    sub_query: str
+        The query to be referenced. This may itself contain CTEs.
+        Unless `cte_name` is provided, this will be aliased as `src`.
+
+    parent_query: str
+        The larger query to append which references the subquery.
+        This must not contain CTEs.
+
+    flavor: str
+        The database flavor, e.g. `'mssql'`.
+
+    cte_name: str, default 'src'
+        The CTE alias, defaults to `src`.
+
+    Returns
+    -------
+    An encapsulating query which allows you to treat `sub_query` as a temporary table.
+
+    Examples
+    --------
+    >>> from meerschaum.utils.sql import wrap_query_with_cte
+    >>> sub_query = (
+    ...     "WITH foo AS (\n"
+    ...     "    SELECT 1 AS val\n"
+    ...     ")\n"
+    ...     "SELECT (val * 2) AS newval\n"
+    ...     "FROM foo"
+    ... )
+    >>> parent_query = "SELECT newval * 3 FROM src"
+    >>> query = wrap_query_with_cte(sub_query, parent_query, 'mysql')
+    >>> print(query)
+
+    """
+    sub_query = sub_query.lstrip()
+    cte_name_quoted = sql_item_name(cte_name, flavor, None)
+
+    if flavor in NO_CTE_FLAVORS:
+        return (
+            parent_query.replace(cte_name_quoted, f"(\n{sub_query}\n) AS {cte_name_quoted}")
+        )
+
+    if 'with ' in sub_query.lower():
+        final_select_ix = sub_query.lower().rfind('select')
+        return (
+            sub_query[:final_select_ix].rstrip() + ',\n'
+            + f"{cte_name_quoted} AS (\n"
+            + sub_query[final_select_ix:]
+            + "\n)\n"
+            + parent_query
+        )
+
+    return (
+        f"WITH {cte_name_quoted} AS (\n"
+        f"    {sub_query}\n"
+        f")\n{parent_query}"
+    )
+
+
 def format_cte_subquery(
-        sub_query: str,
-        flavor: str,
-        sub_name: str = 'src',
-        cols_to_select: Union[List[str], str] = '*',
-    ) -> str:
+    sub_query: str,
+    flavor: str,
+    sub_name: str = 'src',
+    cols_to_select: Union[List[str], str] = '*',
+) -> str:
     """
     Given a subquery, build a wrapper query that selects from the CTE subquery.
 
@@ -1434,28 +1501,25 @@ def format_cte_subquery(
     -------
     A wrapper query that selects from the CTE.
     """
-    import textwrap
     quoted_sub_name = sql_item_name(sub_name, flavor, None)
     cols_str = (
         cols_to_select
         if isinstance(cols_to_select, str)
         else ', '.join([sql_item_name(col, flavor, None) for col in cols_to_select])
     )
-    return textwrap.dedent(
-        f"""
-        SELECT {cols_str}
-        FROM ({sub_query})"""
-        + (f' AS {quoted_sub_name}' if flavor != 'oracle' else '') + """
-        """
+    parent_query = (
+        f"SELECT {cols_str}\n"
+        f"FROM {quoted_sub_name}"
     )
+    return wrap_query_with_cte(sub_query, parent_query, flavor, cte_name=sub_name)
 
 
 def session_execute(
-        session: 'sqlalchemy.orm.session.Session',
-        queries: Union[List[str], str],
-        with_results: bool = False,
-        debug: bool = False,
-    ) -> Union[mrsm.SuccessTuple, Tuple[mrsm.SuccessTuple, List['sqlalchemy.sql.ResultProxy']]]:
+    session: 'sqlalchemy.orm.session.Session',
+    queries: Union[List[str], str],
+    with_results: bool = False,
+    debug: bool = False,
+) -> Union[mrsm.SuccessTuple, Tuple[mrsm.SuccessTuple, List['sqlalchemy.sql.ResultProxy']]]:
     """
     Similar to `SQLConnector.exec_queries()`, execute a list of queries
     and roll back when one fails.

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -758,11 +758,11 @@ def build_where(
 
 
 def table_exists(
-        table: str,
-        connector: mrsm.connectors.sql.SQLConnector,
-        schema: Optional[str] = None,
-        debug: bool = False,
-    ) -> bool:
+    table: str,
+    connector: mrsm.connectors.sql.SQLConnector,
+    schema: Optional[str] = None,
+    debug: bool = False,
+) -> bool:
     """Check if a table exists.
 
     Parameters
@@ -793,12 +793,12 @@ def table_exists(
 
 
 def get_sqlalchemy_table(
-        table: str,
-        connector: Optional[meerschaum.connectors.sql.SQLConnector] = None,
-        schema: Optional[str] = None,
-        refresh: bool = False,
-        debug: bool = False,
-    ) -> 'sqlalchemy.Table':
+    table: str,
+    connector: Optional[mrsm.connectors.sql.SQLConnector] = None,
+    schema: Optional[str] = None,
+    refresh: bool = False,
+    debug: bool = False,
+) -> Union['sqlalchemy.Table', None]:
     """
     Construct a SQLAlchemy table from its name.
 
@@ -828,6 +828,9 @@ def get_sqlalchemy_table(
     if connector is None:
         from meerschaum import get_connector
         connector = get_connector('sql')
+
+    if connector.flavor == 'duckdb':
+        return None
 
     from meerschaum.connectors.sql.tables import get_tables
     from meerschaum.utils.packages import attempt_import
@@ -1455,8 +1458,8 @@ def wrap_query_with_cte(
     if flavor in NO_CTE_FLAVORS:
         return (
             parent_query
-            .replace(cte_name, '--MRSM_SUBQUERY--')
             .replace(cte_name_quoted, '--MRSM_SUBQUERY--')
+            .replace(cte_name, '--MRSM_SUBQUERY--')
             .replace('--MRSM_SUBQUERY--', f"(\n{sub_query}\n) AS {cte_name_quoted}")
         )
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -483,7 +483,17 @@ def test_sync_inplace(flavor: str):
     )
     dest_pipe = Pipe(str(conn), 'inplace', 'dest', instance=conn)
     dest_pipe.delete()
-    query = f"SELECT * FROM {sql_item_name(source_pipe.target, flavor)}"
+    query = f"""
+    WITH {sql_item_name('subquery', flavor)} AS (
+        SELECT *
+        FROM {sql_item_name(source_pipe.target, flavor)}
+    )
+    SELECT *
+    FROM {sql_item_name('subquery', flavor)}
+    """ if flavor not in ('mysql',) else f"""
+    SELECT *
+    FROM {sql_item_name(source_pipe.target, flavor)}
+    """
     dest_pipe = Pipe(
         str(conn), 'inplace', 'dest',
         instance=conn,


### PR DESCRIPTION
# v2.4.12

- **Add the actions `edit jobs` and `bootstrap jobs`.**  
  The action `edit jobs` lets you easily tweak the arguments for an existing job, so there's no need to delete and recreate jobs. The `bootstrap jobs` wizard also gives you a chance to review your changes before starting a job.

- **Fix nested CTEs for MSSQL.**  
  Pipes may now use definitions containing a `WITH` clause for Microsoft SQL Server.

- **Added `wrap_query_with_cte` to `meerschaum.utils.sql`.**  
  Reference a subquery in an encapsulating parent query, even if the subquery contains CTEs itself.

  ```python
  from meerschaum.utils.sql import wrap_query_with_cte
  
  sub_query = """
  WITH [foo] AS (
    SELECT 1 AS [val]
  )
  SELECT ([val] * 2) AS [newval]
  FROM [foo]
  """

  parent_query = "SELECT (newval * 3) FROM [src]"

  query = wrap_query_with_cte(
      sub_query,
      parent_query,
      'mssql',
      cte_name='src',
  )
  print(query)
  # WITH [foo] AS (
  #   SELECT 1 AS [val]
  # ),
  # [src] AS (
  # SELECT ([val] * 2) AS [newval]
  # FROM [foo]
  #
  # )
  # SELECT (newval * 3) FROM [src] 
  ```

- **Fix `--yes` when running in background jobs.**  
  The flags `--yes` and `--noask` are now properly handled when running a background job which contains prompts.

- **Add an external page for jobs to the Web Console.**  
  Like the shareable `/pipes/` links, you may now link to a specific job at the path `/dash/job/{name}`. Click the name of the job on the card to open a job in a new tab.

- **Preserve the original values for `--begin` and `--end`.**  
  When creating jobs in the shell, the original string values for `--begin` and `--end` will be preserved, such as in the case of `--begin 1 month ago`.
  
- **Fix `Pipe` formatting for small terminals.**  
  Pipes with long names are now properly rendered in small terminal windows.

- **Enable shell suggestions for chained actions.**  
  The shell auto-complete now works with chained actions.