### PR TITLE
v2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.3
+### v2.6.1 – v2.6.4
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -31,6 +31,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Improve timezone enforcement when syncing.**
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
+- **Fix timezone detection for existing timezone-naive tables.**
 
 ### v2.6.0
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.3
+### v2.6.1 – v2.6.4
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -31,6 +31,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Improve timezone enforcement when syncing.**
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
+- **Fix timezone detection for existing timezone-naive tables.**
 
 ### v2.6.0
 

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.3"
+__version__ = "2.6.4.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.4.dev1"
+__version__ = "2.6.4"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -884,12 +884,12 @@ def get_pipe_data(
     cols_types = pipe.get_columns_types(debug=debug)
     dtypes = {
         **{
-            col: get_pd_type_from_db_type(typ)
-            for col, typ in cols_types.items()
-        },
-        **{
             p_col: to_pandas_dtype(p_typ)
             for p_col, p_typ in pipe.dtypes.items()
+        },
+        **{
+            col: get_pd_type_from_db_type(typ)
+            for col, typ in cols_types.items()
         }
     }
     if dtypes:

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -877,10 +877,21 @@ def get_pipe_data(
         attempt_cast_to_uuid,
         are_dtypes_equal,
     )
+    from meerschaum.utils.dtypes.sql import get_pd_type_from_db_type
     pd = import_pandas()
     is_dask = 'dask' in pd.__name__
 
-    dtypes = pipe.dtypes
+    cols_types = pipe.get_columns_types(debug=debug)
+    dtypes = {
+        **{
+            col: get_pd_type_from_db_type(typ)
+            for col, typ in cols_types.items()
+        },
+        **{
+            p_col: to_pandas_dtype(p_typ)
+            for p_col, p_typ in pipe.dtypes.items()
+        }
+    }
     if dtypes:
         if self.flavor == 'sqlite':
             if not pipe.columns.get('datetime', None):

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1089,7 +1089,12 @@ def get_pipe_data_query(
     """
     from meerschaum.utils.misc import items_str
     from meerschaum.utils.sql import sql_item_name, dateadd_str
+    from meerschaum.utils.dtypes import coerce_timezone
+    from meerschaum.utils.dtypes.sql import get_pd_type_from_db_type
+
+    dt_col = pipe.columns.get('datetime', None)
     existing_cols = pipe.get_columns_types(debug=debug)
+    dt_typ = get_pd_type_from_db_type(existing_cols[dt_col]) if dt_col in existing_cols else None
     select_columns = (
         [col for col in existing_cols]
         if not select_columns
@@ -1108,6 +1113,10 @@ def get_pipe_data_query(
             begin -= backtrack_interval
 
     begin, end = pipe.parse_date_bounds(begin, end)
+    if isinstance(begin, datetime) and dt_typ:
+        begin = coerce_timezone(begin, strip_utc=('utc' not in dt_typ.lower()))
+    if isinstance(end, datetime) and dt_typ:
+        end = coerce_timezone(end, strip_utc=('utc' not in dt_typ.lower()))
 
     cols_names = [
         sql_item_name(col, self.flavor, None)

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -641,7 +641,7 @@ def exec_queries(
         will be considered a callable hook that returns a list of queries to be executed
         before the next item in the list.
 
-    break_on_error: bool, default True
+    break_on_error: bool, default False
         If `True`, stop executing when a query fails.
 
     rollback: bool, default True

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -416,7 +416,7 @@ def get_pipe_data(
     table_name = self.quote_table(pipe.target)
     indices = [col for col in pipe.columns.values() if col]
     ix_docs = [
-        string_to_dict(doc['ix'].replace(COLON, ':'))
+        string_to_dict(doc.get('ix', '').replace(COLON, ':'))
         for doc in self.read_docs(
             pipe.target,
             begin=begin,

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -284,4 +284,7 @@ def coerce_timezone(
             return dt
         return dt.replace(tzinfo=timezone.utc)
 
-    return dt.astimezone(timezone.utc)
+    utc_dt = dt.astimezone(timezone.utc)
+    if strip_utc:
+        return utc_dt.replace(tzinfo=None)
+    return utc_dt


### PR DESCRIPTION
# v2.6.1 – v2.6.4

- **Add `Pipe.tzinfo`.**  
  Check if a pipe is timezone-aware with `tzinfo`:

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'demo', 'timezone', 'aware',
      columns={'datetime': 'dt'},
  )
  print(pipe.tzinfo)
  # UTC

  pipe = mrsm.Pipe(
      'demo', 'timezone', 'naive',
      columns={'datetime': 'dt'},
      dtypes={'dt': 'datetime64[ns]'},
  )
  print(pipe.tzinfo)
  # None
  ```

- **Improve timezone enforcement when syncing.**
- **Fix inplace syncs with `upsert=True`.**
- **Fix timezone-aware datetime truncation for MSSQL**
- **Fix timezone detection for existing timezone-naive tables.**
