### PR TITLE
v2.6.6 Fix dtypes for new indices, update tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.5
+### v2.6.1 – v2.6.6
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -32,6 +32,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
 - **Fix timezone detection for existing timezone-naive tables.**
+- **Fix new ID column dtype detection.**
 
 ### v2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.6
+### v2.6.6
+
+- **Improve metadata performance when syncing.**  
+  Syncs via the SQLConnector now cache schema and index metadata, speeding up transactions.
+  
+- **Fix upserts for MySQL / MariaDB.**  
+  Upserts in MySQL and MariaDB now use `ON DUPLICATE` instead of `REPLACE INTO`.
+
+- **Fix dtype detection for index columns.**  
+  A bug where new index columns were incorrectly created as `INT` has been fixed.
+
+- **Delete old keys when dropping Valkey pipes.**  
+  Dropping a pipe from Valkey now clears all old index keys.
+
+### v2.6.1 – v2.6.5
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -32,7 +46,6 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
 - **Fix timezone detection for existing timezone-naive tables.**
-- **Fix new ID column dtype detection.**
 
 ### v2.6.0
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.5
+### v2.6.1 – v2.6.6
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -32,6 +32,7 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
 - **Fix timezone detection for existing timezone-naive tables.**
+- **Fix new ID column dtype detection.**
 
 ### v2.6.0
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,21 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.1 – v2.6.6
+### v2.6.6
+
+- **Improve metadata performance when syncing.**  
+  Syncs via the SQLConnector now cache schema and index metadata, speeding up transactions.
+  
+- **Fix upserts for MySQL / MariaDB.**  
+  Upserts in MySQL and MariaDB now use `ON DUPLICATE` instead of `REPLACE INTO`.
+
+- **Fix dtype detection for index columns.**  
+  A bug where new index columns were incorrectly created as `INT` has been fixed.
+
+- **Delete old keys when dropping Valkey pipes.**  
+  Dropping a pipe from Valkey now clears all old index keys.
+
+### v2.6.1 – v2.6.5
 
 - **Add `Pipe.tzinfo`.**  
   Check if a pipe is timezone-aware with `tzinfo`:
@@ -32,7 +46,6 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix inplace syncs with `upsert=True`.**
 - **Fix timezone-aware datetime truncation for MSSQL**
 - **Fix timezone detection for existing timezone-naive tables.**
-- **Fix new ID column dtype detection.**
 
 ### v2.6.0
 

--- a/meerschaum/_internal/docs/index.py
+++ b/meerschaum/_internal/docs/index.py
@@ -741,10 +741,11 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.sql.get_null_replacement()</code></li>
       <li><code>meerschaum.utils.sql.get_db_version()</code></li>
       <li><code>meerschaum.utils.sql.get_rename_table_queries()</code></li>
-      <li><code>meerschaum.utils.sql.get_create_table_query()</code></li>
+      <li><code>meerschaum.utils.sql.get_create_table_queries()</code></li>
       <li><code>meerschaum.utils.sql.wrap_query_with_cte()</code></li>
       <li><code>meerschaum.utils.sql.format_cte_subquery()</code></li>
       <li><code>meerschaum.utils.sql.session_execute()</code></li>
+      <li><code>meerschaum.utils.sql.get_reset_autoincrement_queries()</code></li>
     </ul>
   </details>
   </ul>

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.5"
+__version__ = "2.6.6"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1349,9 +1349,9 @@ def create_pipe_table_from_df(
             for col, typ in df.dtypes.items()
         },
         **{
-            col: 'int'
+            col: str(df.dtypes.get(col, 'int'))
             for col_ix, col in pipe.columns.items()
-            if col_ix != 'primary'
+            if col and col_ix != 'primary'
         },
         **{
             col: 'uuid'

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1696,7 +1696,9 @@ def sync_pipe(
             )
             for col, typ in update_df.dtypes.items()
         }
-        temp_pipe.__dict__['_columns_types_timestamp'] = time.perf_counter()
+        now_ts = time.perf_counter()
+        temp_pipe.__dict__['_columns_types_timestamp'] = now_ts
+        temp_pipe.__dict__['_skip_check_indices'] = True
         temp_success, temp_msg = temp_pipe.sync(update_df, check_existing=False, debug=debug)
         if not temp_success:
             return temp_success, temp_msg
