### PR TITLE
🔒️ v2.6.12 Enforce permissions security settings for jobs and remote actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.10 – v2.6.11
+### v2.6.10 – v2.6.12
 
 - **Improve datetime timezone-awareness enforcement performance.**  
   Datetime columns are only parsed for timezone awareness if the desired awareness differs. This drastically speeds up sync times.
@@ -33,6 +33,9 @@ This is the current release cycle, so stay tuned for future releases!
   This is useful for when you may use `query_df()` with only `select_columns` or `omit_columns`.
 
 - **Fix autoincrementing IDs for Oracle SQL.**
+
+- **Enforce security settings for creating jobs.**  
+  Jobs and remote actions will only be accessible to admin users when running with `--secure` (`system:permissions:actions:non_admin` in config).
 
 ### v2.6.6 – v2.6.9
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.6.10 – v2.6.11
+### v2.6.10 – v2.6.12
 
 - **Improve datetime timezone-awareness enforcement performance.**  
   Datetime columns are only parsed for timezone awareness if the desired awareness differs. This drastically speeds up sync times.
@@ -33,6 +33,9 @@ This is the current release cycle, so stay tuned for future releases!
   This is useful for when you may use `query_df()` with only `select_columns` or `omit_columns`.
 
 - **Fix autoincrementing IDs for Oracle SQL.**
+
+- **Enforce security settings for creating jobs.**  
+  Jobs and remote actions will only be accessible to admin users when running with `--secure` (`system:permissions:actions:non_admin` in config).
 
 ### v2.6.6 – v2.6.9
 

--- a/meerschaum/api/routes/_actions.py
+++ b/meerschaum/api/routes/_actions.py
@@ -17,28 +17,6 @@ from meerschaum.config import get_config
 
 actions_endpoint = endpoints['actions']
 
