### PR TITLE
v2.7.0 Add `bytes`, `enforce`, allow autoincrementing datetime index, improve MSSQL indices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.7.0
 
+- **Introduce the `bytes` data type.**  
+  Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'bytes',
+      instance='sql:memory',
+      dtypes={'blob': 'bytes'},
+  )
+  pipe.sync([
+      {'blob': b'hello, world!'},
+  ])
+
+  df = pipe.get_data()
+  binary_data = df['blob'][0]
+  print(binary_data.decode('utf-8'))
+  # hello, world!
+
+  from meerschaum.utils.dtypes import serialize_bytes, attempt_cast_to_bytes
+  df['encoded'] = df['blob'].apply(serialize_bytes)
+  df['decoded'] = df['encoded'].apply(attempt_cast_to_bytes)
+  print(df)
+  #                blob               encoded           decoded
+  # 0  b'hello, world!'  aGVsbG8sIHdvcmxkIQ==  b'hello, world!'
+  ```
+
 - **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
   Pipes may now use the same column as the `datetime` axis and `primary` with `autoincrement` set to `True`.
 
@@ -24,11 +52,47 @@ This is the current release cycle, so stay tuned for future releases!
 - **Only join on `primary` when present.**  
   When the index `primary` is set, use the column as the primary joining index. This will improve performance when syncing tables with a primary key.
 
+
+- **Add the parameter `enforce`.**  
+  The parameter `enforce` (default `True`) toggles data type enforcement behavior. When `enforce` is `False`, incoming data will not be cast to the desired data types. For static datasets where the incoming data is always expected to be of the correct dtypes, then it is recommended to set `enforce` to `False` and `static` to `True`.
+
+
+  ```python
+  from decimal import Decimal
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'enforce',
+      instance='sql:memory',
+      enforce=False,
+      static=True,
+      autoincrement=True,
+      columns={
+          'primary': 'Id',
+          'datetime': 'Id',
+      },
+      dtypes={
+          'Id': 'int',
+          'Amount': 'numeric',
+      },
+  )
+  pipe.sync([
+      {'Amount': Decimal('1.11')},
+      {'Amount': Decimal('2.22')},
+  ]) 
+
+  df = pipe.get_data()
+  print(df)
+  ```
+
 - **Create the `datetime` axis as a clustered index for MSSQL, even when a `primary` index is specififed.**  
   Specifying a `datetime` and `primary` index will create a nonclustered `PRIMARY KEY`. Specifying the same column as both `datetime` and `primary` will create a clustered primary key (tip: this is useful when `autoincrement=True`).
 
 - **Increase the default chunk interval to 43200 minutes.**  
   New hypertables will use a default chunksize of 30 days (43200 minutes).
+
+- **Virtual environment bugfixes.**  
+  Existing virtual environment packages are backed up before re-initializing a virtual environment. This fixes the issue of disappearing dependencies.
 
 ## 2.6.x Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # 🪵 Changelog
 
+## 2.7.x Releases
+
+### v2.7.0
+
+- **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
+  Pipes may now use the same column as the `datetime` axis and `primary` with `autoincrement` set to `True`.
+
+  ```python
+  pipe = mrsm.Pipe(
+      'demo', 'datetime_primary_key', 'autoincrement',
+      instance='sql:local',
+      columns={
+          'datetime': 'Id',
+          'primary': 'Id',
+      },
+      autoincrement=True,
+  )
+  ```
+
+- **Only join on `primary` when present.**  
+  When the index `primary` is set, use the column as the primary joining index.
+
+- **Create the `datetime` axis as a clustered index for MSSQL.**
+
 ## 2.6.x Releases
 
 This is the current release cycle, so stay tuned for future releases!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.7.x Releases
 
+This is the current release cycle, so stay tuned for future releases!
+
 ### v2.7.0
 
 - **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
@@ -20,13 +22,17 @@
   ```
 
 - **Only join on `primary` when present.**  
-  When the index `primary` is set, use the column as the primary joining index.
+  When the index `primary` is set, use the column as the primary joining index. This will improve performance when syncing tables with a primary key.
 
-- **Create the `datetime` axis as a clustered index for MSSQL.**
+- **Create the `datetime` axis as a clustered index for MSSQL, even when a `primary` index is specififed.**  
+  Specifying a `datetime` and `primary` index will create a nonclustered `PRIMARY KEY`. Specifying the same column as both `datetime` and `primary` will create a clustered primary key (tip: this is useful when `autoincrement=True`).
+
+- **Increase the default chunk interval to 43200 minutes.**  
+  New hypertables will use a default chunksize of 30 days (43200 minutes).
 
 ## 2.6.x Releases
 
-This is the current release cycle, so stay tuned for future releases!
+The 2.6 series added the `primary` index, `autoincrement`, and migrated to timezone-aware datetimes by default, as well as many quality-of-life improvements, especially for MSSQL.
 
 ### v2.6.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ This is the current release cycle, so stay tuned for future releases!
 - **Virtual environment bugfixes.**  
   Existing virtual environment packages are backed up before re-initializing a virtual environment. This fixes the issue of disappearing dependencies.
 
+- **Store `numeric` as `TEXT` for SQLite and DuckDB.**  
+  Due to limited precision, `numeric` columns are now stored as `TEXT`, then parsed into `Decimal` objects upon retrieval.
+
+- **Improve dtype inference.** 
+
 ## 2.6.x Releases
 
 The 2.6 series added the `primary` index, `autoincrement`, and migrated to timezone-aware datetimes by default, as well as many quality-of-life improvements, especially for MSSQL.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -6,6 +6,34 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v2.7.0
 
+- **Introduce the `bytes` data type.**  
+  Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'bytes',
+      instance='sql:memory',
+      dtypes={'blob': 'bytes'},
+  )
+  pipe.sync([
+      {'blob': b'hello, world!'},
+  ])
+
+  df = pipe.get_data()
+  binary_data = df['blob'][0]
+  print(binary_data.decode('utf-8'))
+  # hello, world!
+
+  from meerschaum.utils.dtypes import serialize_bytes, attempt_cast_to_bytes
+  df['encoded'] = df['blob'].apply(serialize_bytes)
+  df['decoded'] = df['encoded'].apply(attempt_cast_to_bytes)
+  print(df)
+  #                blob               encoded           decoded
+  # 0  b'hello, world!'  aGVsbG8sIHdvcmxkIQ==  b'hello, world!'
+  ```
+
 - **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
   Pipes may now use the same column as the `datetime` axis and `primary` with `autoincrement` set to `True`.
 
@@ -24,11 +52,47 @@ This is the current release cycle, so stay tuned for future releases!
 - **Only join on `primary` when present.**  
   When the index `primary` is set, use the column as the primary joining index. This will improve performance when syncing tables with a primary key.
 
+
+- **Add the parameter `enforce`.**  
+  The parameter `enforce` (default `True`) toggles data type enforcement behavior. When `enforce` is `False`, incoming data will not be cast to the desired data types. For static datasets where the incoming data is always expected to be of the correct dtypes, then it is recommended to set `enforce` to `False` and `static` to `True`.
+
+
+  ```python
+  from decimal import Decimal
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'enforce',
+      instance='sql:memory',
+      enforce=False,
+      static=True,
+      autoincrement=True,
+      columns={
+          'primary': 'Id',
+          'datetime': 'Id',
+      },
+      dtypes={
+          'Id': 'int',
+          'Amount': 'numeric',
+      },
+  )
+  pipe.sync([
+      {'Amount': Decimal('1.11')},
+      {'Amount': Decimal('2.22')},
+  ]) 
+
+  df = pipe.get_data()
+  print(df)
+  ```
+
 - **Create the `datetime` axis as a clustered index for MSSQL, even when a `primary` index is specififed.**  
   Specifying a `datetime` and `primary` index will create a nonclustered `PRIMARY KEY`. Specifying the same column as both `datetime` and `primary` will create a clustered primary key (tip: this is useful when `autoincrement=True`).
 
 - **Increase the default chunk interval to 43200 minutes.**  
   New hypertables will use a default chunksize of 30 days (43200 minutes).
+
+- **Virtual environment bugfixes.**  
+  Existing virtual environment packages are backed up before re-initializing a virtual environment. This fixes the issue of disappearing dependencies.
 
 ## 2.6.x Releases
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -1,5 +1,29 @@
 # 🪵 Changelog
 
+## 2.7.x Releases
+
+### v2.7.0
+
+- **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
+  Pipes may now use the same column as the `datetime` axis and `primary` with `autoincrement` set to `True`.
+
+  ```python
+  pipe = mrsm.Pipe(
+      'demo', 'datetime_primary_key', 'autoincrement',
+      instance='sql:local',
+      columns={
+          'datetime': 'Id',
+          'primary': 'Id',
+      },
+      autoincrement=True,
+  )
+  ```
+
+- **Only join on `primary` when present.**  
+  When the index `primary` is set, use the column as the primary joining index.
+
+- **Create the `datetime` axis as a clustered index for MSSQL.**
+
 ## 2.6.x Releases
 
 This is the current release cycle, so stay tuned for future releases!

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -2,6 +2,8 @@
 
 ## 2.7.x Releases
 
+This is the current release cycle, so stay tuned for future releases!
+
 ### v2.7.0
 
 - **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
@@ -20,13 +22,17 @@
   ```
 
 - **Only join on `primary` when present.**  
-  When the index `primary` is set, use the column as the primary joining index.
+  When the index `primary` is set, use the column as the primary joining index. This will improve performance when syncing tables with a primary key.
 
-- **Create the `datetime` axis as a clustered index for MSSQL.**
+- **Create the `datetime` axis as a clustered index for MSSQL, even when a `primary` index is specififed.**  
+  Specifying a `datetime` and `primary` index will create a nonclustered `PRIMARY KEY`. Specifying the same column as both `datetime` and `primary` will create a clustered primary key (tip: this is useful when `autoincrement=True`).
+
+- **Increase the default chunk interval to 43200 minutes.**  
+  New hypertables will use a default chunksize of 30 days (43200 minutes).
 
 ## 2.6.x Releases
 
