### PR TITLE
⚡️ v2.6.10 Speed up dtype enforcement, fix Oracle auto-incrementing IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.10
+
+- **Improve datetime timezone-awareness enforcement performance.**  
+  Datetime columns are only parsed for timezone awareness if the desired awareness differs. This drastically speeds up sync times.
+
+- **Switch to `tz_localize()` when stripping timezone information.**  
+  The previous method of using a lambda to replace individual `tzinfo` attributes did not scale well. Using `tz_localize()` can be vectorized and greatly speeds up syncs, especially with large chunks.
+
+- **Add `enforce_dtypes` to `Pipe.filter_existing()`.**  
+  You may optionally enforce dtype information during `filter_existing()`. This may be useful when implementing custom syncs for instance connectors. Note this may impact memory and compute performance.
+
+  ```python
+  import meerschaum as mrsm
+  import pandas as pd
+
+  pipe = mrsm.Pipe('a', 'b', instance='sql:local')
+  pipe.sync([{'a': 1}])
+
+  df = pd.DataFrame([{'a': '2'}])
+
+  ### `enforce_dtypes=True` will suppress the differing dtypes warning.
+  unseen, update, delta = pipe.filter_existing(df, enforce_dtypes=True)
+  print(delta)
+  ```
+
 ### v2.6.6 – v2.6.9
 
 - **Improve metadata performance when syncing.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This is the current release cycle, so stay tuned for future releases!
   print(delta)
   ```
 
+- **Fix `query_df()` for null parameters.**  
+  This is useful for when you may use `query_df()` with only `select_columns` or `omit_columns`.
+
 ### v2.6.6 – v2.6.9
 
 - **Improve metadata performance when syncing.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,31 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.10
+
+- **Improve datetime timezone-awareness enforcement performance.**  
+  Datetime columns are only parsed for timezone awareness if the desired awareness differs. This drastically speeds up sync times.
+
+- **Switch to `tz_localize()` when stripping timezone information.**  
+  The previous method of using a lambda to replace individual `tzinfo` attributes did not scale well. Using `tz_localize()` can be vectorized and greatly speeds up syncs, especially with large chunks.
+
+- **Add `enforce_dtypes` to `Pipe.filter_existing()`.**  
+  You may optionally enforce dtype information during `filter_existing()`. This may be useful when implementing custom syncs for instance connectors. Note this may impact memory and compute performance.
+
+  ```python
+  import meerschaum as mrsm
+  import pandas as pd
+
+  pipe = mrsm.Pipe('a', 'b', instance='sql:local')
+  pipe.sync([{'a': 1}])
+
+  df = pd.DataFrame([{'a': '2'}])
+
+  ### `enforce_dtypes=True` will suppress the differing dtypes warning.
+  unseen, update, delta = pipe.filter_existing(df, enforce_dtypes=True)
+  print(delta)
+  ```
+
 ### v2.6.6 – v2.6.9
 
 - **Improve metadata performance when syncing.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -29,6 +29,9 @@ This is the current release cycle, so stay tuned for future releases!
   print(delta)
   ```
 
+- **Fix `query_df()` for null parameters.**  
+  This is useful for when you may use `query_df()` with only `select_columns` or `omit_columns`.
+
 ### v2.6.6 – v2.6.9
 
 - **Improve metadata performance when syncing.**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.9"
+__version__ = "2.6.10"

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -56,7 +56,7 @@ def enforce_dtypes(
                 chunksize=chunksize,
                 debug=debug,
             )
