### PR TITLE
🐛 v2.6.1 Improve timezone-aware enforcement, add `Pipe.tzinfo`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.1
+
+- **Add `Pipe.tzinfo`.**  
+  Check if a pipe is timezone-aware with `tzinfo`:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'timezone', 'aware',
+      columns={'datetime': 'dt'},
+  )
+  print(pipe.tzinfo)
+  # UTC
+
+  pipe = mrsm.Pipe(
+      'demo', 'timezone', 'naive',
+      columns={'datetime': 'dt'},
+      dtypes={'dt': 'datetime64[ns]'},
+  )
+  print(pipe.tzinfo)
+  # None
+  ```
+
+- **Improve timezone enforcement when syncing.**
+- **Fix timezone-aware datetime truncation for MSSQL**
+
 ### v2.6.0
 
 - **Enforce a timezone-aware `datetime` axis by default.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,33 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.1
+
+- **Add `Pipe.tzinfo`.**  
+  Check if a pipe is timezone-aware with `tzinfo`:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'timezone', 'aware',
+      columns={'datetime': 'dt'},
+  )
+  print(pipe.tzinfo)
+  # UTC
+
+  pipe = mrsm.Pipe(
+      'demo', 'timezone', 'naive',
+      columns={'datetime': 'dt'},
+      dtypes={'dt': 'datetime64[ns]'},
+  )
+  print(pipe.tzinfo)
+  # None
+  ```
+
+- **Improve timezone enforcement when syncing.**
+- **Fix timezone-aware datetime truncation for MSSQL**
+
 ### v2.6.0
 
 - **Enforce a timezone-aware `datetime` axis by default.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.0"
+__version__ = "2.6.1.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.1.dev1"
+__version__ = "2.6.1"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -383,7 +383,7 @@ def get_pipe_data(
         ignore_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if are_dtypes_equal(str(dtype), 'datetime')
+            if not are_dtypes_equal(str(dtype), 'datetime')
         ],
         strip_timezone=(pipe.tzinfo is None),
         debug=debug,