-This is the current release cycle, so stay tuned for future releases!
+The 2.6 series added the `primary` index, `autoincrement`, and migrated to timezone-aware datetimes by default, as well as many quality-of-life improvements, especially for MSSQL.
 
 ### v2.6.17
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -94,6 +94,11 @@ This is the current release cycle, so stay tuned for future releases!
 - **Virtual environment bugfixes.**  
   Existing virtual environment packages are backed up before re-initializing a virtual environment. This fixes the issue of disappearing dependencies.
 
+- **Store `numeric` as `TEXT` for SQLite and DuckDB.**  
+  Due to limited precision, `numeric` columns are now stored as `TEXT`, then parsed into `Decimal` objects upon retrieval.
+
+- **Improve dtype inference.** 
+
 ## 2.6.x Releases
 
 The 2.6 series added the `primary` index, `autoincrement`, and migrated to timezone-aware datetimes by default, as well as many quality-of-life improvements, especially for MSSQL.

--- a/docs/mkdocs/reference/pipes/parameters.md
+++ b/docs/mkdocs/reference/pipes/parameters.md
@@ -50,20 +50,45 @@ You may designate the same column as both the `datetime` and `primary` indices.
 
 ## `dtypes`
 
-Meerschaum data types allow you to specify how columns should be parsed, deserialized, and stored. With the exception of special types like `numeric`, `uuid`, and `json`, you may specify other Pandas data types (e.g. `datetime64[ns]` for `datetime`).
+Meerschaum data types allow you to specify how columns should be parsed, deserialized, and stored. In addition to special types like `numeric`, `uuid`, `json`, and `bytes`, you may specify other Pandas data types (e.g. `datetime64[ns]`).
 
 Below are the supported Meerschaum data types. See the [SQL dtypes source](https://github.com/bmeares/Meerschaum/blob/main/meerschaum/utils/dtypes/sql.py) to see which types map to specific database types.
 
-| Data Type  | Example                                        | Python, Pandas Types                         | SQL Types Notes                                                                  |
-|------------|------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------------------|
-| `int`      | `1`                                            | `int`, `Int64`, `int64[pyarrow]`, etc.       | `BIGINT`                                                                         |
-| `float`    | `1.1`                                          | `float`, `float64`, `float64[pyarrow]`, etc. | `DOUBLE PRECISION`, `FLOAT`                                                      |
-| `string`   | `'foo'`                                        | `str`, `string[python]`                      | `TEXT`. `NVARCHAR(MAX)` for MSSQL, `NVARCHAR2(2000)` for Oracle.                 |
-| `datetime` | `Timestamp('2024-01-01 00:00:00')`             | `datetime`, `Timestamp`                      | `TIMESTAMP`. Offsets are applied and stripped. All datetimes are treated as UTC. |
-| `numeric`  | `Decimal('1.000')`                             | `Decimal`                                    | `NUMERIC`, `DECIMAL`                                                             |
-| `uuid`     | `UUID('df2572b5-e42e-410d-a624-a14519f73e00')` | `UUID`                                       | `UUID` where supported. `UNIQUEIDENTIFIER` for MSSQL.                            |
-| `bool`     | `True`                                         | `boolean[pyarrow]`                           | `INT` for Oracle, MSSQL, MySQL / MariaDB. `FLOAT` for SQLite.                    |
-| `json`     | `{"foo": "bar"}`                               | `dict`, `list`                               | `JSONB` for PostgreSQL-like flavors, otherwise `TEXT`.                           |
+| Data Type  | Example                                           | Python, Pandas Types                                                            | SQL Types Notes                                                                     |
+|------------|---------------------------------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `int`      | `1`                                               | `int`, `Int64`, `int64[pyarrow]`, etc.                                          | `BIGINT`                                                                            |
+| `float`    | `1.1`                                             | `float`, `float64`, `float64[pyarrow]`, etc.                                    | `DOUBLE PRECISION`, `FLOAT`                                                         |
+| `string`   | `'foo'`                                           | `str`, `string[python]`                                                         | `TEXT`, `NVARCHAR(MAX)` for MSSQL, `NVARCHAR2(2000)` for Oracle.                    |
+| `datetime` | `Timestamp('2024-12-26 00:00:00+0000', tz='UTC')` | `datetime`, `datetime64[ns]`, `datetime64[ns, UTC]` (timezone-aware by default) | `TIMESTAMP`, `TIMESTAMPTZ`, `DATETIMEOFFSET` for MSSQL. Offsets are coerced to UTC. |
+| `numeric`  | `Decimal('1.000')`                                | `Decimal`                                                                       | `NUMERIC`, `DECIMAL`                                                                |
+| `uuid`     | `UUID('df2572b5-e42e-410d-a624-a14519f73e00')`    | `UUID`                                                                          | `UUID` where supported. `UNIQUEIDENTIFIER` for MSSQL                                |
+| `bool`     | `True`                                            | `boolean[pyarrow]`                                                              | `BOOL`, `BIT`, `INT` for Oracle, MSSQL, MySQL / MariaDB, `FLOAT` for SQLite.        |
+| `json`     | `{"foo": "bar"}`                                  | `dict`, `list`                                                                  | `JSONB` for PostgreSQL-like flavors, otherwise `TEXT`.                              |
+| `bytes`    | `b'foo bar'`                                      | `bytes`                                                                         | `BYTEA`, `BLOB`, `VARBINARY`                                                        |
+
+## `enforce`
+
+The `enforce` parameter controls whether a pipe coerces incoming data to match the set data types (default `True`). For example, 
+
+## `fetch`
+
+The `fetch` key contains parameters concerning the [fetch stage](/reference/pipes/syncing/) of the syncing process.
+
+### `fetch:backtrack_minutes`
+
+How many minutes of overlap to request when fetching new rows ― see [Backtracking](/reference/pipes/syncing/#backtracking). Defaults to 1440.
+
+### `fetch:definition`
+
+!!! example inline end ""
+    ```yaml
+    fetch:
+      definition: |-
+        SELECT *
+        FROM foo
+    ```
+    
+The base SQL query to be run when fetching new rows. Aliased as `sql` for convenience. This only applies to pipes with [`SQLConnectors`](/reference/connectors/sql-connectors/) as connectors.
 
 ## `indices`
 
@@ -94,26 +119,6 @@ parameters:
       ((1.8 * temperature_c) + 32) as temperature_f
     FROM weather
 ```
-
-## `fetch`
-
-The `fetch` key contains parameters concerning the [fetch stage](/reference/pipes/syncing/) of the syncing process.
-
-### `fetch:backtrack_minutes`
-
-How many minutes of overlap to request when fetching new rows ― see [Backtracking](/reference/pipes/syncing/#backtracking). Defaults to 1440.
-
-### `fetch:definition`
-
-!!! example inline end ""
-    ```yaml
-    fetch:
-      definition: |-
-        SELECT *
-        FROM foo
-    ```
-    
-The base SQL query to be run when fetching new rows. Aliased as `sql` for convenience. This only applies to pipes with [`SQLConnectors`](/reference/connectors/sql-connectors/) as connectors.
 
 ## `tags`
 

--- a/meerschaum/actions/delete.py
+++ b/meerschaum/actions/delete.py
@@ -9,6 +9,7 @@ Functions for deleting elements.
 from __future__ import annotations
 from meerschaum.utils.typing import Any, SuccessTuple, Union, Optional, List
 
+
 def delete(
     action: Optional[List[str]] = None,
     **kw: Any
@@ -21,7 +22,6 @@ def delete(
 
     """
     from meerschaum.actions import choose_subaction
-    from meerschaum.utils.debug import dprint
     options = {
         'config'     : _delete_config, 
         'pipes'      : _delete_pipes,
@@ -65,19 +65,18 @@ def _complete_delete(
 
 
 def _delete_pipes(
-        debug: bool = False,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    debug: bool = False,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Drop pipes and delete their registrations.
-
     """
     from meerschaum import get_pipes
     from meerschaum.utils.prompt import yes_no
-    from meerschaum.utils.formatting import pprint, highlight_pipes
+    from meerschaum.utils.formatting import highlight_pipes
     from meerschaum.utils.warnings import warn
     from meerschaum.actions import actions
     pipes = get_pipes(as_list=True, debug=debug, **kw)
@@ -126,21 +125,22 @@ def _delete_pipes(
     
     return successes > 0, msg
 
+
 def _delete_config(
-        action: Optional[List[str]] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Delete configuration files.
-
     """
-    import os, shutil
+    import os
+    import shutil
     from meerschaum.utils.prompt import yes_no
-    from meerschaum.config._paths import CONFIG_DIR_PATH, STACK_COMPOSE_PATH, DEFAULT_CONFIG_DIR_PATH
+    from meerschaum.config._paths import STACK_COMPOSE_PATH, DEFAULT_CONFIG_DIR_PATH
     from meerschaum.config._read_config import get_possible_keys, get_keyfile_path
     from meerschaum.utils.debug import dprint
     paths = [p for p in [STACK_COMPOSE_PATH, DEFAULT_CONFIG_DIR_PATH] if p.exists()]
@@ -157,7 +157,7 @@ def _delete_config(
     else:
         sep = '\n' + '  - '
         answer = yes_no(
-            f"Are you sure you want to delete the following configuration files?" +
+            "Are you sure you want to delete the following configuration files?" +
             f"{sep + sep.join([str(p) for p in paths])}\n",
             default='n', noask=noask, yes=yes
         )
@@ -176,18 +176,18 @@ def _delete_config(
     
     return success, msg
 
+
 def _delete_plugins(
-        action: Optional[List[str]] = None,
-        repository: Optional[str] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    repository: Optional[str] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Delete plugins from a Meerschaum repository.
-
     """
     from meerschaum.utils.warnings import info
     from meerschaum.plugins import reload_plugins
@@ -206,7 +206,7 @@ def _delete_plugins(
     ) if not force else True
 
     if not answer:
-        return False, f"No plugins deleted."
+        return False, "No plugins deleted."
 
     successes = {}
     for name in action:
@@ -218,27 +218,24 @@ def _delete_plugins(
     reload_plugins(debug=debug)
     return True, "Success"
 
+
 def _delete_users(
-        action: Optional[List[str]] = None,
-        mrsm_instance: Optional[str] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        shell: bool = False,
-        debug: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    mrsm_instance: Optional[str] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    shell: bool = False,
+    debug: bool = False,
+    **kw
+) -> SuccessTuple:
     """
     Delete users from a Meerschaum instance. Adequate permissions are required.
-
     """
-    from meerschaum import get_connector
     from meerschaum.connectors.parse import parse_instance_keys
-    from meerschaum.utils.prompt import yes_no, prompt
-    from meerschaum.utils.debug import dprint
-    from meerschaum.utils.warnings import warn, error, info
+    from meerschaum.utils.prompt import yes_no
+    from meerschaum.utils.warnings import info
     from meerschaum.core import User
-    from meerschaum.connectors.api import APIConnector
     from meerschaum.utils.formatting import print_tuple
     instance_connector = parse_instance_keys(mrsm_instance)
 
@@ -292,24 +289,25 @@ def _delete_users(
     )
     return True, msg
 
+
 def _delete_connectors(
-        action: Optional[List[str]] = None,
-        connector_keys: Optional[List[str]] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    connector_keys: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Delete configured connectors.
     
     Example:
         `delete connectors sql:test`
-
     """
-    import os, pathlib
-    from meerschaum.utils.prompt import yes_no, prompt
+    import os
+    import pathlib
+    from meerschaum.utils.prompt import yes_no
     from meerschaum.connectors.parse import parse_connector_keys
     from meerschaum.config import _config
     from meerschaum.config._edit import write_config
@@ -329,7 +327,7 @@ def _delete_connectors(
     for ck in _keys:
         try:
             conn = parse_connector_keys(ck, debug=debug)
-        except Exception as e:
+        except Exception:
             warn(f"Could not parse connector '{ck}'. Skipping...", stack=False)
             continue
 
@@ -357,26 +355,27 @@ def _delete_connectors(
                     ):
                         try:
                             os.remove(c.database)
-                        except Exception as e:
+                        except Exception:
                             warn(
                                 "Failed to delete database file for connector "
                                 + f"'{c}'. Ignoring...", stack=False
                             )
-        except Exception as e:
+        except Exception:
             pass
         try:
             del cf['meerschaum']['connectors'][c.type][c.label]
-        except Exception as e:
+        except Exception:
             warn(f"Failed to delete connector '{c}' from configuration. Skipping...", stack=False)
 
     write_config(cf, debug=debug)
     return True, "Success"
 
+
 def _complete_delete_connectors(
-        action: Optional[List[str]] = None,
-        line: str = '',
-        **kw: Any
-    ) -> List[str]:
+    action: Optional[List[str]] = None,
+    line: str = '',
+    **kw: Any
+) -> List[str]:
     from meerschaum.config import get_config
     from meerschaum.utils.misc import get_connector_labels
     types = list(get_config('meerschaum', 'connectors').keys())
@@ -401,10 +400,8 @@ def _delete_jobs(
     Remove a job's log files and delete the job's ID.
     
     If the job is running, ask to kill the job first.
-
     """
     from meerschaum.jobs import (
-        Job,
         get_running_jobs,
         get_stopped_jobs,
         get_filtered_jobs,
@@ -460,7 +457,7 @@ def _delete_jobs(
             ### Ensure the running jobs are dead.
             if get_running_jobs(executor_keys, jobs, debug=debug):
                 return False, (
-                    f"Failed to kill running jobs. Please stop these jobs before deleting."
+                    "Failed to kill running jobs. Please stop these jobs before deleting."
                 )
             _to_delete.update(to_stop_jobs)
 
@@ -475,7 +472,7 @@ def _delete_jobs(
         pprint_jobs(_to_delete, nopretty=nopretty)
         if not yes_no(
             "Are you sure you want to delete these jobs?",
-            yes=yes, noask=noask, default='y',
+            yes=yes, noask=noask, default='n',
         ):
             return False, "No jobs were deleted."
 
@@ -569,7 +566,6 @@ def _delete_venvs(
     from meerschaum.utils.venv import venv_exists
     from meerschaum.utils.prompt import yes_no
     from meerschaum.utils.misc import print_options
-    from meerschaum.utils.warnings import warn
 
     venvs_to_skip = ['mrsm']
     venvs = [

--- a/meerschaum/actions/install.py
+++ b/meerschaum/actions/install.py
@@ -175,7 +175,7 @@ def _install_packages(
             + f" into the virtual environment '{venv}'."
         )
     return False, (
-        f"Failed to install package" + ("s" if len(action) != 1 else '') + f" {items_str(action)}."
+        "Failed to install package" + ("s" if len(action) != 1 else '') + f" {items_str(action)}."
     )
 
 
@@ -200,7 +200,6 @@ def _install_required(
     from meerschaum.core import Plugin
     from meerschaum.utils.warnings import warn, info
     from meerschaum.connectors.parse import parse_repo_keys
-    from meerschaum.utils.formatting import print_tuple
     from meerschaum.plugins import get_plugins_names
     repo_connector = parse_repo_keys(repository)
 

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import io
 import json
-import fastapi
 from decimal import Decimal
 import datetime
 
@@ -359,16 +358,16 @@ def sync_pipe(
     p = get_pipe(connector_keys, metric_key, location_key)
     if p.target in ('users', 'plugins', 'pipes'):
         raise fastapi.HTTPException(
-            status_code = 409,
-            detail = f"Cannot sync data to protected table '{p.target}'.",
+            status_code=409,
+            detail=f"Cannot sync data to protected table '{p.target}'.",
         )
 
     if not p.columns and columns is not None:
         p.columns = json.loads(columns)
     if not p.columns and not is_pipe_registered(p, pipes(refresh=True)):
         raise fastapi.HTTPException(
-            status_code = 409,
-            detail = "Pipe must be registered with the datetime column specified."
+            status_code=409,
+            detail="Pipe must be registered with index columns specified."
         )
 
     result = list(p.sync(
@@ -412,7 +411,7 @@ def get_pipe_data(
     if params is not None:
         try:
             _params = json.loads(params)
-        except Exception as e:
+        except Exception:
             _params = None
     if not isinstance(_params, dict):
         raise fastapi.HTTPException(
@@ -426,7 +425,7 @@ def get_pipe_data(
     if select_columns is not None:
         try:
             _select_columns = json.loads(select_columns)
-        except Exception as e:
+        except Exception:
             _select_columns = None
     if not isinstance(_select_columns, list):
         raise fastapi.HTTPException(
@@ -440,7 +439,7 @@ def get_pipe_data(
     if omit_columns is not None:
         try:
             _omit_columns = json.loads(omit_columns)
-        except Exception as e:
+        except Exception:
             _omit_columns = None
     if _omit_columns is None:
         raise fastapi.HTTPException(

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -137,7 +137,7 @@ default_pipes_config = {
         },
         'verify': {
             'bound_days': 366,
-            'chunk_minutes': 1440,
+            'chunk_minutes': 43200,
         },
     },
     'attributes': {

--- a/meerschaum/config/_paths.py
+++ b/meerschaum/config/_paths.py
@@ -103,7 +103,7 @@ if ENVIRONMENT_VENVS_DIR in os.environ:
     if not _VENVS_DIR_PATH.exists():
         try:
             _VENVS_DIR_PATH.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
+        except Exception:
             print(
                 f"Invalid path set for environment variable '{ENVIRONMENT_VENVS_DIR}':\n"
                 + f"{_VENVS_DIR_PATH}"
@@ -148,6 +148,7 @@ paths = {
     'CACHE_RESOURCES_PATH'           : ('{ROOT_DIR_PATH}', '.cache'),
     'PIPES_CACHE_RESOURCES_PATH'     : ('{CACHE_RESOURCES_PATH}', 'pipes'),
     'USERS_CACHE_RESOURCES_PATH'     : ('{CACHE_RESOURCES_PATH}', 'users'),
+    'VENVS_CACHE_RESOURCES_PATH'     : ('{CACHE_RESOURCES_PATH}', 'venvs'),
 
     'PLUGINS_RESOURCES_PATH'         : ('{INTERNAL_RESOURCES_PATH}', 'plugins'),
     'PLUGINS_INTERNAL_LOCK_PATH'     : ('{INTERNAL_RESOURCES_PATH}', 'plugins.lock'),

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0.dev2"
+__version__ = "2.7.0"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.6.17"
+__version__ = "2.7.0.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0rc2"
+__version__ = "2.7.0"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0.dev1"
+__version__ = "2.7.0.dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0.dev2"
+__version__ = "2.7.0rc1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0"
+__version__ = "2.7.0.dev2"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.0rc1"
+__version__ = "2.7.0rc2"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -15,7 +15,8 @@ from datetime import datetime
 import meerschaum as mrsm
 from meerschaum.utils.debug import dprint
 from meerschaum.utils.warnings import warn, error
-from meerschaum.utils.typing import SuccessTuple, Union, Any, Optional, Mapping, List, Dict, Tuple
+from meerschaum.utils.typing import SuccessTuple, Union, Any, Optional, List, Dict, Tuple
+
 
 def pipe_r_url(
     pipe: mrsm.Pipe
@@ -30,6 +31,7 @@ def pipe_r_url(
         + f"{pipe.connector_keys}/{pipe.metric_key}/{location_key}"
     )
 
+
 def register_pipe(
     self,
     pipe: mrsm.Pipe,
@@ -39,7 +41,6 @@ def register_pipe(
     Returns a tuple of (success_bool, response_dict).
     """
     from meerschaum.utils.debug import dprint
-    from meerschaum.config.static import STATIC_CONFIG
     ### NOTE: if `parameters` is supplied in the Pipe constructor,
     ###       then `pipe.parameters` will exist and not be fetched from the database.
     r_url = pipe_r_url(pipe)
@@ -180,7 +181,7 @@ def sync_pipe(
     from meerschaum.utils.misc import json_serialize_datetime, items_str
     from meerschaum.config import get_config
     from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.dataframe import get_numeric_cols, to_json
+    from meerschaum.utils.dataframe import get_numeric_cols, to_json, get_bytes_cols
     begin = time.time()
     more_itertools = attempt_import('more_itertools')
     if df is None:

--- a/meerschaum/connectors/sql/_instance.py
+++ b/meerschaum/connectors/sql/_instance.py
@@ -9,8 +9,7 @@ Define utilities for instance connectors.
 import time
 from datetime import datetime, timezone, timedelta
 import meerschaum as mrsm
-from meerschaum.utils.typing import Dict, SuccessTuple, Optional, Union, List
-from meerschaum.utils.warnings import warn
+from meerschaum.utils.typing import Dict, SuccessTuple, Union, List
 
 
 _in_memory_temp_tables: Dict[str, bool] = {}
@@ -28,9 +27,9 @@ def _log_temporary_tables_creation(
     from meerschaum.connectors.sql.tables import get_tables
     sqlalchemy = mrsm.attempt_import('sqlalchemy')
     temp_tables_table = get_tables(
-        mrsm_instance = self,
-        create = create,
-        debug = debug,
+        mrsm_instance=self,
+        create=create,
+        debug=debug,
     )['temp_tables']
     if isinstance(tables, str):
         tables = [tables]
@@ -72,7 +71,9 @@ def _drop_temporary_table(
             return True, "Success"
 
     drop_query = f"DROP TABLE {if_exists} " + sql_item_name(
-        table, self.flavor, schema=self.internal_schema
+        table,
+        self.flavor,
+        schema=self.internal_schema
     )
     drop_success = self.exec(drop_query, silent=True, debug=debug) is not None
     drop_msg = "Success" if drop_success else f"Failed to drop temporary table '{table}'."
@@ -83,7 +84,6 @@ def _drop_temporary_tables(self, debug: bool = False) -> SuccessTuple:
     """
     Drop all tables in the internal schema that are marked as ready to be dropped.
     """
-    from meerschaum.utils.sql import sql_item_name, table_exists
     from meerschaum.utils.misc import items_str
     from meerschaum.connectors.sql.tables import get_tables
     sqlalchemy = mrsm.attempt_import('sqlalchemy')
@@ -141,16 +141,15 @@ def _drop_temporary_tables(self, debug: bool = False) -> SuccessTuple:
 
 
 def _drop_old_temporary_tables(
-        self,
-        refresh: bool = True,
-        debug: bool = False,
-    ) -> SuccessTuple:
+    self,
+    refresh: bool = True,
+    debug: bool = False,
+) -> SuccessTuple:
     """
     Drop temporary tables older than the configured interval (24 hours by default).
     """
     from meerschaum.config import get_config
     from meerschaum.connectors.sql.tables import get_tables
-    from meerschaum.utils.misc import items_str
     sqlalchemy = mrsm.attempt_import('sqlalchemy')
     temp_tables_table = get_tables(mrsm_instance=self, create=False, debug=debug)['temp_tables']
     last_check = getattr(self, '_stale_temporary_tables_check_timestamp', 0)

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -971,7 +971,7 @@ def get_pipe_data(
 
     df = self.read(
         query,
-        dtype=dtypes,
+        #  dtype=dtypes,
         debug=debug,
         **kw
     )
@@ -1346,7 +1346,12 @@ def create_pipe_table_from_df(
     """
     Create a pipe's table from its configured dtypes and an incoming dataframe.
     """
-    from meerschaum.utils.dataframe import get_json_cols, get_numeric_cols, get_uuid_cols
+    from meerschaum.utils.dataframe import (
+        get_json_cols,
+        get_numeric_cols,
+        get_uuid_cols,
+        get_datetime_cols,
+    )
     from meerschaum.utils.sql import get_create_table_queries, sql_item_name
     primary_key = pipe.columns.get('primary', None)
     dt_col = pipe.columns.get('datetime', None)
@@ -1371,6 +1376,14 @@ def create_pipe_table_from_df(
         **{
             col: 'numeric'
             for col in get_numeric_cols(df)
+        },
+        **{
+            col: 'datetime64[ns, UTC]'
+            for col in get_datetime_cols(df, timezone_aware=True, timezone_naive=False)
+        },
+        **{
+            col: 'datetime64[ns]'
+            for col in get_datetime_cols(df, timezone_aware=False, timezone_naive=True)
         },
         **pipe.dtypes
     }
@@ -1854,7 +1867,6 @@ def sync_pipe_inplace(
         session_execute,
         update_queries,
     )
-    from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.dtypes.sql import (
         get_pd_type_from_db_type,
     )

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -97,7 +97,6 @@ def edit_pipe(
     if pipe.id is None:
         return False, f"{pipe} is not registered and cannot be edited."
 
-    from meerschaum.utils.debug import dprint
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.sql import json_flavors
     if not patch:
@@ -172,7 +171,7 @@ def fetch_pipes_keys(
     """
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.misc import separate_negation_values, flatten_list
+    from meerschaum.utils.misc import separate_negation_values
     from meerschaum.utils.sql import OMIT_NULLSFIRST_FLAVORS, table_exists
     from meerschaum.config.static import STATIC_CONFIG
     import json
@@ -792,8 +791,6 @@ def delete_pipe(
     """
     Delete a Pipe's registration.
     """
-    from meerschaum.utils.sql import sql_item_name
-    from meerschaum.utils.debug import dprint
     from meerschaum.utils.packages import attempt_import
     sqlalchemy = attempt_import('sqlalchemy')
 
@@ -876,7 +873,6 @@ def get_pipe_data(
 
     """
     import json
-    from meerschaum.utils.sql import sql_item_name
     from meerschaum.utils.misc import parse_df_datetimes, to_pandas_dtype
     from meerschaum.utils.packages import import_pandas
     from meerschaum.utils.dtypes import (
@@ -1280,7 +1276,6 @@ def get_pipe_id(
     if pipe.temporary:
         return None
     from meerschaum.utils.packages import attempt_import
-    import json
     sqlalchemy = attempt_import('sqlalchemy')
     from meerschaum.connectors.sql.tables import get_tables
     pipes_tbl = get_tables(mrsm_instance=self, create=(not pipe.temporary), debug=debug)['pipes']
@@ -3378,9 +3373,7 @@ def deduplicate_pipe(
     """
     from meerschaum.utils.sql import (
         sql_item_name,
-        NO_CTE_FLAVORS,
         get_rename_table_queries,
-        NO_SELECT_INTO_FLAVORS,
         DROP_IF_EXISTS_FLAVORS,
         get_create_table_query,
         format_cte_subquery,
@@ -3502,7 +3495,6 @@ def deduplicate_pipe(
     dedup_table = '-' + session_id + f'_dedup_{pipe.target}'
     temp_old_table = '-' + session_id + f"_old_{pipe.target}"
 
-    dedup_table_name = sql_item_name(dedup_table, self.flavor, self.get_pipe_schema(pipe))
     temp_old_table_name = sql_item_name(temp_old_table, self.flavor, self.get_pipe_schema(pipe))
 
     create_temporary_table_query = get_create_table_query(

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1722,7 +1722,11 @@ def sync_pipe(
             col
             for col_key, col in pipe.columns.items()
             if col and col in existing_cols
-        ] if not primary_key else [primary_key]
+        ] if not primary_key else (
+            [dt_col, primary_key]
+            if self.flavor == 'timescaledb' and dt_col and dt_col in update_df.columns
+            else [primary_key]
+        )
         update_queries = get_update_queries(
             pipe.target,
             temp_target,

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -898,17 +898,15 @@ def get_pipe_data(
             col: get_pd_type_from_db_type(typ)
             for col, typ in cols_types.items()
         }
-    }
+    } if pipe.enforce else {}
     if dtypes:
         if self.flavor == 'sqlite':
             if not pipe.columns.get('datetime', None):
                 _dt = pipe.guess_datetime()
                 dt = sql_item_name(_dt, self.flavor, None) if _dt else None
-                is_guess = True
             else:
                 _dt = pipe.get_columns('datetime')
                 dt = sql_item_name(_dt, self.flavor, None)
-                is_guess = False
 
             if _dt:
                 dt_type = dtypes.get(_dt, 'object').lower()
@@ -936,7 +934,7 @@ def get_pipe_data(
         col: to_pandas_dtype(typ)
         for col, typ in dtypes.items()
         if col in select_columns and col not in (omit_columns or [])
-    }
+    } if pipe.enforce else {}
     query = self.get_pipe_data_query(
         pipe,
         select_columns=select_columns,
@@ -971,7 +969,7 @@ def get_pipe_data(
 
     df = self.read(
         query,
-        #  dtype=dtypes,
+        dtype=dtypes,
         debug=debug,
         **kw
     )

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -624,7 +624,7 @@ def exec_queries(
     rollback: bool = True,
     silent: bool = False,
     debug: bool = False,
-) -> List[sqlalchemy.engine.cursor.LegacyCursorResult]:
+) -> List[Union[sqlalchemy.engine.cursor.CursorResult, None]]:
     """
     Execute a list of queries in a single transaction.
 
@@ -688,6 +688,7 @@ def exec_queries(
             if result is None and break_on_error:
                 if rollback:
                     session.rollback()
+                results.append(result)
                 break
             elif result is not None and hook is not None:
                 hook_queries = hook(session)
@@ -774,8 +775,7 @@ def to_sql(
     """
     import time
     import json
-    import decimal
-    from decimal import Decimal, Context
+    from decimal import Decimal
     from meerschaum.utils.warnings import error, warn
     import warnings
     import functools

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -790,7 +790,12 @@ def to_sql(
         truncate_item_name,
         DROP_IF_EXISTS_FLAVORS,
     )
-    from meerschaum.utils.dataframe import get_json_cols, get_numeric_cols, get_uuid_cols
+    from meerschaum.utils.dataframe import (
+        get_json_cols,
+        get_numeric_cols,
+        get_uuid_cols,
+        get_bytes_cols,
+    )
     from meerschaum.utils.dtypes import are_dtypes_equal, quantize_decimal, coerce_timezone
     from meerschaum.utils.dtypes.sql import (
         NUMERIC_PRECISION_FLAVORS,

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -46,9 +46,20 @@ def serialize_document(doc: Dict[str, Any]) -> str:
     -------
     A serialized string for the document.
     """
+    from meerschaum.utils.dtypes import serialize_bytes
     return json.dumps(
         doc,
-        default=(lambda x: json_serialize_datetime(x) if hasattr(x, 'tzinfo') else str(x)),
+        default=(
+            lambda x: (
+                json_serialize_datetime(x)
+                if hasattr(x, 'tzinfo')
+                else (
+                    serialize_bytes(x)
+                    if isinstance(x, bytes)
+                    else str(x)
+                )
+            )
+        ),
         separators=(',', ':'),
         sort_keys=True,
     )

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -106,6 +106,7 @@ class Pipe:
         upsert,
         static,
         tzinfo,
+        enforce,
         get_columns,
         get_columns_types,
         get_columns_indices,

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -133,6 +133,7 @@ class Pipe:
         _persist_new_json_columns,
         _persist_new_numeric_columns,
         _persist_new_uuid_columns,
+        _persist_new_bytes_columns,
     )
     from ._verify import (
         verify,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -200,10 +200,15 @@ def dtypes(self) -> Union[Dict[str, Any], None]:
     If defined, return the `dtypes` dictionary defined in `meerschaum.Pipe.parameters`.
     """
     from meerschaum.config._patch import apply_patch_to_config
+    from meerschaum.utils.dtypes import MRSM_ALIAS_DTYPES
     configured_dtypes = self.parameters.get('dtypes', {})
     remote_dtypes = self.infer_dtypes(persist=False)
     patched_dtypes = apply_patch_to_config(remote_dtypes, configured_dtypes)
-    return {col: typ for col, typ in patched_dtypes.items() if col and typ}
+    return {
+        col: MRSM_ALIAS_DTYPES.get(typ, typ)
+        for col, typ in patched_dtypes.items()
+        if col and typ
+    }
 
 
 @dtypes.setter

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -289,6 +289,25 @@ def tzinfo(self) -> Union[None, timezone]:
     return None
 
 
+@property
+def enforce(self) -> bool:
+    """
+    Return the `enforce` parameter for the pipe.
+    """
+    if 'enforce' not in self.parameters:
+        self.parameters['enforce'] = True
+
+    return self.parameters['enforce']
+
+
+@enforce.setter
+def enforce(self, _enforce: bool) -> None:
+    """
+    Set the `enforce` parameter for the pipe.
+    """
+    self.parameters['_enforce'] = _enforce
+
+
 def get_columns(self, *args: str, error: bool = False) -> Union[str, Tuple[str]]:
     """
     Check if the requested columns are defined.

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -203,7 +203,7 @@ def dtypes(self) -> Union[Dict[str, Any], None]:
     configured_dtypes = self.parameters.get('dtypes', {})
     remote_dtypes = self.infer_dtypes(persist=False)
     patched_dtypes = apply_patch_to_config(remote_dtypes, configured_dtypes)
-    return patched_dtypes
+    return {col: typ for col, typ in patched_dtypes.items() if col and typ}
 
 
 @dtypes.setter

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -80,6 +80,9 @@ def enforce_dtypes(
             )
         return df
 
+    if not self.enforce:
+        return df
+
     return _enforce_dtypes(
         df,
         pipe_dtypes,

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -41,7 +41,7 @@ def enforce_dtypes(
             )
         return df
 
-    pipe_dtypes = self.dtypes
+    pipe_dtypes = self.dtypes if self.enforce else {}
 
     try:
         if isinstance(df, str):
@@ -78,9 +78,6 @@ def enforce_dtypes(
                 f"Could not find dtypes for {self}.\n"
                 + "    Skipping dtype enforcement..."
             )
-        return df
-
-    if not self.enforce:
         return df
 
     return _enforce_dtypes(

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -119,7 +119,6 @@ def infer_dtypes(self, persist: bool = False, debug: bool = False) -> Dict[str, 
     ###       PostgreSQL- or Pandas-style.
     columns_types = self.get_columns_types(debug=debug)
 
-    dtypes = self.parameters.get('dtypes', {})
     remote_pd_dtypes = {
         c: (
             get_pd_type_from_db_type(t, allow_custom_dtypes=True)
@@ -128,12 +127,15 @@ def infer_dtypes(self, persist: bool = False, debug: bool = False) -> Dict[str, 
         )
         for c, t in columns_types.items()
     } if columns_types else {}
+    if not persist:
+        return remote_pd_dtypes
+
+    dtypes = self.parameters.get('dtypes', {})
     dtypes.update({
         col: typ
         for col, typ in remote_pd_dtypes.items()
         if col not in dtypes
     })
-    if persist:
-        self.dtypes = dtypes
-        self.edit(interactive=False, debug=debug)
-    return dtypes
+    self.dtypes = dtypes
+    self.edit(interactive=False, debug=debug)
+    return remote_pd_dtypes

--- a/meerschaum/core/Pipe/_dtypes.py
+++ b/meerschaum/core/Pipe/_dtypes.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     pd = mrsm.attempt_import('pandas')
 
+
 def enforce_dtypes(
     self,
     df: 'pd.DataFrame',
@@ -30,7 +31,7 @@ def enforce_dtypes(
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.dataframe import parse_df_datetimes, enforce_dtypes as _enforce_dtypes
-    from meerschaum.utils.dtypes import are_dtypes_equal
+    from meerschaum.utils.dtypes import are_dtypes_equal, MRSM_PD_DTYPES
     from meerschaum.utils.packages import import_pandas
     pd = import_pandas(debug=debug)
     if df is None:
@@ -41,7 +42,11 @@ def enforce_dtypes(
             )
         return df
 
-    pipe_dtypes = self.dtypes if self.enforce else {}
+    pipe_dtypes = self.dtypes if self.enforce else {
+        col: typ
+        for col, typ in self.dtypes.items()
+        if typ in MRSM_PD_DTYPES
+    }
 
     try:
         if isinstance(df, str):

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -696,12 +696,11 @@ def filter_existing(
             min_dt = None
 
     if isinstance(min_dt, datetime):
-        begin = (
-            round_time(
-                min_dt,
-                to='down'
-            ) - timedelta(minutes=1)
-        )
+        rounded_min_dt = round_time(min_dt, to='down')
+        try:
+            begin = rounded_min_dt - timedelta(minutes=1)
+        except OverflowError:
+            begin = rounded_min_dt
     elif dt_type and 'int' in dt_type.lower():
         begin = min_dt
     elif dt_col is None:

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -617,11 +617,13 @@ def filter_existing(
         filter_unseen_df,
         add_missing_cols_to_df,
         get_unhashable_cols,
-        get_numeric_cols,
     )
     from meerschaum.utils.dtypes import (
         to_pandas_dtype,
         none_if_null,
+        to_datetime,
+        are_dtypes_equal,
+        value_is_null,
     )
     from meerschaum.config import get_config
     pd = import_pandas()
@@ -682,14 +684,15 @@ def filter_existing(
         if is_dask and min_dt_val is not None:
             min_dt_val = min_dt_val.compute()
         min_dt = (
-            pandas.to_datetime(min_dt_val).to_pydatetime()
-            if min_dt_val is not None and 'datetime' in str(dt_type)
+            to_datetime(min_dt_val, as_pydatetime=True)
+            if min_dt_val is not None and are_dtypes_equal(dt_type, 'datetime')
             else min_dt_val
         )
     except Exception:
         min_dt = None
-    if not ('datetime' in str(type(min_dt))) or str(min_dt) == 'NaT':
-        if 'int' not in str(type(min_dt)).lower():
+
+    if not are_dtypes_equal('datetime', str(type(min_dt))) or value_is_null(min_dt):
+        if not are_dtypes_equal('int', str(type(min_dt))):
             min_dt = None
 
     if isinstance(min_dt, datetime):
@@ -710,7 +713,7 @@ def filter_existing(
         if is_dask and max_dt_val is not None:
             max_dt_val = max_dt_val.compute()
         max_dt = (
-            pandas.to_datetime(max_dt_val).to_pydatetime()
+            to_datetime(max_dt_val, as_pydatetime=True)
             if max_dt_val is not None and 'datetime' in str(dt_type)
             else max_dt_val
         )
@@ -719,8 +722,8 @@ def filter_existing(
         traceback.print_exc()
         max_dt = None
 
-    if ('datetime' not in str(type(max_dt))) or str(min_dt) == 'NaT':
-        if 'int' not in str(type(max_dt)).lower():
+    if not are_dtypes_equal('datetime', str(type(max_dt))) or value_is_null(max_dt):
+        if not are_dtypes_equal('int', str(type(max_dt))):
             max_dt = None
 
     if isinstance(max_dt, datetime):

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -161,7 +161,7 @@ def sync(
     self._exists = None
 
     def _sync(
-        p: 'meerschaum.Pipe',
+        p: mrsm.Pipe,
         df: Union[
             'pd.DataFrame',
             Dict[str, List[Any]],
@@ -960,10 +960,7 @@ def _persist_new_numeric_columns(self, df, debug: bool = False) -> SuccessTuple:
         return True, "Success"
 
     self._attributes_sync_time = None
-    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
-    if dt_col not in dtypes:
-        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'numeric' for col in numeric_cols})
     self.parameters['dtypes'] = dtypes
     if not self.temporary:
@@ -988,10 +985,7 @@ def _persist_new_uuid_columns(self, df, debug: bool = False) -> SuccessTuple:
         return True, "Success"
 
     self._attributes_sync_time = None
-    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
-    if dt_col not in dtypes:
-        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'uuid' for col in uuid_cols})
     self.parameters['dtypes'] = dtypes
     if not self.temporary:
@@ -1016,10 +1010,7 @@ def _persist_new_json_columns(self, df, debug: bool = False) -> SuccessTuple:
         return True, "Success"
 
     self._attributes_sync_time = None
-    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
-    if dt_col not in dtypes:
-        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'json' for col in json_cols})
     self.parameters['dtypes'] = dtypes
 
@@ -1045,10 +1036,7 @@ def _persist_new_bytes_columns(self, df, debug: bool = False) -> SuccessTuple:
         return True, "Success"
 
     self._attributes_sync_time = None
-    dt_col = self.columns.get('datetime', None)
     dtypes = self.parameters.get('dtypes', {})
-    if dt_col not in dtypes:
-        dtypes[dt_col] = 'datetime'
     dtypes.update({col: 'bytes' for col in bytes_cols})
     self.parameters['dtypes'] = dtypes
 

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -7,9 +7,10 @@ Verify the contents of a pipe by resyncing its interval.
 """
 
 from datetime import datetime, timedelta
-from meerschaum.utils.typing import SuccessTuple, Any, Optional, Union, Tuple, List, Dict
+
+import meerschaum as mrsm
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, Union, Tuple, Dict
 from meerschaum.utils.warnings import warn, info
-from meerschaum.utils.debug import dprint
 
 
 def verify(
@@ -94,9 +95,6 @@ def verify(
             else 1
         )
 
-    sync_less_than_begin = not bounded and begin is None
-    sync_greater_than_end = not bounded and end is None
-
     cannot_determine_bounds = not self.exists(debug=debug)
 
     if cannot_determine_bounds:
@@ -164,7 +162,7 @@ def verify(
     )
 
     info(
-        f"Syncing {len(chunk_bounds)} chunk" + ('s' if len(chunk_bounds) != 1 else '')
+        f"Verifying {self}:\n    Syncing {len(chunk_bounds)} chunk" + ('s' if len(chunk_bounds) != 1 else '')
         + f" ({'un' if not bounded else ''}bounded)"
         + f" of size '{interval_str(chunk_interval)}'"
         + f" between '{begin_to_print}' and '{end_to_print}'."
@@ -187,7 +185,7 @@ def verify(
             return chunk_begin_and_end, bounds_success_tuples[chunk_begin_and_end]
 
         chunk_begin, chunk_end = chunk_begin_and_end
-        return chunk_begin_and_end, self.sync(
+        chunk_success, chunk_msg = self.sync(
             begin=chunk_begin,
             end=chunk_end,
             params=params,
@@ -195,6 +193,9 @@ def verify(
             debug=debug,
             **kwargs
         )
+        chunk_msg = chunk_msg.strip()
+        mrsm.pprint((chunk_success, chunk_msg))
+        return chunk_begin_and_end, (chunk_success, chunk_msg)
 
     ### If we have more than one chunk, attempt to sync the first one and return if its fails.
     if len(chunk_bounds) > 1:

--- a/meerschaum/jobs/_Job.py
+++ b/meerschaum/jobs/_Job.py
@@ -200,6 +200,8 @@ class Job:
             if root_dir is None:
                 from meerschaum.config.paths import ROOT_DIR_PATH
                 root_dir = ROOT_DIR_PATH
+            else:
+                root_dir = pathlib.Path(root_dir)
             jobs_dir = root_dir / DAEMON_RESOURCES_PATH.name
             daemon_dir = jobs_dir / daemon_id
             pid_file = daemon_dir / 'process.pid'

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -817,10 +817,10 @@ class Plugin:
 
 
     def install_dependencies(
-            self,
-            force: bool = False,
-            debug: bool = False,
-        ) -> bool:
+        self,
+        force: bool = False,
+        debug: bool = False,
+    ) -> bool:
         """
         If specified, install dependencies.
         
@@ -841,12 +841,9 @@ class Plugin:
         Returns
         -------
         A bool indicating success.
-
         """
         from meerschaum.utils.packages import pip_install, venv_contains_package
-        from meerschaum.utils.debug import dprint
         from meerschaum.utils.warnings import warn, info
-        from meerschaum.connectors.parse import parse_repo_keys
         _deps = self.get_dependencies(debug=debug)
         if not _deps and self.requirements_file_path is None:
             return True

--- a/meerschaum/plugins/_Plugin.py
+++ b/meerschaum/plugins/_Plugin.py
@@ -255,11 +255,11 @@ class Plugin:
 
 
     def install(
-            self,
-            skip_deps: bool = False,
-            force: bool = False,
-            debug: bool = False,
-        ) -> SuccessTuple:
+        self,
+        skip_deps: bool = False,
+        force: bool = False,
+        debug: bool = False,
+    ) -> SuccessTuple:
         """
         Extract a plugin's tar archive to the plugins directory.
         
@@ -359,7 +359,7 @@ class Plugin:
             is_same_version = new_version and old_version and (
                 packaging_version.parse(old_version) == packaging_version.parse(new_version)
             )
-        except Exception as e:
+        except Exception:
             is_new_version, is_same_version = True, False
 
         ### Determine where to permanently store the new plugin.
@@ -404,7 +404,7 @@ class Plugin:
                         dprint(f"Moving '{src_file}' to '{dst_dir}'...")
                     try:
                         shutil.move(src_file, dst_dir)
-                    except Exception as e:
+                    except Exception:
                         success, msg = False, (
                             f"Failed to install plugin '{self}': " +
                             f"Could not move file '{src_file}' to '{dst_dir}'"

--- a/meerschaum/utils/daemon/Daemon.py
+++ b/meerschaum/utils/daemon/Daemon.py
@@ -472,7 +472,7 @@ class Daemon:
             process.kill()
             process.wait(timeout=timeout)
         except Exception as e:
-            return False, f"Failed to kill job {self} with exception: {e}"
+            return False, f"Failed to kill job {self} ({process}) with exception: {e}"
 
         try:
             if process.status():
@@ -734,7 +734,7 @@ class Daemon:
             time.sleep(check_timeout_interval)
 
         return False, (
-            f"Failed to stop daemon '{self.daemon_id}' within {timeout} second"
+            f"Failed to stop daemon '{self.daemon_id}' (PID: {pid}) within {timeout} second"
             + ('s' if timeout != 1 else '') + '.'
         )
 

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -494,7 +494,7 @@ def parse_df_datetimes(
     ### skip parsing if DataFrame is empty
     if len(pdf) == 0:
         if debug:
-            dprint(f"df is empty. Returning original DataFrame without casting datetime columns...")
+            dprint("df is empty. Returning original DataFrame without casting datetime columns...")
         return df
 
     ignore_cols = set(
@@ -509,7 +509,7 @@ def parse_df_datetimes(
     if len(cols_to_inspect) == 0:
         if debug:
             dprint("All columns are ignored, skipping datetime detection...")
-        return df.fillna(pandas.NA)
+        return df.infer_objects(copy=False).fillna(pandas.NA)
 
     ### apply regex to columns to determine which are ISO datetimes
     iso_dt_regex = r'\d{4}-\d{2}-\d{2}.\d{2}\:\d{2}\:\d+'
@@ -522,7 +522,7 @@ def parse_df_datetimes(
     if not datetime_cols:
         if debug:
             dprint("No columns detected as datetimes, returning...")
-        return df.fillna(pandas.NA)
+        return df.infer_objects(copy=False).fillna(pandas.NA)
 
     if debug:
         dprint("Converting columns to datetimes: " + str(datetime_cols))

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -15,7 +15,7 @@ import meerschaum as mrsm
 from meerschaum.utils.typing import Dict, Union, Any
 from meerschaum.utils.warnings import warn
 
-MRSM_PD_DTYPES: Dict[str, str] = {
+MRSM_PD_DTYPES: Dict[Union[str, None], str] = {
     'json': 'object',
     'numeric': 'object',
     'uuid': 'object',
@@ -27,6 +27,7 @@ MRSM_PD_DTYPES: Dict[str, str] = {
     'int32': 'Int32',
     'int64': 'Int64',
     'str': 'string[python]',
+    None: 'object',
 }
 
 
@@ -279,8 +280,11 @@ def coerce_timezone(
 
         dt_series = to_datetime(dt, coerce_utc=False)
         if strip_utc:
-            if dt_series.dt.tz is not None:
-                dt_series = dt_series.dt.tz_localize(None)
+            try:
+                if dt_series.dt.tz is not None:
+                    dt_series = dt_series.dt.tz_localize(None)
+            except Exception:
+                pass
 
         return dt_series
 
@@ -326,6 +330,6 @@ def to_datetime(dt_val: Any, as_pydatetime: bool = False, coerce_utc: bool = Tru
         return new_series
 
     new_dt_val = parse(dt_val)
-    if coerce_utc:
+    if not coerce_utc:
         return new_dt_val
     return coerce_timezone(new_dt_val)

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -13,9 +13,8 @@ NUMERIC_PRECISION_FLAVORS: Dict[str, Tuple[int, int]] = {
     'mariadb': (38, 20),
     'mysql': (38, 20),
     'mssql': (28, 10),
-    'duckdb': (15, 3),
-    'sqlite': (15, 4),
 }
+NUMERIC_AS_TEXT_FLAVORS = {'sqlite', 'duckdb'}
 TIMEZONE_NAIVE_FLAVORS = {'oracle', 'mysql', 'mariadb'}
 
 ### MySQL doesn't allow for casting as BIGINT, so this is a workaround.
@@ -256,8 +255,8 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'mysql': f'DECIMAL{NUMERIC_PRECISION_FLAVORS["mysql"]}',
         'mssql': f'NUMERIC{NUMERIC_PRECISION_FLAVORS["mssql"]}',
         'oracle': 'NUMBER',
-        'sqlite': f'DECIMAL{NUMERIC_PRECISION_FLAVORS["sqlite"]}',
-        'duckdb': 'NUMERIC',
+        'sqlite': 'TEXT',
+        'duckdb': 'TEXT',
         'citus': 'NUMERIC',
         'cockroachdb': 'NUMERIC',
         'default': 'NUMERIC',
@@ -415,7 +414,7 @@ PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'mysql': 'Numeric',
         'mssql': 'Numeric',
         'oracle': 'Numeric',
-        'sqlite': 'Numeric',
+        'sqlite': 'UnicodeText',
         'duckdb': 'Numeric',
         'citus': 'Numeric',
         'cockroachdb': 'Numeric',
@@ -597,7 +596,6 @@ def get_db_type_from_pd_type(
         return cls(*cls_args, **cls_kwargs)
 
     if 'numeric' in db_type.lower():
-        numeric_type_str = PD_TO_DB_DTYPES_FLAVORS['numeric'].get(flavor, 'NUMERIC')
         if flavor not in NUMERIC_PRECISION_FLAVORS:
             return sqlalchemy_types.Numeric
         precision, scale = NUMERIC_PRECISION_FLAVORS[flavor]

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -101,6 +101,10 @@ DB_TO_PD_DTYPES: Dict[str, Union[str, Dict[str, str]]] = {
     'JSONB': 'json',
     'UUID': 'uuid',
     'UNIQUEIDENTIFIER': 'uuid',
+    'BYTEA': 'bytes',
+    'BLOB': 'bytes',
+    'VARBINARY': 'bytes',
+    'VARBINARY(MAX)': 'bytes',
     'substrings': {
         'CHAR': 'string[pyarrow]',
         'TIMESTAMP': 'datetime64[ns]',
@@ -113,6 +117,9 @@ DB_TO_PD_DTYPES: Dict[str, Union[str, Dict[str, str]]] = {
         'INT': 'int64[pyarrow]',
         'BOOL': 'bool[pyarrow]',
         'JSON': 'json',
+        'BYTE': 'bytes',
+        'LOB': 'bytes',
+        'BINARY': 'bytes',
     },
     'default': 'object',
 }

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -276,6 +276,19 @@ PD_TO_DB_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'cockroachdb': 'UUID',
         'default': 'TEXT',
     },
+    'bytes': {
+        'timescaledb': 'BYTEA',
+        'postgresql': 'BYTEA',
+        'mariadb': 'BLOB',
+        'mysql': 'BLOB',
+        'mssql': 'VARBINARY(MAX)',
+        'oracle': 'BLOB',
+        'sqlite': 'BLOB',
+        'duckdb': 'BLOB',
+        'citus': 'BYTEA',
+        'cockroachdb': 'BYTEA',
+        'default': 'BLOB',
+    },
 }
 PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
     'int': {
@@ -420,6 +433,19 @@ PD_TO_SQLALCHEMY_DTYPES_FLAVORS: Dict[str, Dict[str, str]] = {
         'citus': 'Uuid',
         'cockroachdb': 'Uuid',
         'default': 'Uuid',
+    },
+    'bytes': {
+        'timescaledb': 'LargeBinary',
+        'postgresql': 'LargeBinary',
+        'mariadb': 'LargeBinary',
+        'mysql': 'LargeBinary',
+        'mssql': 'LargeBinary',
+        'oracle': 'LargeBinary',
+        'sqlite': 'LargeBinary',
+        'duckdb': 'LargeBinary',
+        'citus': 'LargeBinary',
+        'cockroachdb': 'LargeBinary',
+        'default': 'LargeBinary',
     },
 }
 

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -528,7 +528,7 @@ def get_db_type_from_pd_type(
     """
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.dtypes import are_dtypes_equal
+    from meerschaum.utils.dtypes import are_dtypes_equal, MRSM_ALIAS_DTYPES
     from meerschaum.utils.misc import parse_arguments_str
     sqlalchemy_types = attempt_import('sqlalchemy.types')
 
@@ -537,6 +537,9 @@ def get_db_type_from_pd_type(
         if not as_sqlalchemy
         else PD_TO_SQLALCHEMY_DTYPES_FLAVORS
     )
+
+    if pd_type in MRSM_ALIAS_DTYPES:
+        pd_type = MRSM_ALIAS_DTYPES[pd_type]
 
     ### Check whether we are able to match this type (e.g. pyarrow support).
     found_db_type = False

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -177,14 +177,14 @@ def string_to_dict(
         keys = _keys[:-1]
         try:
             val = ast.literal_eval(_keys[-1])
-        except Exception as e:
+        except Exception:
             val = str(_keys[-1])
 
         c = params_dict
         for _k in keys[:-1]:
             try:
                 k = ast.literal_eval(_k)
-            except Exception as e:
+            except Exception:
                 k = str(_k)
             if k not in c:
                 c[k] = {}
@@ -196,12 +196,12 @@ def string_to_dict(
 
 
 def parse_config_substitution(
-        value: str,
-        leading_key: str = 'MRSM',
-        begin_key: str = '{',
-        end_key: str = '}',
-        delimeter: str = ':'
-    ) -> List[Any]:
+    value: str,
+    leading_key: str = 'MRSM',
+    begin_key: str = '{',
+    end_key: str = '}',
+    delimeter: str = ':'
+) -> List[Any]:
     """
     Parse Meerschaum substitution syntax
     E.g. MRSM{value1:value2} => ['value1', 'value2']

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1630,7 +1630,7 @@ def get_update_queries(
 
     ### NOTE: MSSQL upserts must exclude the update portion if only upserting indices.
     when_matched_update_sets_subquery_none = "" if not value_cols else (
-        "WHEN MATCHED THEN"
+        "WHEN MATCHED THEN\n"
         f"     UPDATE {sets_subquery('', 'p.')}"
     )
 

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1062,7 +1062,7 @@ def get_sqlalchemy_table(
                 connector.metadata,
                 **table_kwargs
             )
-        except sqlalchemy.exc.NoSuchTableError as e:
+        except sqlalchemy.exc.NoSuchTableError:
             warn(f"Table '{truncated_table_name}' does not exist in '{connector}'.")
             return None
     return tables[truncated_table_name]

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -108,6 +108,7 @@ update_queries = {
             {cols_equal_values}
     """,
     'mssql': """
+        {with_temp_date_bounds}
         MERGE {target_table_name} f
             USING (SELECT {patch_cols_str} FROM {patch_table_name}) p
             ON {and_subquery_f}

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1686,7 +1686,8 @@ def get_null_replacement(typ: str, flavor: str) -> str:
         )
         return f'CAST({val_to_cast} AS {bool_typ})'
     if 'time' in typ.lower() or 'date' in typ.lower():
-        return dateadd_str(flavor=flavor, begin='1900-01-01', db_type=typ)
+        db_type = typ if typ.isupper() else None
+        return dateadd_str(flavor=flavor, begin='1900-01-01', db_type=db_type)
     if 'float' in typ.lower() or 'double' in typ.lower() or typ.lower() in ('decimal',):
         return '-987654321.0'
     if flavor == 'oracle' and typ.lower().split('(', maxsplit=1)[0] == 'char':

--- a/meerschaum/utils/venv/_Venv.py
+++ b/meerschaum/utils/venv/_Venv.py
@@ -34,10 +34,10 @@ class Venv:
     """
 
     def __init__(
-            self,
-            venv: Union[str, 'meerschaum.plugins.Plugin', None] = 'mrsm',
-            debug: bool = False,
-        ) -> None:
+        self,
+        venv: Union[str, 'meerschaum.plugins.Plugin', None] = 'mrsm',
+        debug: bool = False,
+    ) -> None:
         from meerschaum.utils.venv import activate_venv, deactivate_venv, active_venvs
         ### For some weird threading issue,
         ### we can't use `isinstance` here.

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -371,7 +371,7 @@ def init_venv(
     from contextlib import redirect_stdout, redirect_stderr
     import sys, platform, os, pathlib, shutil
     from meerschaum.config.static import STATIC_CONFIG
-    from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
+    from meerschaum.config._paths import VIRTENV_RESOURCES_PATH, VENVS_CACHE_RESOURCES_PATH
     from meerschaum.utils.packages import is_uv_enabled
     venv_path = VIRTENV_RESOURCES_PATH / venv
     vtp = venv_target_path(venv=venv, allow_nonexistent=True, debug=debug)
@@ -403,7 +403,7 @@ def init_venv(
         virtualenv = None
 
     _venv_success = False
-    temp_vtp = vtp.parent / '.site-packages.old'
+    temp_vtp = VENVS_CACHE_RESOURCES_PATH / str(venv)
     rename_vtp = vtp.exists()
 
     if rename_vtp:

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -218,17 +218,22 @@ def is_venv_active(
 
 verified_venvs = set()
 def verify_venv(
-        venv: str,
-        debug: bool = False,
-    ) -> None:
+    venv: str,
+    debug: bool = False,
+) -> None:
     """
     Verify that the virtual environment matches the expected state.
     """
-    import pathlib, platform, os, shutil, subprocess, sys
+    import pathlib
+    import platform
+    import os
+    import shutil
+    import sys
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
     from meerschaum.utils.process import run_process
     from meerschaum.utils.misc import make_symlink, is_symlink
     from meerschaum.utils.warnings import warn
+
     venv_path = VIRTENV_RESOURCES_PATH / venv
     bin_path = venv_path / (
         'bin' if platform.system() != 'Windows' else "Scripts"
@@ -368,16 +373,21 @@ def init_venv(
         return True
 
     import io
-    from contextlib import redirect_stdout, redirect_stderr
-    import sys, platform, os, pathlib, shutil
+    from contextlib import redirect_stdout
+    import sys
+    import platform
+    import os
+    import pathlib
+    import shutil
+
     from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH, VENVS_CACHE_RESOURCES_PATH
     from meerschaum.utils.packages import is_uv_enabled
+
     venv_path = VIRTENV_RESOURCES_PATH / venv
     vtp = venv_target_path(venv=venv, allow_nonexistent=True, debug=debug)
     docker_home_venv_path = pathlib.Path('/home/meerschaum/venvs/mrsm')
 
-    runtime_env_var = STATIC_CONFIG['environment']['runtime']
     work_dir_env_var = STATIC_CONFIG['environment']['work_dir']
     if (
         not force
@@ -404,10 +414,13 @@ def init_venv(
 
     _venv_success = False
     temp_vtp = VENVS_CACHE_RESOURCES_PATH / str(venv)
-    rename_vtp = vtp.exists()
+    rename_vtp = vtp.exists() and not temp_vtp.exists()
 
     if rename_vtp:
-        vtp.rename(temp_vtp)
+        try:
+            vtp.rename(temp_vtp)
+        except FileExistsError:
+            pass
 
     if uv is not None:
         _venv_success = run_python_package(

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -59,11 +59,13 @@ services:
       - "mysql_volume:/var/lib/mysql"
 
   oracle:
-    image: "konnecteam/docker-oracle-12c:sequelize"
+    image: "container-registry.oracle.com/database/express:latest"
     ports:
       - "1529:1521"
+    environment:
+      ORACLE_PWD: "oracle"
     volumes:
-      - "oracle_volume:/u01/app/oracle"
+      - "oracle_volume:/opt/oracle/oradata"
 
   citus:
     image: "citusdata/citus:11.0.2"

--- a/tests/plugins/stress.py
+++ b/tests/plugins/stress.py
@@ -6,7 +6,7 @@
 Stress test for pipes.
 """
 
-__version__ = '0.3.9'
+__version__ = '0.4.0'
 
 from datetime import datetime, timezone, timedelta
 import random
@@ -56,9 +56,6 @@ def fetch(
         chunksize = 1440
 
     dt_col, id_col, val_col = 'datetime', 'id', 'val'
-    print(f"{begin=}")
-    print(f"{end=}")
-    #  print(f"{sync_time=}")
 
     fetch_params = pipe.parameters.get('fetch', {})
     row_limit = fetch_params.get('rows', None) or 1440

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -814,6 +814,7 @@ def test_distant_datetimes(flavor: str):
         columns={
             'datetime': 'ts',
         },
+        enforce=False,
     )
     docs = [
         {'ts': datetime(1, 1, 1)},

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -81,7 +81,6 @@ def test_dtype_enforcement(flavor: str):
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'numeric': '1'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'uuid': '00000000-1234-5678-0000-000000000000'}], debug=debug)
     pipe.sync([{'dt': '2022-01-01', 'id': 1, 'bytes': 'Zm9vIGJhcg=='}], debug=debug)
-    return pipe
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert len(df.columns) == 11
@@ -161,7 +160,7 @@ def test_infer_numeric_dtype(flavor: str):
     from meerschaum.utils.misc import generate_password
     from meerschaum.utils.dtypes.sql import NUMERIC_PRECISION_FLAVORS
     scale, precision = NUMERIC_PRECISION_FLAVORS.get(
-        flavor, NUMERIC_PRECISION_FLAVORS['sqlite']
+        flavor, NUMERIC_PRECISION_FLAVORS['mssql']
     )
     digits = (list(reversed(range(0, 10))) * 4)[:(-1 * (40 - scale))]
     decimal_digits = digits[(-1 * precision):]
@@ -231,7 +230,6 @@ def test_infer_bytes_dtype(flavor: str):
         ],
         debug=debug,
     )
-    return pipe
     assert success, msg
     pprint(pipe.get_columns_types())
     df = pipe.get_data(debug=debug)
@@ -243,18 +241,17 @@ def test_infer_bytes_dtype(flavor: str):
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_infer_numeric_from_mixed_types(flavor: str):
     """
-    Ensure that new pipes with complex columns (dict or list) as enforced as NUMERIC. 
+    Ensure that new pipes with mixed int and floats as enforced as NUMERIC. 
     """
     from meerschaum.utils.formatting import pprint
     from meerschaum.utils.misc import generate_password
-    session_id = generate_password(6)
     conn = conns[flavor]
-    pipe = Pipe('foo', 'bar', session_id, instance=conn)
+    pipe = Pipe('test', 'infer_numeric', 'mixed', instance=conn)
     _ = pipe.delete(debug=debug)
-    pipe = Pipe('foo', 'bar', session_id, instance=conn, columns=['id'])
-    success, msg = pipe.sync([{'id': 1, 'a': 1}])
+    pipe = Pipe('test', 'infer_numeric', 'mixed', instance=conn, columns=['id'])
+    success, msg = pipe.sync([{'id': 1, 'a': 1}], debug=debug)
     assert success, msg
-    success, msg = pipe.sync([{'id': 2, 'a': 2.1}])
+    success, msg = pipe.sync([{'id': 2, 'a': 2.1}], debug=debug)
     assert success, msg
     pprint(pipe.get_columns_types())
     df = pipe.get_data(debug=debug)

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -814,12 +814,9 @@ def test_distant_datetimes(flavor: str):
         columns={
             'datetime': 'ts',
         },
-        dtypes={
-            'ts': 'datetime64[s, UTC]',
-        },
     )
     docs = [
-        {'ts': '0001-01-01'},
+        {'ts': datetime(1, 1, 1)},
     ]
     success, msg = pipe.sync(docs, debug=debug)
     assert success, msg

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1104,6 +1104,7 @@ def test_static_schema(flavor: str):
         except Exception as e:
             success, msg = False, str(e)
     assert not success
+    return pipe
 
     cols_types = pipe.get_columns_types(debug=debug)
     assert 'bar' not in cols_types

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -944,7 +944,6 @@ def test_autoincrement_primary_key(flavor: str):
     df = pipe.get_data(['shirt_size'], params={'id': [4, 5]}, debug=debug)
     assert list(df['shirt_size']) == ['L', 'M']
 
-    return pipe
     success, msg = pipe.sync([{'color': 'purple'}, {'shirt_size': 'S'}], debug=debug)
     assert success, msg
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1104,7 +1104,6 @@ def test_static_schema(flavor: str):
         except Exception as e:
             success, msg = False, str(e)
     assert not success
-    return pipe
 
     cols_types = pipe.get_columns_types(debug=debug)
     assert 'bar' not in cols_types

--- a/tests/utils/test_dtypes.py
+++ b/tests/utils/test_dtypes.py
@@ -27,6 +27,7 @@ pd = import_pandas(debug=DEBUG)
         ('float', 'object', False),
         ('datetime', 'object', False),
         ('uuid', 'object', True),
+        ('bytes', 'object', True),
     ]
 )
 def test_are_dtypes_equal(ldtype: str, rdtype: str, are_equal: bool):


### PR DESCRIPTION
# v2.7.0

- **Introduce the `bytes` data type.**  
  Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'demo', 'bytes',
      instance='sql:memory',
      dtypes={'blob': 'bytes'},
  )
  pipe.sync([
      {'blob': b'hello, world!'},
  ])

  df = pipe.get_data()
  binary_data = df['blob'][0]
  print(binary_data.decode('utf-8'))
  # hello, world!

  from meerschaum.utils.dtypes import serialize_bytes, attempt_cast_to_bytes
  df['encoded'] = df['blob'].apply(serialize_bytes)
  df['decoded'] = df['encoded'].apply(attempt_cast_to_bytes)
  print(df)
  #                blob               encoded           decoded
  # 0  b'hello, world!'  aGVsbG8sIHdvcmxkIQ==  b'hello, world!'
  ```

- **Allow for pipes to use the same column for `datetime`, `primary`, and `autoincrement=True`.**  
  Pipes may now use the same column as the `datetime` axis and `primary` with `autoincrement` set to `True`.

  ```python
  pipe = mrsm.Pipe(
      'demo', 'datetime_primary_key', 'autoincrement',
      instance='sql:local',
      columns={
          'datetime': 'Id',
          'primary': 'Id',
      },
      autoincrement=True,
  )
  ```

- **Only join on `primary` when present.**  
  When the index `primary` is set, use the column as the primary joining index. This will improve performance when syncing tables with a primary key.


- **Add the parameter `enforce`.**  
  The parameter `enforce` (default `True`) toggles data type enforcement behavior. When `enforce` is `False`, incoming data will not be cast to the desired data types. For static datasets where the incoming data is always expected to be of the correct dtypes, then it is recommended to set `enforce` to `False` and `static` to `True`.


  ```python
  from decimal import Decimal
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'demo', 'enforce',
      instance='sql:memory',
      enforce=False,
      static=True,
      autoincrement=True,
      columns={
          'primary': 'Id',
          'datetime': 'Id',
      },
      dtypes={
          'Id': 'int',
          'Amount': 'numeric',
      },
  )
  pipe.sync([
      {'Amount': Decimal('1.11')},
      {'Amount': Decimal('2.22')},
  ]) 

  df = pipe.get_data()
  print(df)
  ```

- **Create the `datetime` axis as a clustered index for MSSQL, even when a `primary` index is specififed.**  
  Specifying a `datetime` and `primary` index will create a nonclustered `PRIMARY KEY`. Specifying the same column as both `datetime` and `primary` will create a clustered primary key (tip: this is useful when `autoincrement=True`).

- **Increase the default chunk interval to 43200 minutes.**  
  New hypertables will use a default chunksize of 30 days (43200 minutes).

- **Virtual environment bugfixes.**  
  Existing virtual environment packages are backed up before re-initializing a virtual environment. This fixes the issue of disappearing dependencies.

- **Store `numeric` as `TEXT` for SQLite and DuckDB.**  
  Due to limited precision, `numeric` columns are now stored as `TEXT`, then parsed into `Decimal` objects upon retrieval.

- **Improve dtype inference.** 