@@ -1867,6 +1869,7 @@ def sync_pipe_inplace(
     )
     pipe_name = sql_item_name(pipe.target, self.flavor, self.get_pipe_schema(pipe))
     upsert = pipe.parameters.get('upsert', False) and f'{self.flavor}-upsert' in update_queries
+    static = pipe.parameters.get('static', False)
     database = getattr(self, 'database', self.parse_uri(self.URI).get('database', None))
     primary_key = pipe.columns.get('primary', None)
     autoincrement = pipe.parameters.get('autoincrement', False)
@@ -1944,7 +1947,7 @@ def sync_pipe_inplace(
         schema=internal_schema,
         database=database,
         debug=debug,
-    )
+    ) if not static else pipe.get_columns_types(debug=debug)
     if not new_cols_types:
         return False, f"Failed to get new columns for {pipe}."
 
@@ -2049,7 +2052,7 @@ def sync_pipe_inplace(
         schema=internal_schema,
         database=database,
         debug=debug,
-    ) if not upsert else new_cols_types
+    ) if not (upsert or static) else new_cols_types
 
     common_cols = [col for col in new_cols if col in backtrack_cols_types]
     on_cols = {
@@ -2123,7 +2126,7 @@ def sync_pipe_inplace(
         schema=internal_schema,
         database=database,
         debug=debug,
-    ) if not upsert else new_cols_types
+    ) if not (upsert or static) else new_cols_types
 
     ### This is a weird bug on SQLite.
     ### Sometimes the backtrack dtypes are all empty strings.