-        else:
+        elif isinstance(df, (dict, list)):
             df = parse_df_datetimes(
                 df,
                 ignore_cols=[

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1283,18 +1283,8 @@ def query_df(
                 if debug:
                     dprint(f"`end` will be cast to '{end}'.")
 
-            begin_tz = begin.tzinfo if begin is not None else None
-            end_tz = end.tzinfo if end is not None else None
-
-            if begin_tz is not None or end_tz is not None or df_tz is not None:
-                begin = coerce_timezone(begin, strip_utc=False)
-                end = coerce_timezone(end, strip_utc=False)
-                if df_tz is not None:
-                    if debug:
-                        dprint(f"Casting column '{datetime_column}' to UTC...")
-                    df[datetime_column] = coerce_timezone(df[datetime_column], strip_utc=False)
-                if debug:
-                    dprint(f"Using datetime bounds:\n{begin=}\n{end=}")
+            begin = coerce_timezone(begin, strip_utc=(df_tz is None)) if begin is not None else None
+            end = coerce_timezone(end, strip_utc=(df_tz is None)) if begin is not None else None
 
     in_ex_params = get_in_ex_params(params)
 

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1330,15 +1330,24 @@ def query_df(
     ]
     for col in bool_cols:
         df[col] = df[col].astype('boolean[pyarrow]')
-    df['__mrsm_mask'] = query_mask.astype('boolean[pyarrow]')
 
-    if inplace:
-        df.where(query_mask, other=NA, inplace=True)
-        df.dropna(how='all', inplace=True)
-        result_df = df
+    if not isinstance(query_mask, bool):
+        df['__mrsm_mask'] = (
+            query_mask.astype('boolean[pyarrow]')
+            if hasattr(query_mask, 'astype')
+            else query_mask
+        )
+
+        if inplace:
+            df.where(query_mask, other=NA, inplace=True)
+            df.dropna(how='all', inplace=True)
+            result_df = df
+        else:
+            result_df = df.where(query_mask, other=NA)
+            result_df.dropna(how='all', inplace=True)
+
     else:
-        result_df = df.where(query_mask, other=NA)
-        result_df.dropna(how='all', inplace=True)
+        result_df = df
 
     if '__mrsm_mask' in df.columns:
         del df['__mrsm_mask']

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -267,8 +267,18 @@ def coerce_timezone(
 
     if dt_is_series:
         is_dask = 'dask' in dt.__module__
-        pandas = mrsm.attempt_import('pandas')
+        pandas = mrsm.attempt_import('pandas', lazy=False)
         dd = mrsm.attempt_import('dask.dataframe') if is_dask else None
+
+        if (
+            pandas.api.types.is_datetime64_any_dtype(dt) and (
+                (dt.dt.tz is not None and not strip_utc)
+                or
+                (dt.dt.tz is None and strip_utc)
+            )
+        ):
+            return dt
+
         dt_series = (
             pandas.to_datetime(dt, utc=True, format='ISO8601')
             if dd is None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -23,7 +23,7 @@ def test_create_job():
     success, msg = job.start()
     assert success, msg
 
-    duration = 1.0
+    duration = 2.0
     time.sleep(duration)
 
     success, msg = job.stop()


### PR DESCRIPTION
# v2.6.10

- **Improve datetime timezone-awareness enforcement performance.**  
  Datetime columns are only parsed for timezone awareness if the desired awareness differs. This drastically speeds up sync times.

- **Switch to `tz_localize()` when stripping timezone information.**  
  The previous method of using a lambda to replace individual `tzinfo` attributes did not scale well. Using `tz_localize()` can be vectorized and greatly speeds up syncs, especially with large chunks.

- **Add `enforce_dtypes` to `Pipe.filter_existing()`.**  
  You may optionally enforce dtype information during `filter_existing()`. This may be useful when implementing custom syncs for instance connectors. Note this may impact memory and compute performance.

  ```python
  import meerschaum as mrsm
  import pandas as pd

  pipe = mrsm.Pipe('a', 'b', instance='sql:local')
  pipe.sync([{'a': 1}])

  df = pd.DataFrame([{'a': '2'}])

  ### `enforce_dtypes=True` will suppress the differing dtypes warning.
  unseen, update, delta = pipe.filter_existing(df, enforce_dtypes=True)
  print(delta)
  ```

- **Fix `query_df()` for null parameters.**  
  This is useful for when you may use `query_df()` with only `select_columns` or `omit_columns`.
