### PR TITLE
🐛 v2.6.15 Fix inplace syncs without a datetime column.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.15
+
+- **Fix inplace syncs without a `datetime` axis.**  
+  A bug introduced by a performance optimization has been fixed. Inplace pipes without a `datetime` axis will skip searching for date bounds. Setting `upsert` to `true` will bypass this bug for previous releases.
+
+- **Skip invoking `get_sync_time()` for pipes without a `datetime` axis.**  
+  Invoking an instance connector's `get_sync_time()` method will now only occur when `datetime` is set.
+
+- **Remove `guess_datetime()` check from `SQLConnector.get_sync_time()`.**  
+  Because sync times are only checked for pipes with a dedicated `datetime` column, the `guess_datetime()` check has been removed from the `SQLConnector.get_sync_time()` method.
+
+- **Skip persisting default `target` to parameters.**  
+  The default target table name will no longer be persisted to `parameters`. This helps avoid accidentally setting the wrong target table when copying pipes.
+
+- **Default to "no" for syncing data when copying pipes.**  
+  The action `copy pipes` will no longer sync data by default, instead requiring an explicit yes to begin syncing.
+
+- **Fix the "Update query" button behavior on the Web Console.**  
+  Existing but null keys are now accounted for when update a SQL pipe's query.
+
+- **Fix another Oracle autoincrement edge case.**
+
 ### v2.6.10 – v2.6.14
 
 - **Improve datetime timezone-awareness enforcement performance.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,28 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.6.15
+
+- **Fix inplace syncs without a `datetime` axis.**  
+  A bug introduced by a performance optimization has been fixed. Inplace pipes without a `datetime` axis will skip searching for date bounds. Setting `upsert` to `true` will bypass this bug for previous releases.
+
+- **Skip invoking `get_sync_time()` for pipes without a `datetime` axis.**  
+  Invoking an instance connector's `get_sync_time()` method will now only occur when `datetime` is set.
+
+- **Remove `guess_datetime()` check from `SQLConnector.get_sync_time()`.**  
+  Because sync times are only checked for pipes with a dedicated `datetime` column, the `guess_datetime()` check has been removed from the `SQLConnector.get_sync_time()` method.
+
+- **Skip persisting default `target` to parameters.**  
+  The default target table name will no longer be persisted to `parameters`. This helps avoid accidentally setting the wrong target table when copying pipes.
+
+- **Default to "no" for syncing data when copying pipes.**  
+  The action `copy pipes` will no longer sync data by default, instead requiring an explicit yes to begin syncing.
+
+- **Fix the "Update query" button behavior on the Web Console.**  
+  Existing but null keys are now accounted for when update a SQL pipe's query.
+
+- **Fix another Oracle autoincrement edge case.**
+
 ### v2.6.10 – v2.6.14
 
 - **Improve datetime timezone-awareness enforcement performance.**  

--- a/docs/mkdocs/reference/connectors/instance-connectors.md
+++ b/docs/mkdocs/reference/connectors/instance-connectors.md
@@ -532,7 +532,7 @@ Delete a pipe's data within a bounded or unbounded interval without dropping the
 
 ### `#!python deduplicate_pipe()` (optional)
 
