### PR TITLE
v2.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.13
+
+- **Add `--timeout` to pipeline arguments.**  
+  You may now designate the maximum number of seconds to run a pipeline with `--timeout`. This will run the entire pipeline in a subprocess rather than a persistent session.
+
+  ```bash
+  mrsm sync pipes + clear pipes --end '1 month ago' : -s daily --timeout 3600
+  ```
+
+- **Add auto-complete to `edit jobs` and `bootstrap jobs`.**
+
+- **Improve the editing experience for `edit jobs` and `bootstrap jobs`.**
+
+- **Fixed plugin detection for Python 3.9.**
+
 ### v2.4.12
 
 - **Add the actions `edit jobs` and `bootstrap jobs`.**  
@@ -60,7 +75,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Enable shell suggestions for chained actions.**  
   The shell auto-complete now works with chained actions.
-  
 
 ### v2.4.9 – v2.4.11
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.4.13
+
+- **Add `--timeout` to pipeline arguments.**  
+  You may now designate the maximum number of seconds to run a pipeline with `--timeout`. This will run the entire pipeline in a subprocess rather than a persistent session.
+
+  ```bash
+  mrsm sync pipes + clear pipes --end '1 month ago' : -s daily --timeout 3600
+  ```
+
+- **Add auto-complete to `edit jobs` and `bootstrap jobs`.**
+
+- **Improve the editing experience for `edit jobs` and `bootstrap jobs`.**
+
+- **Fixed plugin detection for Python 3.9.**
+
 ### v2.4.12
 
 - **Add the actions `edit jobs` and `bootstrap jobs`.**  
@@ -60,7 +75,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Enable shell suggestions for chained actions.**  
   The shell auto-complete now works with chained actions.
-  
 
 ### v2.4.9 – v2.4.11
 

--- a/meerschaum/_internal/entry.py
+++ b/meerschaum/_internal/entry.py
@@ -43,6 +43,7 @@ if (_STATIC_CONFIG['environment']['systemd_log_path']) in os.environ:
     if _systemd_stdin_path:
         sys.stdin = _StdinFile(_systemd_stdin_path)
 