@@ -393,7 +393,7 @@ def get_pipe_data(
 
 def get_pipe_id(
     self,
-    pipe: meerschuam.Pipe,
+    pipe: mrsm.Pipe,
     debug: bool = False,
 ) -> int:
     """Get a Pipe's ID from the API."""
@@ -415,7 +415,7 @@ def get_pipe_id(
 
 def get_pipe_attributes(
     self,
-    pipe: meerschaum.Pipe,
+    pipe: mrsm.Pipe,
     debug: bool = False,
 ) -> Dict[str, Any]:
     """Get a Pipe's attributes from the API
@@ -441,7 +441,7 @@ def get_pipe_attributes(
 
 def get_sync_time(
     self,
-    pipe: 'meerschaum.Pipe',
+    pipe: mrsm.Pipe,
     params: Optional[Dict[str, Any]] = None,
     newest: bool = True,
     debug: bool = False,

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -367,6 +367,7 @@ def get_pipe_data(
 
     from meerschaum.utils.packages import import_pandas
     from meerschaum.utils.dataframe import parse_df_datetimes, add_missing_cols_to_df
+    from meerschaum.utils.dtypes import are_dtypes_equal
     pd = import_pandas()
     try:
         df = pd.read_json(StringIO(response.text))
@@ -382,9 +383,10 @@ def get_pipe_data(
         ignore_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if 'datetime' not in str(dtype)
+            if are_dtypes_equal(str(dtype), 'datetime')
         ],
-        debug = debug,
+        strip_timezone=(pipe.tzinfo is None),
+        debug=debug,
     )
     return df
 

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -95,7 +95,7 @@ def fetch(
         ignore_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if are_dtypes_equal(str(dtype), 'datetime')
+            if not are_dtypes_equal(str(dtype), 'datetime')
         ]
         return (
             parse_df_datetimes(

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -90,16 +90,18 @@ def fetch(
     )
     ### if sqlite, parse for datetimes
     if not as_hook_results and self.flavor == 'sqlite':
-        from meerschaum.utils.misc import parse_df_datetimes
+        from meerschaum.utils.dataframe import parse_df_datetimes
+        from meerschaum.utils.dtypes import are_dtypes_equal
         ignore_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if 'datetime' not in str(dtype)
+            if are_dtypes_equal(str(dtype), 'datetime')
         ]
         return (
             parse_df_datetimes(
                 chunk,
                 ignore_cols=ignore_cols,
+                strip_timezone=(pipe.tzinfo is None),
                 debug=debug,
             )
             for chunk in chunks

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -872,7 +872,11 @@ def get_pipe_data(
     from meerschaum.utils.sql import sql_item_name
     from meerschaum.utils.misc import parse_df_datetimes, to_pandas_dtype
     from meerschaum.utils.packages import import_pandas
-    from meerschaum.utils.dtypes import attempt_cast_to_numeric, attempt_cast_to_uuid
+    from meerschaum.utils.dtypes import (
+        attempt_cast_to_numeric,
+        attempt_cast_to_uuid,
+        are_dtypes_equal,
+    )
     pd = import_pandas()
     is_dask = 'dask' in pd.__name__
 
@@ -967,7 +971,7 @@ def get_pipe_data(
         ignore_dt_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if 'datetime' not in str(dtype)
+            if are_dtypes_equal(str(dtype), 'datetime')
         ]
         ### NOTE: We have to consume the iterator here to ensure that datetimes are parsed correctly
         df = (
@@ -975,6 +979,7 @@ def get_pipe_data(
                 df,
                 ignore_cols=ignore_dt_cols,
                 chunksize=kw.get('chunksize', None),
+                strip_timezone=(pipe.tzinfo is None),
                 debug=debug,
             ) if isinstance(df, pd.DataFrame) else (
                 [
@@ -982,6 +987,7 @@ def get_pipe_data(
                         c,
                         ignore_cols=ignore_dt_cols,
                         chunksize=kw.get('chunksize', None),
+                        strip_timezone=(pipe.tzinfo is None),
                         debug=debug,
                     )
                     for c in df

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -971,7 +971,7 @@ def get_pipe_data(
         ignore_dt_cols = [
             col
             for col, dtype in pipe.dtypes.items()
-            if are_dtypes_equal(str(dtype), 'datetime')
+            if not are_dtypes_equal(str(dtype), 'datetime')
         ]
         ### NOTE: We have to consume the iterator here to ensure that datetimes are parsed correctly
         df = (

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1090,6 +1090,8 @@ def get_pipe_data_query(
         if begin is not None:
             begin -= backtrack_interval
 
+    begin, end = pipe.parse_date_bounds(begin, end)
+
     cols_names = [
         sql_item_name(col, self.flavor, None)
         for col in select_columns
@@ -1661,11 +1663,14 @@ def sync_pipe(
                 'autoincrement': False,
             },
         )
-        temp_pipe._columns_types = {
-            col: get_db_type_from_pd_type(str(typ), self.flavor)
+        temp_pipe.__dict__['_columns_types'] = {
+            col: get_db_type_from_pd_type(
+                pipe.dtypes.get(col, str(typ)),
+                self.flavor,
+            )
             for col, typ in update_df.dtypes.items()
         }
-        temp_pipe._columns_types_timestamp = time.perf_counter()
+        temp_pipe.__dict__['_columns_types_timestamp'] = time.perf_counter()
         temp_success, temp_msg = temp_pipe.sync(update_df, check_existing=False, debug=debug)
         if not temp_success:
             return temp_success, temp_msg

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -409,6 +409,7 @@ def get_pipe_data(
         return None
 
     from meerschaum.utils.dataframe import query_df, parse_df_datetimes
+    from meerschaum.utils.dtypes import are_dtypes_equal
 
     valkey_dtypes = pipe.parameters.get('valkey', {}).get('dtypes', {})
     dt_col = pipe.columns.get('datetime', None)
@@ -442,13 +443,14 @@ def get_pipe_data(
     ignore_dt_cols = [
         col
         for col, dtype in pipe.dtypes.items()
-        if 'datetime' not in str(dtype)
+        if are_dtypes_equal(str(dtype), 'datetime')
     ]
 
     df = parse_df_datetimes(
         docs,
         ignore_cols=ignore_dt_cols,
         chunksize=kwargs.get('chunksize', None),
+        strip_timezone=(pipe.tzinfo is None),
         debug=debug,
     )
     for col, typ in valkey_dtypes.items():

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -443,7 +443,7 @@ def get_pipe_data(
     ignore_dt_cols = [
         col
         for col, dtype in pipe.dtypes.items()
-        if are_dtypes_equal(str(dtype), 'datetime')
+        if not are_dtypes_equal(str(dtype), 'datetime')
     ]
 
     df = parse_df_datetimes(

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -105,6 +105,7 @@ class Pipe:
         autoincrement,
         upsert,
         static,
+        tzinfo,
         get_columns,
         get_columns_types,
         get_columns_indices,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -14,6 +14,7 @@ import meerschaum as mrsm
 from meerschaum.utils.typing import Tuple, Dict, SuccessTuple, Any, Union, Optional, List
 from meerschaum.utils.warnings import warn
 
+
 @property
 def attributes(self) -> Dict[str, Any]:
     """
@@ -54,6 +55,13 @@ def parameters(self) -> Optional[Dict[str, Any]]:
     """
     if 'parameters' not in self.attributes:
         self.attributes['parameters'] = {}
+    _parameters = self.attributes['parameters']
+    dt_col = _parameters.get('columns', {}).get('datetime', None)
+    dt_typ = _parameters.get('dtypes', {}).get(dt_col, None) if dt_col else None
+    if dt_col and not dt_typ:
+        if 'dtypes' not in _parameters:
+            self.attributes['parameters']['dtypes'] = {}
+        self.attributes['parameters']['dtypes'][dt_col] = 'datetime'
     return self.attributes['parameters']
 
 

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -8,6 +8,8 @@ Fetch and manipulate Pipes' attributes
 
 from __future__ import annotations
 
+from datetime import timezone
+
 import meerschaum as mrsm
 from meerschaum.utils.typing import Tuple, Dict, SuccessTuple, Any, Union, Optional, List
 from meerschaum.utils.warnings import warn
@@ -258,6 +260,25 @@ def autoincrement(self, _autoincrement: bool) -> None:
     Set the `autoincrement` parameter for the pipe.
     """
     self.parameters['autoincrement'] = _autoincrement
+
+
+@property
+def tzinfo(self) -> Union[None, timezone]:
+    """
+    Return `timezone.utc` if the pipe is timezone-aware.
+    """
+    dt_col = self.columns.get('datetime', None)
+    if not dt_col:
+        return None
+
+    dt_typ = str(self.dtypes.get(dt_col, 'datetime64[ns, UTC]'))
+    if 'utc' in dt_typ.lower() or dt_typ == 'datetime':
+        return timezone.utc
+
+    if dt_typ == 'datetime64[ns]':
+        return None
+
+    return None
 
 
 def get_columns(self, *args: str, error: bool = False) -> Union[str, Tuple[str]]:

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -30,6 +30,7 @@ def enforce_dtypes(
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.dataframe import parse_df_datetimes, enforce_dtypes as _enforce_dtypes
+    from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.packages import import_pandas
     pd = import_pandas(debug=debug)
     if df is None:
@@ -51,6 +52,7 @@ def enforce_dtypes(
                     for col, dtype in pipe_dtypes.items()
                     if 'datetime' not in str(dtype)
                 ],
+                strip_timezone=(self.tzinfo is None),
                 chunksize=chunksize,
                 debug=debug,
             )
@@ -60,8 +62,9 @@ def enforce_dtypes(
                 ignore_cols=[
                     col
                     for col, dtype in pipe_dtypes.items()
-                    if 'datetime' not in str(dtype)
+                    if are_dtypes_equal(str(dtype), 'datetime')
                 ],
+                strip_timezone=(self.tzinfo is None),
                 chunksize=chunksize,
                 debug=debug,
             )
@@ -77,7 +80,14 @@ def enforce_dtypes(
             )
         return df
 
-    return _enforce_dtypes(df, pipe_dtypes, safe_copy=safe_copy, debug=debug)
+    return _enforce_dtypes(
+        df,
+        pipe_dtypes,
+        safe_copy=safe_copy,
+        strip_timezone=(self.tzinfo is None),
+        coerce_timezone=True,
+        debug=debug,
+    )
 
 
 def infer_dtypes(self, persist: bool = False, debug: bool = False) -> Dict[str, Any]:

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -62,7 +62,7 @@ def enforce_dtypes(
                 ignore_cols=[
                     col
                     for col, dtype in pipe_dtypes.items()
-                    if are_dtypes_equal(str(dtype), 'datetime')
+                    if not are_dtypes_equal(str(dtype), 'datetime')
                 ],
                 strip_timezone=(self.tzinfo is None),
                 chunksize=chunksize,

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -933,7 +933,11 @@ def _persist_new_numeric_columns(self, df, debug: bool = False) -> SuccessTuple:
     if not new_numeric_cols:
         return True, "Success"
 
+    self._attributes_sync_time = None
+    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
+    if dt_col not in dtypes:
+        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'numeric' for col in numeric_cols})
     self.parameters['dtypes'] = dtypes
     if not self.temporary:
@@ -957,7 +961,11 @@ def _persist_new_uuid_columns(self, df, debug: bool = False) -> SuccessTuple:
     if not new_uuid_cols:
         return True, "Success"
 
+    self._attributes_sync_time = None
+    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
+    if dt_col not in dtypes:
+        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'uuid' for col in uuid_cols})
     self.parameters['dtypes'] = dtypes
     if not self.temporary:
@@ -981,7 +989,11 @@ def _persist_new_json_columns(self, df, debug: bool = False) -> SuccessTuple:
     if not new_json_cols:
         return True, "Success"
 
+    self._attributes_sync_time = None
+    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
+    if dt_col not in dtypes:
+        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'json' for col in json_cols})
     self.parameters['dtypes'] = dtypes
 

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -689,6 +689,7 @@ def enforce_dtypes(
     safe_copy: bool = True,
     coerce_numeric: bool = True,
     coerce_timezone: bool = True,
+    strip_timezone: bool = False,
     debug: bool = False,
 ) -> 'pd.DataFrame':
     """
@@ -712,6 +713,10 @@ def enforce_dtypes(
 
     coerce_timezone: bool, default True
         If `True`, convert datetimes to UTC.
+
+    strip_timezone: bool, default False
+        If `coerce_timezone` and `strip_timezone` are `True`,
+        remove timezone information from datetimes.
 
     debug: bool, default False
         Verbosity toggle.
@@ -817,7 +822,7 @@ def enforce_dtypes(
             dprint(f"Checking for datetime conversion: {datetime_cols}")
         for col in datetime_cols:
             if col in df.columns:
-                df[col] = _coerce_timezone(df[col])
+                df[col] = _coerce_timezone(df[col], strip_utc=strip_timezone)
 
     df_dtypes = {c: str(t) for c, t in df.dtypes.items()}
     if are_dtypes_equal(df_dtypes, pipe_pandas_dtypes):

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -304,6 +304,19 @@ PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'cockroachdb': 'Float',
         'default': 'Float',
     },
+    'datetime': {
+        'timescaledb': 'DateTime(timezone=True)',
+        'postgresql': 'DateTime(timezone=True)',
+        'mariadb': 'DateTime(timezone=True)',
+        'mysql': 'DateTime(timezone=True)',
+        'mssql': 'sqlalchemy.dialects.mssql.DATETIMEOFFSET',
+        'oracle': 'sqlalchemy.dialects.oracle.TIMESTAMP(timezone=True)',
+        'sqlite': 'DateTime(timezone=True)',
+        'duckdb': 'DateTime(timezone=True)',
+        'citus': 'DateTime(timezone=True)',
+        'cockroachdb': 'DateTime(timezone=True)',
+        'default': 'DateTime(timezone=True)',
+    },
     'datetime64[ns]': {
         'timescaledb': 'DateTime',
         'postgresql': 'DateTime',
@@ -489,7 +502,7 @@ def get_db_type_from_pd_type(
     """
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.dtypes import are_dtypes_equal, MRSM_PD_DTYPES
+    from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.misc import parse_arguments_str
     sqlalchemy_types = attempt_import('sqlalchemy.types')
 

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -606,7 +606,7 @@ def dateadd_str(
         da = begin + (f" + INTERVAL '{number} {datepart}'" if number != 0 else '')
 
     elif flavor in ('mssql',):
-        if begin_time and begin_time.microsecond != 0:
+        if begin_time and begin_time.microsecond != 0 and not dt_is_utc:
             begin = begin[:-4] + "'"
         begin = f"CAST({begin} AS {db_type})" if begin != 'now' else 'GETUTCDATE()'
         da = f"DATEADD({datepart}, {number}, {begin})" if number != 0 else begin

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -84,6 +84,7 @@ def test_dtype_enforcement(flavor: str):
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert len(df.columns) == 10
+    return pipe
     for col, typ in df.dtypes.items():
         pipe_dtype = pipe.dtypes[col]
         if pipe_dtype == 'json':

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -307,6 +307,8 @@ def test_utc_offset_datetimes(flavor: str):
     assert success, msg
     df = pipe.get_data(debug=debug)
     synced_docs = df.to_dict(orient='records')
+    mrsm.pprint(synced_docs)
+    mrsm.pprint(expected_docs)
     assert synced_docs == expected_docs
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -929,7 +929,7 @@ def test_static_schema(flavor: str):
     )
     docs = [
         {
-            'dt': '2024-01-01',
+            'dt': '2024-01-01 01:02:03.456789',
             'id': 'e7a57f9b-da26-4c70-bffc-ed27cdd74565',
             'num': '1.23',
             'val': '2.34',
@@ -941,7 +941,7 @@ def test_static_schema(flavor: str):
 
     new_docs = [
         {
-            'dt': '2024-01-01',
+            'dt': '2024-01-01 01:02:03.456789',
             'id': '44be2c5a-3d42-4e5f-b118-93a56697ae14',
             'val': 'foo',
             'bar': 1,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -921,7 +921,7 @@ def test_static_schema(flavor: str):
         },
         dtypes={
             'id': 'uuid',
-            'dt': 'datetime',
+            'dt': 'datetime64[ns]',
             'num': 'numeric',
             'val': 'float',
             'meta': 'json',

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -575,6 +575,7 @@ def test_sync_dask_dataframe(flavor: str):
     pipe = mrsm.Pipe(
         'dask', 'demo',
         columns={'datetime': 'dt'},
+        dtypes={'dt': 'datetime'},
         instance=conn,
     )
     pipe.sync([
@@ -589,11 +590,14 @@ def test_sync_dask_dataframe(flavor: str):
     pipe2 = mrsm.Pipe(
         'dask', 'insert',
         columns=pipe.columns,
+        dtypes=pipe.dtypes,
         instance=conn,
     )
     pipe2.sync(ddf, debug=debug)
-    docs = pipe.get_data().to_dict(orient='records')
-    docs2 = pipe2.get_data().to_dict(orient='records')
+    df = pipe.get_data()
+    df2 = pipe2.get_data()
+    docs = df.to_dict(orient='records')
+    docs2 = df2.to_dict(orient='records')
     assert docs == docs2
 
 

--- a/tests/utils/test_sql.py
+++ b/tests/utils/test_sql.py
@@ -69,7 +69,10 @@ def test_build_where(params: Dict[str, Any], expected_subqueries: List[str]):
     """
     where_subquery = build_where(
         params,
-        mrsm.get_connector('sql', 'build_where_test', uri='postgresql://foo:bar@localhost:5432/baz')
+        mrsm.get_connector(
+            'sql', 'build_where_test',
+            uri='postgresql+psycopg2://foo:bar@localhost:5432/baz'
+        )
     )
     for subquery in expected_subqueries:
         assert subquery in where_subquery


### PR DESCRIPTION
# v2.6.1

- **Add `Pipe.tzinfo`.**  
  Check if a pipe is timezone-aware with `tzinfo`:

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'demo', 'timezone', 'aware',
      columns={'datetime': 'dt'},
  )
  print(pipe.tzinfo)
  # UTC

  pipe = mrsm.Pipe(
      'demo', 'timezone', 'naive',
      columns={'datetime': 'dt'},
      dtypes={'dt': 'datetime64[ns]'},
  )
  print(pipe.tzinfo)
  # None
  ```

- **Improve timezone enforcement when syncing.**
- **Fix timezone-aware datetime truncation for MSSQL**