-def is_user_allowed_to_execute(user) -> SuccessTuple:
-    if user is None:
-        return False, "Could not load user."
-
-    if user.type == 'admin':
-        return True, "Success"
-
-    allow_non_admin = get_config(
-        'system', 'api', 'permissions', 'actions', 'non_admin', patch=True
-    )
-    if not allow_non_admin:
-        return False, (
-            "The administrator for this server has not allowed users to perform actions.\n\n"
-            + "Please contact the system administrator, or if you are running this server, "
-            + "open the configuration file with `edit config system` "
-            + "and search for 'permissions'. "
-            + "\nUnder the keys 'api:permissions:actions', "
-            + "you can allow non-admin users to perform actions."
-        )
-
-    return True, "Success"
-
 
 @app.get(actions_endpoint, tags=['Actions'])
 def get_actions(

--- a/meerschaum/api/routes/_jobs.py
+++ b/meerschaum/api/routes/_jobs.py
@@ -32,6 +32,8 @@ from meerschaum.api import (
     no_auth,
 )
 from meerschaum.config.static import STATIC_CONFIG
+from meerschaum.core.User import is_user_allowed_to_execute
+
 
 JOBS_STDIN_MESSAGE: str = STATIC_CONFIG['api']['jobs']['stdin_message']
 JOBS_STOP_MESSAGE: str = STATIC_CONFIG['api']['jobs']['stop_message']
@@ -141,6 +143,10 @@ def create_job(
     """
     Create and start a new job.
     """
+    allowed_success, allowed_msg = is_user_allowed_to_execute(curr_user)
+    if not allowed_success:
+        return allowed_success, allowed_msg
+
     sysargs = metadata if isinstance(metadata, list) else metadata['sysargs']
     properties = metadata['properties'] if isinstance(metadata, dict) else None
     job = Job(
@@ -172,6 +178,9 @@ def delete_job(
     """
     Delete a job.
     """
+    allowed_success, allowed_msg = is_user_allowed_to_execute(curr_user)
+    if not allowed_success:
+        return allowed_success, allowed_msg
     job = _get_job(name)
     return job.delete()
 
@@ -221,6 +230,10 @@ def start_job(
     """
     Start a job if stopped.
     """
+    allowed_success, allowed_msg = is_user_allowed_to_execute(curr_user)
+    if not allowed_success:
+        return allowed_success, allowed_msg
+
     job = _get_job(name)
     if not job.exists():
         raise fastapi.HTTPException(
@@ -240,6 +253,10 @@ def stop_job(
     """
     Stop a job if running.
     """
+    allowed_success, allowed_msg = is_user_allowed_to_execute(curr_user)
+    if not allowed_success:
+        return allowed_success, allowed_msg
+
     job = _get_job(name)
     if not job.exists():
         raise fastapi.HTTPException(
@@ -259,6 +276,10 @@ def pause_job(
     """
     Pause a job if running.
     """
+    allowed_success, allowed_msg = is_user_allowed_to_execute(curr_user)
+    if not allowed_success:
+        return allowed_success, allowed_msg
+
     job = _get_job(name)
     if not job.exists():
         raise fastapi.HTTPException(

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.11"
+__version__ = "2.6.12"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -50,10 +50,15 @@ def register_pipe(
     )
     if debug:
         dprint(response.text)
-    if isinstance(response.json(), list):
-        response_tuple = response.__bool__(), response.json()[1]
+
+    if not response:
+        return False, response.text
+
+    response_data = response.json()
+    if isinstance(response_data, list):
+        response_tuple = response_data[0], response_data[1]
     elif 'detail' in response.json():
-        response_tuple = response.__bool__(), response.json()['detail']
+        response_tuple = response.__bool__(), response_data['detail']
     else:
         response_tuple = response.__bool__(), response.text
     return response_tuple
@@ -80,10 +85,13 @@ def edit_pipe(
     )
     if debug:
         dprint(response.text)
+
+    response_data = response.json()
+
     if isinstance(response.json(), list):
-        response_tuple = response.__bool__(), response.json()[1]
+        response_tuple = response_data[0], response_data[1]
     elif 'detail' in response.json():
-        response_tuple = response.__bool__(), response.json()['detail']
+        response_tuple = response.__bool__(), response_data['detail']
     else:
         response_tuple = response.__bool__(), response.text
     return response_tuple
@@ -318,10 +326,12 @@ def delete_pipe(
     )
     if debug:
         dprint(response.text)
+
+    response_data = response.json()
     if isinstance(response.json(), list):
-        response_tuple = response.__bool__(), response.json()[1]
+        response_tuple = response_data[0], response_data[1]
     elif 'detail' in response.json():
-        response_tuple = response.__bool__(), response.json()['detail']
+        response_tuple = response.__bool__(), response_data['detail']
     else:
         response_tuple = response.__bool__(), response.text
     return response_tuple
@@ -637,7 +647,7 @@ def drop_pipe(
         return False, f"Failed to drop {pipe}."
 
     if isinstance(data, list):
-        response_tuple = response.__bool__(), data[1]
+        response_tuple = data[0], data[1]
     elif 'detail' in response.json():
         response_tuple = response.__bool__(), data['detail']
     else:

--- a/meerschaum/core/User/__init__.py
+++ b/meerschaum/core/User/__init__.py
@@ -6,4 +6,34 @@
 Manager users' metadata via the User class
 """
 
+from typing import Optional
+
+import meerschaum as mrsm
 from meerschaum.core.User._User import User, hash_password, verify_password
+
+
+def is_user_allowed_to_execute(user: Optional[User]) -> mrsm.SuccessTuple:
+    """
+    Return a `SuccessTuple` indicating whether a given user is allowed to execute actions.
+    """
+    if user is None:
+        return True, "Success"
+
+    if user.type == 'admin':
+        return True, "Success"
+
+    from meerschaum.config import get_config
+
+    allow_non_admin = get_config('system', 'api', 'permissions', 'actions', 'non_admin')
+    if not allow_non_admin:
+        return False, (
+            "The administrator for this server has not allowed users to perform actions.\n\n"
+            + "Please contact the system administrator, or if you are running this server, "
+            + "open the configuration file with `edit config system` "
+            + "and search for 'permissions'. "
+            + "\nUnder the keys 'api:permissions:actions', "
+            + "you can allow non-admin users to perform actions."
+        )
+
+    return True, "Success"
+

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup_kw_args = {
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
         "Topic :: Database",
         "Natural Language :: English",
     ],

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -23,7 +23,7 @@ def test_create_job():
     success, msg = job.start()
     assert success, msg
 
-    duration = 2.0
+    duration = 4.0
     time.sleep(duration)
 
     success, msg = job.stop()


### PR DESCRIPTION
- **Enforce security settings for creating jobs.**  
  Jobs and remote actions will only be accessible to admin users when running with `--secure` (`system:permissions:actions:non_admin` in config).