+
 def entry(
     sysargs: Optional[List[str]] = None,
     _patch_args: Optional[Dict[str, Any]] = None,

--- a/meerschaum/actions/bootstrap.py
+++ b/meerschaum/actions/bootstrap.py
@@ -19,7 +19,7 @@ def bootstrap(
 ) -> SuccessTuple:
     """
     Launch an interactive wizard to bootstrap pipes or connectors.
-    
+
     Example:
         `bootstrap pipes`
 
@@ -473,13 +473,14 @@ def _bootstrap_jobs(
             continue
 
         info(
-            "Press [Esc + Enter] to submit, [CTRL + C] to exit.\n"
+            f"Editing arguments for job '{name}'.\n"
+            "    Press [Esc + Enter] to submit, [CTRL + C] to exit.\n\n"
             "    Tip: join multiple actions with `+`, add pipeline arguments with `:`.\n"
             "    https://meerschaum.io/reference/actions/#chaining-actions\n"
         )
         try:
             new_sysargs_str = prompt(
-                f"Arguments for job '{name}':",
+                "",
                 multiline=True,
                 icon=False,
                 completer=ShellCompleter(),
@@ -491,6 +492,7 @@ def _bootstrap_jobs(
         new_sysargs, pipeline_args = split_pipeline_sysargs(new_sysargs)
         chained_sysargs = split_chained_sysargs(new_sysargs)
 
+        clear_screen(debug=debug)
         if len(chained_sysargs) > 1:
             print_options(
                 [
@@ -508,6 +510,7 @@ def _bootstrap_jobs(
         if pipeline_args:
             print('\n' + make_header("Pipeline Arguments:"))
             print(shlex.join(pipeline_args))
+            print()
 
         if not yes_no(
             (

--- a/meerschaum/actions/bootstrap.py
+++ b/meerschaum/actions/bootstrap.py
@@ -462,7 +462,6 @@ def _bootstrap_jobs(
     if not action:
         action = [prompt("What is the name of the job you'd like to create?")]
 
-    new_jobs = {}
     for name in action:
         clear_screen(debug=debug)
         job = mrsm.Job(name, executor_keys=executor_keys)
@@ -527,15 +526,11 @@ def _bootstrap_jobs(
         if not start_success:
             return start_success, start_msg
 
-        new_jobs[name] = new_job
-
-    if not new_jobs:
-        return False, "No new jobs were created."
-
     msg = (
         "Successfully bootstrapped job"
-        + ('s' if len(new_jobs) != 1 else '')
-        + items_str(list(new_jobs.keys()))
+        + ('s' if len(action) != 1 else '')
+        + ' '
+        + items_str(action)
         + '.'
     )
     return True, msg

--- a/meerschaum/actions/delete.py
+++ b/meerschaum/actions/delete.py
@@ -498,7 +498,7 @@ def _complete_delete_jobs(
     action: Optional[List[str]] = None,
     executor_keys: Optional[str] = None,
     line: str = '',
-    _get_job_method: Optional[str, List[str]] = None,
+    _get_job_method: Union[str, List[str], None] = None,
     **kw
 ) -> List[str]:
     from meerschaum._internal.shell.Shell import shell_attrs

--- a/meerschaum/actions/edit.py
+++ b/meerschaum/actions/edit.py
@@ -421,7 +421,7 @@ def _edit_jobs(
 
         try:
             new_sysargs_str = prompt(
-                "Edit:",
+                "",
                 default_editable=sysargs_str.lstrip().rstrip().replace(' + ', '\n+ '),
                 multiline=True,
                 icon=False,

--- a/meerschaum/actions/sh.py
+++ b/meerschaum/actions/sh.py
@@ -9,14 +9,15 @@ NOTE: This action may be a huge security vulnerability
 
 from meerschaum.utils.typing import SuccessTuple, List, Any, Optional
 
+
 def sh(
-        action: Optional[List[str]] = None,
-        sub_args: Optional[List[str]] = None,
-        filtered_sysargs: Optional[List[str]] = None,
-        use_bash: bool = True,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    sub_args: Optional[List[str]] = None,
+    filtered_sysargs: Optional[List[str]] = None,
+    use_bash: bool = True,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Execute system commands.
     """
@@ -50,7 +51,7 @@ def sh(
         if len(action) != 0:
             try:
                 command_list += ["-c", shlex.join(cmd_list)]
-            except Exception as e:
+            except Exception:
                 command_list += ["-c", ' '.join(cmd_list)]
     else:
         if len(action) == 0:
@@ -64,8 +65,8 @@ def sh(
     try:
         process = subprocess.Popen(
             command_list,
-            shell = False,
-            env = os.environ,
+            shell=False,
+            env=os.environ,
         )
         exit_code = process.wait()
     except FileNotFoundError:

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -129,14 +129,12 @@ def _pipes_lap(
             stack=False,
         )
 
-
     def _task_label(count: int):
         return f"[cyan]Syncing {count} pipe{'s' if count != 1 else ''}..."
 
     _task = (
         _progress.add_task(_task_label(len(pipes)), start=True, total=len(pipes))
     ) if _progress is not None else None
-
 
     def worker_fn():
         while not stop_event.is_set():
@@ -188,7 +186,7 @@ def _pipes_lap(
                     decoded[begin_index + len(fence_begin):end_index]
                 ))
                 return
-            sys.stdout.buffer.write(line)
+            print(decoded)
 
         def timeout_handler(p, *args, **kw):
             success, msg = False, (
@@ -227,7 +225,7 @@ def _pipes_lap(
             write_line,
             timeout_seconds,
             timeout_handler,
-            (p,)
+            (p,),
         )
         return _success_tuple
 
@@ -249,18 +247,18 @@ def _pipes_lap(
 
 
 def _sync_pipes(
-        loop: bool = False,
-        min_seconds: int = 1,
-        unblock: bool = False,
-        verify: bool = False,
-        deduplicate: bool = False,
-        bounded: Optional[bool] = None,
-        chunk_interval: Union[timedelta, int, None] = None,
-        shell: bool = False,
-        nopretty: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    loop: bool = False,
+    min_seconds: int = 1,
+    unblock: bool = False,
+    verify: bool = False,
+    deduplicate: bool = False,
+    bounded: Optional[bool] = None,
+    chunk_interval: Union[timedelta, int, None] = None,
+    shell: bool = False,
+    nopretty: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Fetch and sync new data for pipes.
 

--- a/meerschaum/actions/upgrade.py
+++ b/meerschaum/actions/upgrade.py
@@ -9,16 +9,17 @@ Upgrade your current Meerschaum environment
 from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Union
 
+
 def upgrade(
     action: Optional[List[str]] = None,
     **kw: Any
 ) -> SuccessTuple:
     """
     Upgrade Meerschaum, plugins, or packages.
-    
+
     Command:
         `upgrade {option}`
-    
+
     Example:
         `upgrade meerschaum`
     """
@@ -77,7 +78,7 @@ def _upgrade_meerschaum(
         if force:
             answer = True
         else:
-            answer = yes_no(f"Take down the stack?", default='y', yes=yes, noask=noask)
+            answer = yes_no("Take down the stack?", default='n', yes=yes, noask=noask)
 
         if answer:
             if debug:
@@ -95,7 +96,7 @@ def _upgrade_meerschaum(
     if debug:
         dprint('Upgrade meerschaum with dependencies: \"' + f'{dependencies}' + '\"')
     if not pip_install(install_name, venv=None, debug=debug):
-        return False, f"Failed to upgrade Meerschaum via pip."
+        return False, "Failed to upgrade Meerschaum via pip."
 
     if debug:
         dprint("Pulling new Docker images...")

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.4.12"
+__version__ = "2.4.13"

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -309,6 +309,8 @@ def _simple_fetch_query(
     """Build a fetch query from a pipe's definition."""
     from meerschaum.utils.sql import format_cte_subquery
     definition = get_pipe_query(pipe)
+    if definition is None:
+        raise ValueError(f"No SQL definition could be found for {pipe}.")
     return format_cte_subquery(definition, flavor, 'definition')
 
 

--- a/meerschaum/plugins/__init__.py
+++ b/meerschaum/plugins/__init__.py
@@ -316,7 +316,11 @@ def sync_plugins_symlinks(debug: bool = False, warn: bool = True) -> None:
 
         ### NOTE: Allow plugins to be installed via `pip`.
         packaged_plugin_paths = []
-        discovered_packaged_plugins_eps = entry_points(group='meerschaum.plugins')
+        try:
+            discovered_packaged_plugins_eps = entry_points(group='meerschaum.plugins')
+        except TypeError:
+            discovered_packaged_plugins_eps = []
+
         for ep in discovered_packaged_plugins_eps:
             module_name = ep.name
             for package_file_path in ep.dist.files:
@@ -330,7 +334,7 @@ def sync_plugins_symlinks(debug: bool = False, warn: bool = True) -> None:
         if is_symlink(PLUGINS_RESOURCES_PATH) or not PLUGINS_RESOURCES_PATH.exists():
             try:
                 PLUGINS_RESOURCES_PATH.unlink()
-            except Exception as e:
+            except Exception:
                 pass
 
         PLUGINS_RESOURCES_PATH.mkdir(exist_ok=True)

--- a/meerschaum/plugins/bootstrap.py
+++ b/meerschaum/plugins/bootstrap.py
@@ -47,7 +47,6 @@ IMPORTS_LINES: Dict[str, str] = {
     ),
 }
 
-### TODO: Add feature for custom connectors.
 FEATURE_LINES: Dict[str, str] = {
     'header': (
         "#! /usr/bin/env python3\n"
@@ -94,7 +93,7 @@ FEATURE_LINES: Dict[str, str] = {
         "class {plugin_name_capitalized}Connector(Connector):\n"
         "    \"\"\"Implement '{plugin_name_lower}' connectors.\"\"\"\n\n"
         "    REQUIRED_ATTRIBUTES: list[str] = []\n"
-        "    \n"
+        "\n"
         "    def fetch(\n"
         "        self,\n"
         "        pipe: mrsm.Pipe,\n"
@@ -149,11 +148,12 @@ FEATURE_LINES: Dict[str, str] = {
     ),
 }
 
+
 def bootstrap_plugin(
-        plugin_name: str,
-        debug: bool = False,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    plugin_name: str,
+    debug: bool = False,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Prompt the user for features and create a plugin file.
     """
@@ -177,9 +177,9 @@ def bootstrap_plugin(
     features: List[str] = choose(
         "Which of the following features would you like to add to your plugin?",
         list(FEATURE_CHOICES.items()),
-        default = 'fetch',
-        multiple = True,
-        as_indices = True,
+        default='fetch',
+        multiple=True,
+        as_indices=True,
         **kwargs
     )
 
@@ -256,7 +256,7 @@ def bootstrap_plugin(
         _ = prompt(
             f"Press [Enter] to edit plugin '{plugin_name}',"
             + " [CTRL+C] to skip.",
-            icon = False,
+            icon=False,
         )
     except (KeyboardInterrupt, Exception):
         return True, "Success"
@@ -267,7 +267,7 @@ def bootstrap_plugin(
 
 def _get_plugins_dir_path() -> pathlib.Path:
     from meerschaum.config.paths import PLUGINS_DIR_PATHS
-    
+
     if not PLUGINS_DIR_PATHS:
         raise EnvironmentError("No plugin dir path could be found.")
 
@@ -278,9 +278,9 @@ def _get_plugins_dir_path() -> pathlib.Path:
         choose(
             "In which directory do you want to write your plugin?",
             [path.as_posix() for path in PLUGINS_DIR_PATHS],
-            numeric = True,
-            multiple = False,
-            default = PLUGINS_DIR_PATHS[0].as_posix(),
+            numeric=True,
+            multiple=False,
+            default=PLUGINS_DIR_PATHS[0].as_posix(),
         )
     )
  
@@ -290,7 +290,7 @@ def _ask_to_uninstall(plugin: mrsm.Plugin, **kwargs: Any) -> SuccessTuple:
     warn(f"Plugin '{plugin}' is already installed!", stack=False)
     uninstall_plugin = yes_no(
         f"Do you want to first uninstall '{plugin}'?",
-        default = 'n',
+        default='n',
         **kwargs
     )
     if not uninstall_plugin:

--- a/meerschaum/utils/warnings.py
+++ b/meerschaum/utils/warnings.py
@@ -154,13 +154,13 @@ def exception_with_traceback(
 
 
 def error(
-        message: str,
-        exception_class = Exception,
-        nopretty: bool = False,
-        silent: bool = True,
-        stack: bool = True,
-        raise_: bool = True,
-    ):
+    message: str,
+    exception_class = Exception,
+    nopretty: bool = False,
+    silent: bool = True,
+    stack: bool = True,
+    raise_: bool = True,
+):
     """
     Raise an exception with supressed traceback.
     """


### PR DESCRIPTION
# v2.4.13

- **Add `--timeout` to pipeline arguments.**  
  You may now designate the maximum number of seconds to run a pipeline with `--timeout`. This will run the entire pipeline in a subprocess rather than a persistent session.

  ```bash
  mrsm sync pipes + clear pipes --end '1 month ago' : -s daily --timeout 3600
  ```

- **Add auto-complete to `edit jobs` and `bootstrap jobs`.**

- **Improve the editing experience for `edit jobs` and `bootstrap jobs`.**

- **Fixed plugin detection for Python 3.9.**