-Like `sync_pipe_inplace()`, you may choose to implement `deduplicate_pipe()` for a performance boost. Otherwise, the default implementation relies upon `get_pipe_data()`, `clear_pipe()`, and `get_pipe_rowcount()`. See the [`#!python SQLConnector.deduplicate_pipe()`](https://docs.meerschaum.io/connectors/sql/SQLConnector.html#meerschaum.connectors.sql.SQLConnector.SQLConnector.deduplicate_pipe) method for reference.
+Like `sync_pipe_inplace()`, you may choose to implement `deduplicate_pipe()` for a performance boost. Otherwise, the default implementation relies upon `get_pipe_data()`, `clear_pipe()`, and `get_pipe_rowcount()`. See the [`#!python SQLConnector.deduplicate_pipe()`](https://docs.meerschaum.io/meerschaum/connectors.html#SQLConnector.deduplicate_pipe) method for reference.
 ## `#!python get_pipe_data()`
 
 Return the target table's data according to the filters.

--- a/meerschaum/actions/bootstrap.py
+++ b/meerschaum/actions/bootstrap.py
@@ -54,10 +54,9 @@ def _bootstrap_pipes(
     """
     from meerschaum import get_pipes
     from meerschaum.config import get_config
-    from meerschaum.utils.warnings import info, warn, error
-    from meerschaum.utils.debug import dprint
+    from meerschaum.utils.warnings import info, warn
     from meerschaum.utils.prompt import yes_no, prompt, choose
-    from meerschaum.connectors.parse import is_valid_connector_keys, parse_instance_keys
+    from meerschaum.connectors.parse import parse_instance_keys
     from meerschaum.utils.misc import get_connector_labels
     from meerschaum.utils.formatting._shell import clear_screen
 
@@ -102,7 +101,7 @@ def _bootstrap_pipes(
         ### Get the connector.
         new_label = 'New'
         info(
-            f"To create a pipe without explicitly using a connector, "
+            "To create a pipe without explicitly using a connector, "
             + "use the `register pipes` command.\n"
         )
         try:
@@ -133,7 +132,7 @@ def _bootstrap_pipes(
                     break
                 elif isinstance(tup[0], bool) and not tup[0]:
                     return abort_tuple
-                warn(f"Please register a new connector or press CTRL+C to cancel.", stack=False)
+                warn("Please register a new connector or press CTRL+C to cancel.", stack=False)
         connector_keys = [ck]
 
         ### Get the metric.
@@ -142,9 +141,9 @@ def _bootstrap_pipes(
                 clear_screen(debug=debug)
             try:
                 mk = prompt(
-                    f"What kind of data is this?\n\n" +
-                    f"    The metric is the label for the contents of the pipe.\n" +
-                    f"    For example, 'weather' might be a metric for weather station data.\n\n" +
+                    "What kind of data is this?\n\n" +
+                    "    The metric is the label for the contents of the pipe.\n" +
+                    "    For example, 'weather' might be a metric for weather station data.\n\n" +
                     f" {get_config('formatting', 'emoji', 'metric')} Metric:"
                 )
             except KeyboardInterrupt:
@@ -224,6 +223,7 @@ def _bootstrap_pipes(
 
     return (successes > 0), msg
 
+
 def _bootstrap_connectors(
     action: Optional[List[str]] = None,
     connector_keys: Optional[List[str]] = None,
@@ -237,7 +237,6 @@ def _bootstrap_connectors(
     """
     Prompt the user for the details necessary to create a Connector.
     """
-    from meerschaum.connectors.parse import is_valid_connector_keys
     from meerschaum.connectors import (
         connectors,
         get_connector,

--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -38,7 +38,6 @@ def _complete_copy(
     """
     Override the default Meerschaum `complete_` function.
     """
-    from meerschaum.actions.edit import _complete_edit_config
     if action is None:
         action = []
 
@@ -71,7 +70,7 @@ def _copy_pipes(
     """
     from meerschaum import get_pipes, Pipe
     from meerschaum.utils.prompt import prompt, yes_no
-    from meerschaum.utils.warnings import warn, info
+    from meerschaum.utils.warnings import warn
     from meerschaum.utils.formatting import print_tuple
     from meerschaum.utils.formatting._shell import clear_screen
     pipes = get_pipes(as_list=True, **kw)
@@ -110,7 +109,9 @@ def _copy_pipes(
                     f"Do you want to copy data from {p} into {_new_pipe}?\n\n"
                     + "If you specified `--begin`, `--end` or `--params`, data will be filtered."
                 ),
-                    noask=noask, yes=yes
+                    noask=noask,
+                    yes=yes,
+                    default='n',
                 )
         ):
             _new_pipe.sync(

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -131,7 +131,6 @@ default_pipes_config = {
     'parameters': {
         'columns': {
             'datetime': None,
-            'id': None,
         },
         'fetch': {
             'backtrack_minutes': 1440,

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.14"
+__version__ = "2.6.15"

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -284,15 +284,15 @@ def set_pipe_query(pipe: mrsm.Pipe, query: str) -> None:
     - query
     - sql
     """
-    if pipe.parameters.get('fetch', {}).get('definition', None):
+    if 'fetch' in pipe.parameters and 'definition' in pipe.parameters['fetch']:
         if pipe.parameters.get('fetch', None) is None:
             pipe.parameters['fetch'] = {}
         dict_to_set = pipe.parameters['fetch']
         key_to_set = 'definition'
-    elif pipe.parameters.get('definition', None):
+    elif 'definition' in pipe.parameters:
         dict_to_set = pipe.parameters
         key_to_set = 'definition'
-    elif pipe.parameters.get('query', None):
+    elif 'query' in pipe.parameters:
         dict_to_set = pipe.parameters
         key_to_set = 'query'
     else:

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -612,24 +612,32 @@ def target(self) -> str:
       - `target_table_name`
     """
     if 'target' not in self.parameters:
-        target = self._target_legacy()
+        default_target = self._target_legacy()
         potential_keys = ('target_name', 'target_table', 'target_table_name')
+        _target = None
         for k in potential_keys:
             if k in self.parameters:
-                target = self.parameters[k]
+                _target = self.parameters[k]
                 break
+
+        _target = _target or default_target
 
         if self.instance_connector.type == 'sql':
             from meerschaum.utils.sql import truncate_item_name
-            truncated_target = truncate_item_name(target, self.instance_connector.flavor)
-            if truncated_target != target:
+            truncated_target = truncate_item_name(_target, self.instance_connector.flavor)
+            if truncated_target != _target:
                 warn(
-                    f"The target '{target}' is too long for '{self.instance_connector.flavor}', "
+                    f"The target '{_target}' is too long for '{self.instance_connector.flavor}', "
                     + f"will use {truncated_target} instead."
                 )
-                target = truncated_target
+                _target = truncated_target
 
-        self.target = target
+        if _target in (
+            default_target,
+            truncate_item_name(default_target, self.instance_connector.flavor),
+        ):
+            return _target
+        self.target = _target
     return self.parameters['target']
 
 

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -613,6 +613,7 @@ def target(self) -> str:
     """
     if 'target' not in self.parameters:
         default_target = self._target_legacy()
+        default_targets = {default_target}
         potential_keys = ('target_name', 'target_table', 'target_table_name')
         _target = None
         for k in potential_keys:
@@ -625,6 +626,7 @@ def target(self) -> str:
         if self.instance_connector.type == 'sql':
             from meerschaum.utils.sql import truncate_item_name
             truncated_target = truncate_item_name(_target, self.instance_connector.flavor)
+            default_targets.add(truncated_target)
             if truncated_target != _target:
                 warn(
                     f"The target '{_target}' is too long for '{self.instance_connector.flavor}', "
@@ -632,10 +634,7 @@ def target(self) -> str:
                 )
                 _target = truncated_target
 
-        if _target in (
-            default_target,
-            truncate_item_name(default_target, self.instance_connector.flavor),
-        ):
+        if _target in default_targets:
             return _target
         self.target = _target
     return self.parameters['target']

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -493,6 +493,9 @@ def get_sync_time(
     from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.misc import round_time
 
+    if not self.columns.get('datetime', None):
+        return None
+
     with Venv(get_connector_plugin(self.instance_connector)):
         sync_time = self.instance_connector.get_sync_time(
             self,

--- a/meerschaum/utils/prompt.py
+++ b/meerschaum/utils/prompt.py
@@ -127,15 +127,15 @@ def prompt(
 
 
 def yes_no(
-        question: str = '',
-        options: Tuple[str, str] = ('y', 'n'),
-        default: str = 'y',
-        wrappers: Tuple[str, str] = ('[', ']'),
-        icon: bool = True,
-        yes: bool = False,
-        noask: bool = False,
-        **kw : Any
-    ) -> bool:
+    question: str = '',
+    options: Tuple[str, str] = ('y', 'n'),
+    default: str = 'y',
+    wrappers: Tuple[str, str] = ('[', ']'),
+    icon: bool = True,
+    yes: bool = False,
+    noask: bool = False,
+    **kw : Any
+) -> bool:
     """
     Print a question and prompt the user with a yes / no input.
     Returns `True` for `'yes'`, False for `'no'`.


### PR DESCRIPTION
# v2.6.15

- **Fix inplace syncs without a `datetime` axis.**  
  A bug introduced by a performance optimization has been fixed. Inplace pipes without a `datetime` axis will skip searching for date bounds. Setting `upsert` to `true` will bypass this bug for previous releases.

- **Skip invoking `get_sync_time()` for pipes without a `datetime` axis.**  
  Invoking an instance connector's `get_sync_time()` method will now only occur when `datetime` is set.

- **Remove `guess_datetime()` check from `SQLConnector.get_sync_time()`.**  
  Because sync times are only checked for pipes with a dedicated `datetime` column, the `guess_datetime()` check has been removed from the `SQLConnector.get_sync_time()` method.

- **Skip persisting default `target` to parameters.**  
  The default target table name will no longer be persisted to `parameters`. This helps avoid accidentally setting the wrong target table when copying pipes.

- **Default to "no" for syncing data when copying pipes.**  
  The action `copy pipes` will no longer sync data by default, instead requiring an explicit yes to begin syncing.

- **Fix the "Update query" button behavior on the Web Console.**  
  Existing but null keys are now accounted for when update a SQL pipe's query.

- **Fix another Oracle autoincrement edge case.**