@@ -2812,12 +2815,13 @@ def get_pipe_columns_indices(
     pipe: mrsm.Pipe
         The pipe to be queried against.
 
-
     Returns
     -------
     A dictionary mapping columns names to lists of dictionaries.
     The dictionaries in the lists contain the name and type of the indices.
     """
+    if pipe.__dict__.get('_skip_check_indices', False):
+        return {}
     from meerschaum.utils.sql import get_table_cols_indices
     return get_table_cols_indices(
         pipe.target,

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -547,7 +547,7 @@ def sync_pipe(
                 new_dtypes[col] = 'string'
                 df[col] = df[col].astype('string')
 
-    if new_dtypes and not static:
+    if new_dtypes and (not static or not valkey_dtypes):
         valkey_dtypes.update(new_dtypes)
         if 'valkey' not in pipe.parameters:
             pipe.parameters['valkey'] = {}

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -85,7 +85,7 @@ def columns(self) -> Union[Dict[str, str], None]:
     if not isinstance(cols, dict):
         cols = {}
         self.parameters['columns'] = cols
-    return cols
+    return {col_ix: col for col_ix, col in cols.items() if col}
 
 
 @columns.setter
@@ -127,11 +127,11 @@ def indices(self) -> Union[Dict[str, Union[str, List[str]]], None]:
     ) + [
         col
         for col_ix, col in _columns.items()
-        if col_ix != 'datetime'
+        if col and col_ix != 'datetime'
     ]))
     return {
         **({'unique': unique_cols} if len(unique_cols) > 1 else {}),
-        **_columns,
+        **{col_ix: col for col_ix, col in _columns.items() if col},
         **_indices
     }
 

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -416,7 +416,11 @@ def get_columns_indices(
     from meerschaum.utils.warnings import dprint
 
     now = time.perf_counter()
-    exists_timeout_seconds = STATIC_CONFIG['pipes']['exists_timeout_seconds']
+    cache_seconds = (
+        STATIC_CONFIG['pipes']['static_schema_cache_seconds']
+        if self.static
+        else STATIC_CONFIG['pipes']['exists_timeout_seconds']
+    )
     if refresh:
         _ = self.__dict__.pop('_columns_indices_timestamp', None)
         _ = self.__dict__.pop('_columns_indices', None)
@@ -425,7 +429,7 @@ def get_columns_indices(
         columns_indices_timestamp = self.__dict__.get('_columns_indices_timestamp', None)
         if columns_indices_timestamp is not None:
             delta = now - columns_indices_timestamp
-            if delta < exists_timeout_seconds:
+            if delta < cache_seconds:
                 if debug:
                     dprint(
                         f"Returning cached `columns_indices` for {self} "

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -371,8 +371,7 @@ def get_columns_types(
 
     now = time.perf_counter()
     cache_seconds = STATIC_CONFIG['pipes']['static_schema_cache_seconds']
-    static = self.parameters.get('static', False)
-    if not static:
+    if not self.static:
         refresh = True
     if refresh:
         _ = self.__dict__.pop('_columns_types_timestamp', None)

--- a/meerschaum/core/Pipe/_drop.py
+++ b/meerschaum/core/Pipe/_drop.py
@@ -9,6 +9,7 @@ Drop a Pipe's table but keep its registration
 from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Any
 
+
 def drop(
     self,
     debug: bool = False,
@@ -39,4 +40,8 @@ def drop(
 
     with Venv(get_connector_plugin(self.instance_connector)):
         result = self.instance_connector.drop_pipe(self, debug=debug, **kw)
+
+    _ = self.__dict__.pop('_exists', None)
+    _ = self.__dict__.pop('_exists_timestamp', None)
+
     return result

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1284,7 +1284,8 @@ def query_df(
                     if debug:
                         dprint(f"Casting column '{datetime_column}' to UTC...")
                     df[datetime_column] = coerce_timezone(df[datetime_column], strip_utc=False)
-                dprint(f"Using datetime bounds:\n{begin=}\n{end=}")
+                if debug:
+                    dprint(f"Using datetime bounds:\n{begin=}\n{end=}")
 
     in_ex_params = get_in_ex_params(params)
 

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -270,9 +270,9 @@ def coerce_timezone(
         pandas = mrsm.attempt_import('pandas')
         dd = mrsm.attempt_import('dask.dataframe') if is_dask else None
         dt_series = (
-            pandas.to_datetime(dt, utc=True)
+            pandas.to_datetime(dt, utc=True, format='ISO8601')
             if dd is None
-            else dd.to_datetime(dt, utc=True)
+            else dd.to_datetime(dt, utc=True, format='ISO8601')
         )
         if strip_utc:
             dt_series = dt_series.apply(lambda x: x.replace(tzinfo=None))

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1467,7 +1467,6 @@ def import_pandas(
     """
     Quality-of-life function to attempt to import the configured version of `pandas`.
     """
-    import sys
     pandas_module_name = pandas_name()
     global emitted_pandas_warning
 
@@ -1482,11 +1481,11 @@ def import_pandas(
                         + f"'{pandas_module_name}'"
                         + "\n   Features may not work as expected."
                     ),
-                    stack = False,
+                    stack=False,
                 )
 
     pytz = attempt_import('pytz', debug=debug, lazy=False, **kw)
-    pandas = attempt_import('pandas', debug=debug, lazy=False, **kw)
+    pandas, pyarrow = attempt_import('pandas', 'pyarrow', debug=debug, lazy=False, **kw)
     pd = attempt_import(pandas_module_name, debug=debug, lazy=lazy, **kw)
     return pd
 

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -103,6 +103,7 @@ packages: Dict[str, Dict[str, str]] = {
         'pytest_xdist'               : 'pytest-xdist>=3.2.1',
         'heartrate'                  : 'heartrate>=0.2.1',
         'build'                      : 'build>=1.2.1',
+        'attrs'                      : 'attrs>=24.2.0',
     },
     'setup': {
     },

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -2179,7 +2179,25 @@ def get_reset_autoincrement_queries(
     debug: bool = False,
 ) -> List[str]:
     """
-    Return a list of queries to reset a table's auto-increment counter.
+    Return a list of queries to reset a table's auto-increment counter to the next largest value.
+
+    Parameters
+    ----------
+    table: str
+        The name of the table on which the auto-incrementing column exists.
+
+    column: str
+        The name of the auto-incrementing column.
+
+    connector: mrsm.connectors.SQLConnector
+        The SQLConnector to the database on which the table exists.
+
+    schema: Optional[str], default None
+        The schema of the table. Defaults to `connector.schema`.
+
+    Returns
+    -------
+    A list of queries to be executed to reset the auto-incrementing column.
     """
     if not table_exists(table, connector, schema=schema, debug=debug):
         return []

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -87,10 +87,10 @@ update_queries = {
         WHERE {date_bounds_subquery}
     """,
     'mysql-upsert': """
-        INSERT INTO {target_table_name} ({patch_cols_str})
+        INSERT {ignore}INTO {target_table_name} ({patch_cols_str})
         SELECT {patch_cols_str}
         FROM {patch_table_name}
-        ON DUPLICATE KEY UPDATE
+        {on_duplicate_key_update}
             {cols_equal_values}
     """,
     'mariadb': """
@@ -101,10 +101,10 @@ update_queries = {
         WHERE {date_bounds_subquery}
     """,
     'mariadb-upsert': """
-        INSERT INTO {target_table_name} ({patch_cols_str})
+        INSERT {ignore}INTO {target_table_name} ({patch_cols_str})
         SELECT {patch_cols_str}
         FROM {patch_table_name}
-        ON DUPLICATE KEY UPDATE
+        {on_duplicate_key_update}
             {cols_equal_values}
     """,
     'mssql': """
@@ -1588,6 +1588,12 @@ def get_update_queries(
             for c_name, c_type in value_cols
         ]
     )
+    on_duplicate_key_update = (
+        "ON DUPLICATE KEY UPDATE"
+        if value_cols
+        else ""
+    )
+    ignore = "IGNORE " if not value_cols else ""
 
     return [
         base_query.format(
@@ -1606,6 +1612,8 @@ def get_update_queries(
             update_or_nothing=update_or_nothing,
             when_matched_update_sets_subquery_none=when_matched_update_sets_subquery_none,
             cols_equal_values=cols_equal_values,
+            on_duplicate_key_update=on_duplicate_key_update,
+            ignore=ignore,
         )
         for base_query in base_queries
     ]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -102,11 +102,17 @@ true && \
 [ "$rc" != '0' ] && exit "$rc"
 
 $PYTHON_BIN -m pytest \
+  -n=auto \
+  tests/test_users.py; rc="$?"
+[ "$rc" != '0' ] && exit "$rc"
+
+$PYTHON_BIN -m pytest \
   --durations=0 \
   --ignore=portable/ \
   --ignore=test_root/ \
   --ignore=tests/data/ \
   --ignore=docs/ \
+  -n=auto \
   --ff \
   -v; rc="$?"
 

--- a/tests/connectors.py
+++ b/tests/connectors.py
@@ -62,11 +62,11 @@ conns = {
         database=str(data_path / 'test_sqlite.db'),
         flavor='sqlite',
     ),
-    'duckdb': get_connector(
-        'sql', 'test_duckdb',
-        database=str(data_path / 'test_duck.db'),
-        flavor='duckdb',
-    ),
+    #  'duckdb': get_connector(
+        #  'sql', 'test_duckdb',
+        #  database=str(data_path / 'test_duck.db'),
+        #  flavor='duckdb',
+    #  ),
     'citus': get_connector(
         'sql', 'test_citus',
         flavor='citus',

--- a/tests/pipes.py
+++ b/tests/pipes.py
@@ -17,8 +17,8 @@ for _label, instance in conns.items():
     all_pipes[_label], remote_pipes[_label] = [], []
     stress_pipe = Pipe(
         'plugin:stress', 'test',
-        mrsm_instance = instance,
-        parameters = {
+        mrsm_instance=instance,
+        parameters={
             'columns': {
                 'datetime': 'datetime',
                 'id': 'id',

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -6,28 +6,22 @@
 Test pipe deduplication syncs.
 """
 
-import pytest
 import json
 from datetime import datetime, timedelta
-from tests import debug
-from tests.pipes import all_pipes, stress_pipes, remote_pipes
-from tests.connectors import conns, get_flavors
-from tests.test_users import test_register_user
-import meerschaum as mrsm
-from meerschaum import Pipe
-from meerschaum.actions import actions
 
-@pytest.fixture(autouse=True)
-def run_before_and_after(flavor: str):
-    test_register_user(flavor)
-    yield
+import pytest
+
+import meerschaum as mrsm
+
+from tests import debug
+from tests.connectors import conns, get_flavors
+
 
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_deduplicate_default(flavor: str):
     """
     Test that verification will fill any backtracked docs.
     """
-    import pandas as pd
     from meerschaum.utils.sql import sql_item_name
     from meerschaum.utils.dataframe import parse_df_datetimes
     conn = conns[flavor]
@@ -70,16 +64,16 @@ def test_deduplicate_without_instance_method(flavor: str):
     """
     Test that verification will fill any backtracked docs.
     """
-    import pandas as pd
-    from meerschaum.utils.sql import sql_item_name
     from meerschaum.utils.dataframe import parse_df_datetimes
     conn = conns[flavor]
     if conn.type != 'sql':
         return
+    pipe = mrsm.Pipe('test', 'deduplicate', 'chunked', instance=conn)
+    pipe.delete()
     pipe = mrsm.Pipe(
         'test', 'deduplicate', 'chunked',
-        instance = conn,
-        columns = {
+        instance=conn,
+        columns={
             'datetime': 'datetime',
             'id': 'id',
         }

--- a/tests/test_pipe_data.py
+++ b/tests/test_pipe_data.py
@@ -10,16 +10,6 @@ from meerschaum import Pipe
 
 from tests.connectors import conns, get_flavors
 from tests import debug
-from tests.test_users import test_register_user as _test_register_user
-
-
-@pytest.fixture(autouse=True)
-def run_before_and_after(flavor: str):
-    """
-    Ensure the test user is registered before running tests.
-    """
-    _test_register_user(flavor)
-    yield
 
 
 @pytest.mark.parametrize("flavor", get_flavors())

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -52,7 +52,7 @@ def test_dtype_enforcement(flavor: str):
     pipe = Pipe(
         'dtype', 'enforcement',
         static=True,
-        upsert=False, ### TODO: Test with `upsert=True`.
+        upsert=True, ### TODO: Test with `upsert=True`.
         columns={
             'datetime': 'dt',
             'id': 'id',

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -58,6 +58,7 @@ def test_dtype_enforcement(flavor: str):
             'id': 'id',
         },
         dtypes={
+            'id': 'int',
             'int': 'int',
             'float': 'float',
             'bool': 'bool',
@@ -77,7 +78,6 @@ def test_dtype_enforcement(flavor: str):
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'json': '{"a": {"b": 1}}'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'numeric': '1'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'uuid': '00000000-1234-5678-0000-000000000000'}], debug=debug)
-    #  return pipe
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert len(df.columns) == 10

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -9,17 +9,11 @@ from decimal import Decimal
 from uuid import UUID
 from tests import debug
 from tests.connectors import conns, get_flavors
-from tests.test_users import test_register_user as _test_register_user
 import meerschaum as mrsm
 from meerschaum import Pipe
 from meerschaum.utils.dtypes import are_dtypes_equal
 from meerschaum.utils.sql import sql_item_name
 from meerschaum.utils.dtypes.sql import PD_TO_DB_DTYPES_FLAVORS
-
-@pytest.fixture(autouse=True)
-def run_before_and_after(flavor: str):
-    _test_register_user(flavor)
-    yield
 
 
 @pytest.mark.parametrize("flavor", get_flavors())
@@ -480,12 +474,12 @@ def test_sync_bools_inferred(flavor: str):
     Test that pipes are able to sync bools.
     """
     conn = conns[flavor]
-    pipe = mrsm.Pipe('test', 'bools', instance=conn)
+    pipe = mrsm.Pipe('test', 'bools', 'inferred', instance=conn)
     _ = pipe.delete()
     pipe = mrsm.Pipe(
-        'test', 'bools',
-        instance = conn,
-        columns = {'datetime': 'dt'},
+        'test', 'bools', 'inferred',
+        instance=conn,
+        columns={'datetime': 'dt'},
     )
     _ = pipe.drop()
     docs = [

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -51,6 +51,8 @@ def test_dtype_enforcement(flavor: str):
     pipe.delete(debug=debug)
     pipe = Pipe(
         'dtype', 'enforcement',
+        static=True,
+        upsert=True,
         columns={
             'datetime': 'dt',
             'id': 'id',
@@ -78,7 +80,6 @@ def test_dtype_enforcement(flavor: str):
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert len(df.columns) == 10
-    return pipe
     for col, typ in df.dtypes.items():
         pipe_dtype = pipe.dtypes[col]
         if pipe_dtype == 'json':
@@ -583,7 +584,6 @@ def test_sync_bools_inplace(flavor: str):
     assert success, msg
     df = inplace_pipe.get_data(params={'id': 3}, debug=True)
     assert 'na' in str(df['is_bool'][0]).lower()
-    return pipe, inplace_pipe
 
 
 @pytest.mark.parametrize("flavor", get_flavors())

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -52,7 +52,7 @@ def test_dtype_enforcement(flavor: str):
     pipe = Pipe(
         'dtype', 'enforcement',
         static=True,
-        upsert=True,
+        upsert=False, ### TODO: Test with `upsert=True`.
         columns={
             'datetime': 'dt',
             'id': 'id',
@@ -77,6 +77,7 @@ def test_dtype_enforcement(flavor: str):
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'json': '{"a": {"b": 1}}'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'numeric': '1'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'uuid': '00000000-1234-5678-0000-000000000000'}], debug=debug)
+    #  return pipe
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert len(df.columns) == 10

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -533,7 +533,7 @@ def test_sync_inplace_upsert(flavor: str):
     docs = [
         {'dt': '2023-01-01 00:00:00', 'id': UUID('9f680a72-b5f7-4336-8f7c-30927ec21cb1')},
         {'dt': '2023-01-01 00:01:00', 'id': UUID('335b0322-4b54-40aa-8019-07666cbefa52')},
-        {'dt': '2023-01-01 00:02:00', 'id': UUID('d7d42913-2dfe-47d6-b0e0-7f71e13e814e')},
+        {'dt': '2023-01-01 00:02:00', 'id': UUID('d7d42913-2dfe-47d6-b0e0-7f71e13e814e'), 'd': 7},
         {'dt': '2023-01-01 00:03:00', 'id': UUID('7e194a2c-26b4-4632-af02-e0a8b2c6ce1e')},
         {'dt': '2023-01-01 00:04:00', 'id': UUID('31e5fd08-fb81-47f4-8a1c-0c9dcf08ac5e')},
     ]
@@ -549,11 +549,11 @@ def test_sync_inplace_upsert(flavor: str):
     assert dest_pipe.get_rowcount(debug=debug) == len(docs)
 
     new_docs = [
-        {'dt': '2023-01-02 00:00:00', 'id': UUID('afb0b31b-15dc-485e-ac6f-d8622b6d03d4')},
-        {'dt': '2023-01-02 00:01:00', 'id': UUID('8b7bf428-d0ed-40fa-951b-bb115a03eac5')},
-        {'dt': '2023-01-02 00:02:00', 'id': UUID('36aed9b4-4c7a-4566-a321-d1774ef1015a')},
-        {'dt': '2023-01-02 00:03:00', 'id': UUID('7a4ef6cc-37d8-4899-9ddb-07b4998d0b53')},
-        {'dt': '2023-01-02 00:04:00', 'id': UUID('59244211-fdb8-46f1-b14b-8631146758c0')},
+        {'dt': '2023-01-02 00:00:00', 'id': UUID('afb0b31b-15dc-485e-ac6f-d8622b6d03d4'), 'c': 9},
+        {'dt': '2023-01-02 00:01:00', 'id': UUID('8b7bf428-d0ed-40fa-951b-bb115a03eac5'), 'c': 8},
+        {'dt': '2023-01-02 00:02:00', 'id': UUID('36aed9b4-4c7a-4566-a321-d1774ef1015a'), 'c': 7},
+        {'dt': '2023-01-02 00:03:00', 'id': UUID('7a4ef6cc-37d8-4899-9ddb-07b4998d0b53'), 'c': 6},
+        {'dt': '2023-01-02 00:04:00', 'id': UUID('59244211-fdb8-46f1-b14b-8631146758c0'), 'c': 5},
     ]
     success, msg = source_pipe.sync(new_docs)
     assert success, msg
@@ -580,6 +580,7 @@ def test_sync_inplace_upsert(flavor: str):
     df = dest_pipe.get_data(params={'id': 'd7d42913-2dfe-47d6-b0e0-7f71e13e814e'})
     assert len(df) == 1
     assert df['a'][0] == 3
+    assert df['d'][0] == 7
 
 
 @pytest.mark.parametrize("flavor", get_flavors())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -13,18 +13,7 @@ from meerschaum import Pipe
 from meerschaum.actions import actions
 
 from tests import debug
-from tests.pipes import all_pipes, stress_pipes, remote_pipes
 from tests.connectors import conns, get_flavors
-from tests.test_users import test_register_user as _test_register_user
-
-
-@pytest.fixture(autouse=True)
-def run_before_and_after(flavor: str):
-    """
-    Ensure the test user is registered before running tests.
-    """
-    _test_register_user(flavor)
-    yield
 
 
 @pytest.mark.parametrize("flavor", get_flavors())
@@ -32,10 +21,13 @@ def test_register_and_delete(flavor: str):
     """
     Verify user registration and deletion.
     """
-    pipe = all_pipes[flavor][0]
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'register', 'delete', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'register', 'delete', instance=conn)
     params = pipe.parameters.copy()
     assert params is not None
-    output = pipe.delete()
+    pipe.delete()
     pipe.parameters = params
     assert pipe.parameters is not None
     success, msg = pipe.register(debug=debug)
@@ -53,17 +45,23 @@ def test_drop_and_sync(flavor: str):
     """
     Verify dropping and resyncing pipes.
     """
-    pipe = all_pipes[flavor][0]
-    pipe.drop()
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'drop_sync', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe(
+        'test', 'drop_sync',
+        instance=conn,
+        columns=['datetime', 'id'],
+    )
     assert pipe.exists(debug=debug) is False
     assert pipe.columns is not None
     now1 = datetime(2021, 1, 1, 12, 0)
-    data = {'datetime' : [now1], 'id' : [1], 'val': [1]}
+    data = {'datetime': [now1], 'id' : [1], 'val': [1]}
     success, msg = pipe.sync(data, debug=debug)
     assert success, msg
     assert pipe.exists(debug=debug)
     now2 = datetime(2021, 1, 1, 12, 1)
-    data = {'datetime' : [now2], 'id' : [1], 'val': [1]}
+    data = {'datetime': [now2], 'id' : [1], 'val': [1]}
     success, msg = pipe.sync(data, debug=debug)
     assert success, msg
     assert pipe.exists(debug=debug)
@@ -71,14 +69,20 @@ def test_drop_and_sync(flavor: str):
     assert data is not None
     assert len(data) == 2
 
+
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_drop_and_sync_duplicate(flavor: str):
     """
     Verify dropping a table and syncing duplicate rows are filtered out.
     """
-    pipe = all_pipes[flavor][0]
-    pipe.drop(debug=debug)
-    assert not pipe.exists(debug=debug)
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'drop_sync', 'duplicate', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe(
+        'test', 'drop_sync', 'duplicate',
+        instance=conn,
+        columns=['datetime', 'id'],
+    )
 
     now1 = datetime(2021, 1, 1, 12, 0)
     data = {'datetime': [now1], 'id': [1], 'val': [1]}
@@ -93,80 +97,27 @@ def test_drop_and_sync_duplicate(flavor: str):
     assert success, msg
     data = pipe.get_data(debug=debug)
     assert len(data) == 1
-
-@pytest.mark.parametrize("flavor", get_flavors())
-def test_drop_and_sync_stress(flavor: str):
-    pipe = stress_pipes[flavor]
-    pipe.drop(debug=debug)
-    success, msg = pipe.sync(debug=debug)
-    assert success, msg
-
-@pytest.mark.parametrize("flavor", get_flavors())
-def test_drop_and_sync_remote(flavor: str):
-    pipe = None
-    for p in remote_pipes[flavor]:
-        if str(p.connector) == str(p.instance_connector):
-            pipe = p
-            break
-    if pipe is None:
-        return
-    pipe.delete(debug=debug)
-    parent_pipe = Pipe('plugin:stress', 'test', instance=pipe.connector)
-    parent_pipe.delete(debug=debug)
-    begin, end = datetime(2020, 1, 1), datetime(2020, 1, 2)
-    success, msg = parent_pipe.sync(begin=begin, end=end, debug=debug)
-    parent_len = parent_pipe.get_rowcount(debug=debug)
-    assert success, msg
-
-    success, msg = pipe.sync(debug=debug)
-    assert success, msg
-    child_len = pipe.get_rowcount(debug=debug)
-    assert parent_len == child_len
-
-    success, msg = parent_pipe.sync(
-        [{'datetime': '2020-01-03', 'id': -1, 'foo': 'a'}],
-        debug=debug,
-    )
-    assert success, msg
-    parent_len2 = parent_pipe.get_rowcount(debug=debug)
-    assert parent_len2 == (parent_len + 1)
-    success, msg = pipe.sync(debug=debug)
-    assert len(pipe.get_columns_types(debug=debug)) == 4
-    child_len2 = pipe.get_rowcount(debug=debug)
-    assert parent_len2 == child_len2
-    success, msg = parent_pipe.sync(
-        [{'datetime': '2020-01-03', 'id': -1, 'foo': 'b'}],
-        debug=debug,
-    )
-    assert success, msg
-    parent_len3 = parent_pipe.get_rowcount(debug=debug)
-    assert parent_len2 == parent_len3
-    success, msg = pipe.sync(debug=debug, begin='2020-01-01')
-    assert success, msg
-    child_len3 = pipe.get_rowcount(debug=debug)
-    assert child_len3 == parent_len3
-    df = pipe.get_data(params={'id': -1}, debug=debug)
-    assert len(df) == 1
-    assert df.to_dict(orient='records')[0]['foo'] == 'b'
 
 
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_sync_engine(flavor: str):
+    """
+    Test that we can sync a test pipe via the `sync pipes` action.
+    """
     ### Weird concurrency issues with our tests.
     if flavor == 'duckdb':
         return
-    pipe = stress_pipes[flavor]
-    _ = pipe.register()
-    mrsm_instance = str(pipe.instance_connector)
-    _ = actions['drop'](
-        ['pipes'],
-        connector_keys=[pipe.connector_keys],
-        metric_keys=[pipe.metric_key],
-        location_keys=[pipe.location_key],
-        mrsm_instance=mrsm_instance,
-        yes=True,
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('plugin:stress', 'test', 'engine', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe(
+        'plugin:stress', 'test', 'engine',
+        instance=conn,
+        columns=['datetime', 'id'],
     )
-
+    success, msg = pipe.register()
+    assert success, msg
+    mrsm_instance = str(pipe.instance_connector)
     success, msg = actions['sync'](
         ['pipes'],
         connector_keys=[pipe.connector_keys],
@@ -186,8 +137,6 @@ def test_target_mutable(flavor: str):
     pipe = Pipe('target', 'mutable', target=target, instance=conn)
     pipe.delete()
     pipe = Pipe('target', 'mutable', target=target, instance=conn, columns={'datetime': 'dt', 'id': 'id'})
-    pipe.drop(debug=debug)
-    assert not pipe.exists(debug=debug)
     success, msg = pipe.sync(
         {'dt': [datetime(2022, 6, 8)], 'id': [1], 'vl': [10]},
         debug=debug,
@@ -260,7 +209,7 @@ def test_temporary_pipes(flavor: str):
             {'id': 1, 'b': 4},
             {'id': 2, 'a': 5},
         ],
-        debug = debug,
+        debug=debug,
     )
     success, msg = pipe.delete(debug=debug)
     assert (not success), msg

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -9,7 +9,6 @@ Test user registration, deletion, and more.
 import pytest
 import datetime
 from tests import debug
-from tests.pipes import all_pipes, stress_pipes, remote_pipes
 from tests.connectors import conns, get_flavors
 from meerschaum.core import User
 
@@ -18,7 +17,4 @@ def test_register_user(flavor: str):
     username, password, email = conns['api'].username, conns['api'].password, 'none@none.com'
     user = User(username, password, email=email)
     conn = conns[flavor]
-    #  conn.delete_user(user, debug=debug)
     conn.register_user(user, debug=debug)
-    #  success, msg = conn.register_user(user, debug=debug)
-    #  assert success, msg


### PR DESCRIPTION
# v2.6.6

- **Improve metadata performance when syncing.**  
  Syncs via the SQLConnector now cache schema and index metadata, speeding up transactions.
  
- **Fix upserts for MySQL / MariaDB.**  
  Upserts in MySQL and MariaDB now use `ON DUPLICATE` instead of `REPLACE INTO`.

- **Fix dtype detection for index columns.**  
  A bug where new index columns were incorrectly created as `INT` has been fixed.

- **Delete old keys when dropping Valkey pipes.**  
  Dropping a pipe from Valkey now clears all old index keys.
