### PR TITLE
Enforce `DATETIMEOFFSET` as UTC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.0 – v2.7.2
+### v2.7.0 – v2.7.3
 
 - **Introduce the `bytes` data type.**  
   Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
@@ -99,6 +99,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Show the Webterm by default when changing instances.**  
   On the Web Console, changing the instance select will make the Webterm visible.
+  
+- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
+  Certain database flavors (e.g. MSSQL) consider timezone-aware timestamps equivalent only if they share offsets. This patch coerces all timezone-aware datetimes into UTC before checking equality.
 
 - **Improve dtype inference.** 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,48 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.0 – v2.7.3
+### v2.7.3
+
+- **Allow for dynamic targets in SQL queries.**  
+  Include a pipe definition in double curly braces (à la Jinja) to substitute a pipe's target into a templated query.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe('demo', 'template', target='foo', instance='sql:local')
+  _ = pipe.register()
+
+  downstream_pipe = mrsm.Pipe(
+      'sql:local', 'template',
+      instance='sql:local',
+      parameters={
+          'sql': "SELECT *\nFROM {{Pipe('demo', 'template', instance='sql:local')}}"
+      },
+  )
+
+  conn = mrsm.get_connector('sql:local')
+  print(conn.get_pipe_metadef(downstream_pipe))
+  # WITH "definition" AS (
+  #     SELECT *
+  #     FROM "foo"
+  # )
+  # SELECT *
+  # FROM "definition"
+  ```
+
+- **Add `--skip-enforce-dtypes`.**  
+  To override a pipe's `enforce` parameter, pass `--skip-enforce-dtypes` to a sync.
+
+- **Skip enforcing custom dtypes when `enforce=False`.**  
+  To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
+
+- **Fix timezone-aware casts.**  
+  A bug has been fixed where it was possible to mix timezone-aware and -naive casts in a single query. This patch ensures that this no longer occurs.
+
+- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
+  By default, timezone-aware columns are now cast as time zone UTC in SQL. This may be skipped by setting `enforce` to `False`.
+
+### v2.7.0 – v2.7.2
 
 - **Introduce the `bytes` data type.**  
   Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
@@ -99,9 +140,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Show the Webterm by default when changing instances.**  
   On the Web Console, changing the instance select will make the Webterm visible.
-  
-- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
-  Certain database flavors (e.g. MSSQL) consider timezone-aware timestamps equivalent only if they share offsets. This patch coerces all timezone-aware datetimes into UTC before checking equality.
 
 - **Improve dtype inference.** 
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.0 – v2.7.2
+### v2.7.0 – v2.7.3
 
 - **Introduce the `bytes` data type.**  
   Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
@@ -99,6 +99,9 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Show the Webterm by default when changing instances.**  
   On the Web Console, changing the instance select will make the Webterm visible.
+  
+- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
+  Certain database flavors (e.g. MSSQL) consider timezone-aware timestamps equivalent only if they share offsets. This patch coerces all timezone-aware datetimes into UTC before checking equality.
 
 - **Improve dtype inference.** 
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,48 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.0 – v2.7.3
+### v2.7.3
+
+- **Allow for dynamic targets in SQL queries.**  
+  Include a pipe definition in double curly braces (à la Jinja) to substitute a pipe's target into a templated query.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe('demo', 'template', target='foo', instance='sql:local')
+  _ = pipe.register()
+
+  downstream_pipe = mrsm.Pipe(
+      'sql:local', 'template',
+      instance='sql:local',
+      parameters={
+          'sql': "SELECT *\nFROM {{Pipe('demo', 'template', instance='sql:local')}}"
+      },
+  )
+
+  conn = mrsm.get_connector('sql:local')
+  print(conn.get_pipe_metadef(downstream_pipe))
+  # WITH "definition" AS (
+  #     SELECT *
+  #     FROM "foo"
+  # )
+  # SELECT *
+  # FROM "definition"
+  ```
+
+- **Add `--skip-enforce-dtypes`.**  
+  To override a pipe's `enforce` parameter, pass `--skip-enforce-dtypes` to a sync.
+
+- **Skip enforcing custom dtypes when `enforce=False`.**  
+  To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
+
+- **Fix timezone-aware casts.**  
+  A bug has been fixed where it was possible to mix timezone-aware and -naive casts in a single query. This patch ensures that this no longer occurs.
+
+- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
+  By default, timezone-aware columns are now cast as time zone UTC in SQL. This may be skipped by setting `enforce` to `False`.
+
+### v2.7.0 – v2.7.2
 
 - **Introduce the `bytes` data type.**  
   Instance connectors which support binary data (e.g. `SQLConnector`) may now take advantage of the `bytes` dtype. Other connectors (e.g. `ValkeyConnector`) may use `meerschaum.utils.dtypes.serialize_bytes()` to store binary data as a base64-encoded string.
@@ -99,9 +140,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 - **Show the Webterm by default when changing instances.**  
   On the Web Console, changing the instance select will make the Webterm visible.
-  
-- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
-  Certain database flavors (e.g. MSSQL) consider timezone-aware timestamps equivalent only if they share offsets. This patch coerces all timezone-aware datetimes into UTC before checking equality.
 
 - **Improve dtype inference.** 
 

--- a/meerschaum/_internal/arguments/_parse_arguments.py
+++ b/meerschaum/_internal/arguments/_parse_arguments.py
@@ -240,6 +240,8 @@ def parse_synonyms(
         args_dict['instance'] = args_dict['mrsm_instance']
     if args_dict.get('skip_check_existing', None):
         args_dict['check_existing'] = False
+    if args_dict.get('skip_enforce_dtypes', None):
+        args_dict['enforce_dtypes'] = False
     if args_dict.get('venv', None) in ('None', '[None]'):
         args_dict['venv'] = None
     chunk_minutes = args_dict.get('chunk_minutes', None)

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -87,7 +87,7 @@ def parse_datetime(dt_str: str) -> Union[datetime, int, str]:
                 dt = round_time(dt, round_delta)
         else:
             dt = dateutil_parser.parse(dt_str)
-    except Exception as e:
+    except Exception:
         dt = None
     if dt is None:
         from meerschaum.utils.warnings import error
@@ -121,7 +121,7 @@ def parse_help(sysargs: Union[List[str], Dict[str, Any]]) -> None:
     """Parse the `--help` flag to determine which help message to print."""
     from meerschaum._internal.arguments._parse_arguments import parse_arguments, parse_line
     from meerschaum.actions import actions, get_subactions
-    import importlib, inspect, textwrap
+    import textwrap
     from copy import deepcopy
     if isinstance(sysargs, list):
         args = parse_arguments(sysargs)
@@ -140,14 +140,14 @@ def parse_help(sysargs: Union[List[str], Dict[str, Any]]) -> None:
     if len(args['action']) > 1:
         try:
             subaction = get_subactions(args['action'][0])[args['action'][1]]
-        except Exception as e:
+        except Exception:
             subaction = None
         if subaction is not None:
             return print(textwrap.dedent(subaction.__doc__))
 
     try:
         doc = actions[args['action'][0]].__doc__
-    except Exception as e:
+    except Exception:
         doc = None
     if doc is None:
         doc = "No help available for '" + f"{args['action'][0]}" + "'."
@@ -309,7 +309,7 @@ groups['sync'].add_argument(
 )
 groups['sync'].add_argument(
     '--chunksize', type=int, help=(
-        "Specify the database chunksize. Defaults to 10,000."
+        "Specify the database chunksize. Defaults to 100,000."
     ),
 )
 groups['sync'].add_argument(
@@ -336,18 +336,24 @@ groups['sync'].add_argument(
 )
 groups['sync'].add_argument(
     '--bounded', '--bound', action="store_true",
-    help = (
+    help=(
         "When verifying, do not sync outside "
-        + "the existing oldest and newest datetime bounds."
+        "the existing oldest and newest datetime bounds."
     )
 )
 groups['sync'].add_argument(
     '--skip-check-existing', '--allow-duplicates', action='store_true',
-    help = (
-        "Skip checking for duplicate rows when syncing. " +
-        "This drastically improves performance when all rows to be synced are unique. " +
-        "For example, this setting is highly recommended for use with IoT devices."
+    help=(
+        "Skip checking for duplicate rows when syncing. "
+        "This improves performance when all rows to be synced are unique. "
     )
+)
+groups['sync'].add_argument(
+    '--skip-enforce-dtypes', action='store_true',
+    help=(
+        "Skip enforcing incoming data to a pipe's dtypes. "
+        "This improves performance when all rows are expected to already be of the correct type."
+    ),
 )
 groups['sync'].add_argument(
     '--cache', action='store_true',

--- a/meerschaum/actions/clear.py
+++ b/meerschaum/actions/clear.py
@@ -137,7 +137,7 @@ def _ask_with_rowcounts(
     )
     total_num_rows = sum([rc for p, rc in pipes_rowcounts.items()])
     question = (
-        f"Are you sure you want to delete {total_num_rows} rows across {len(pipes)} pipe"
+        f"Are you sure you want to delete {total_num_rows:,} rows across {len(pipes)} pipe"
         + ('s' if len(pipes) != 1 else '')
         + " in the following range?\n"
     )

--- a/meerschaum/actions/edit.py
+++ b/meerschaum/actions/edit.py
@@ -498,7 +498,7 @@ def _edit_jobs(
         num_edited += 1
 
     msg = (
-        "Successfully edit job"
+        "Successfully edited job"
         + ('s' if len(jobs) != 1 else '')
         + ' '
         + items_str(list(jobs.keys()))

--- a/meerschaum/actions/verify.py
+++ b/meerschaum/actions/verify.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from meerschaum.utils.typing import Union, Any, Sequence, SuccessTuple, Optional, Tuple, List
 
 def verify(
-        action: Optional[List[str]] = None,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Verify the states of pipes, packages, and more.
     """
@@ -36,19 +36,17 @@ def _verify_pipes(**kwargs) -> SuccessTuple:
 
 
 def _verify_packages(
-        debug: bool = False,
-        venv: Optional[str] = 'mrsm',
-        **kw
-    ) -> SuccessTuple:
+    debug: bool = False,
+    venv: Optional[str] = 'mrsm',
+    **kw
+) -> SuccessTuple:
     """
     Verify the versions of packages.
     """
     from meerschaum.utils.packages import (
-        attempt_import, need_update, all_packages, is_installed, venv_contains_package,
+        attempt_import, all_packages, is_installed, venv_contains_package,
         _monkey_patch_get_distribution, manually_import_module,
     )
-    from meerschaum.utils.formatting import pprint
-    from meerschaum.utils.debug import dprint
 
     venv_packages, base_packages, miss_packages = [], [], []
 
@@ -80,10 +78,10 @@ def _verify_packages(
 
 
 def _verify_venvs(
-        action: Optional[List[str]],
-        debug: bool = False,
-        **kw
-    ) -> SuccessTuple:
+    action: Optional[List[str]],
+    debug: bool = False,
+    **kw
+) -> SuccessTuple:
     """
     Verify your virtual environments.
     """
@@ -94,15 +92,14 @@ def _verify_venvs(
 
 
 def _verify_plugins(
-        action: Optional[List[str]] = None,
-        **kwargs: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Verify that all of the available plugins are able to be imported as expected.
     """
-    from meerschaum.utils.formatting import print_options, UNICODE, print_tuple
-    from meerschaum.plugins import import_plugins, get_plugins_names, Plugin
-    from meerschaum.config import get_config
+    from meerschaum.utils.formatting import print_options, print_tuple
+    from meerschaum.plugins import get_plugins_names, Plugin
     from meerschaum.utils.misc import items_str
 
     plugins_names_to_verify = action or get_plugins_names()
@@ -135,7 +132,7 @@ def _verify_plugins(
         f"Successfully imported {len(plugins_names_to_verify)} plugins."
         if success
         else (
-            f"Failed to import plugin"
+            "Failed to import plugin"
             + ('s' if len(failed_to_import) != 1 else '')
             + f" {items_str(failed_to_import)}."
         )

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.2"
+__version__ = "2.7.3.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.3.dev1"
+__version__ = "2.7.3"

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -144,37 +144,37 @@ def get_pipe_metadef(
     -------
     A pipe's meta definition fetch query string.
     """
-    from meerschaum.utils.debug import dprint
-    from meerschaum.utils.warnings import warn, error
+    from meerschaum.utils.warnings import warn
     from meerschaum.utils.sql import sql_item_name, dateadd_str, build_where
+    from meerschaum.utils.dtypes.sql import get_db_type_from_pd_type
     from meerschaum.utils.misc import is_int
     from meerschaum.config import get_config
 
-    definition = get_pipe_query(pipe)
-
-    if not pipe.columns.get('datetime', None):
-        _dt = pipe.guess_datetime()
-        dt_name = sql_item_name(_dt, self.flavor, None) if _dt else None
+    dt_col = pipe.columns.get('datetime', None)
+    if not dt_col:
+        dt_col = pipe.guess_datetime()
+        dt_name = sql_item_name(dt_col, self.flavor, None) if dt_col else None
         is_guess = True
     else:
-        _dt = pipe.get_columns('datetime')
-        dt_name = sql_item_name(_dt, self.flavor, None)
+        dt_name = sql_item_name(dt_col, self.flavor, None)
         is_guess = False
+    dt_typ = pipe.dtypes.get(dt_col, 'datetime') if dt_col else None
+    db_dt_typ = get_db_type_from_pd_type(dt_typ, self.flavor)
 
     if begin not in (None, '') or end is not None:
         if is_guess:
-            if _dt is None:
+            if dt_col is None:
                 warn(
                     f"Unable to determine a datetime column for {pipe}."
                     + "\n    Ignoring begin and end...",
-                    stack = False,
+                    stack=False,
                 )
                 begin, end = '', None
             else:
                 warn(
                     f"A datetime wasn't specified for {pipe}.\n"
-                    + f"    Using column \"{_dt}\" for datetime bounds...",
-                    stack = False
+                    + f"    Using column \"{dt_col}\" for datetime bounds...",
+                    stack=False
                 )
 
     apply_backtrack = begin == '' and check_existing
@@ -200,6 +200,7 @@ def get_pipe_metadef(
                 datepart='minute',
                 number=((-1 * btm) if apply_backtrack else 0),
                 begin=begin,
+                db_type=db_dt_typ,
             )
             if begin
             else None
@@ -210,11 +211,13 @@ def get_pipe_metadef(
                 datepart='minute',
                 number=0,
                 begin=end,
+                db_type=db_dt_typ,
             )
             if end
             else None
         )
 
+    definition_name = sql_item_name('definition', self.flavor, None)
     meta_def = (
         _simple_fetch_query(pipe, self.flavor) if (
             (not (pipe.columns or {}).get('id', None))
@@ -225,9 +228,9 @@ def get_pipe_metadef(
     has_where = 'where' in meta_def.lower()[meta_def.lower().rfind('definition'):]
     if dt_name and (begin_da or end_da):
         definition_dt_name = (
-            dateadd_str(self.flavor, 'minute', 0, f"definition.{dt_name}")
+            dateadd_str(self.flavor, 'minute', 0, f"{definition_name}.{dt_name}", db_type=db_dt_typ)
             if not is_int((begin_da or end_da))
-            else f"definition.{dt_name}"
+            else f"{definition_name}.{dt_name}"
         )
         meta_def += "\n" + ("AND" if has_where else "WHERE") + " "
         has_where = True
@@ -331,11 +334,7 @@ def _join_fetch_query(
     pipe_instance_name = sql_item_name(
         pipe.target, pipe.instance_connector.flavor, pipe.instance_connector.schema
     )
-    #  pipe_remote_name = sql_item_name(pipe.target, pipe.connector.flavor)
     sync_times_table = pipe.target + "_sync_times"
-    sync_times_instance_name = sql_item_name(
-        sync_times_table, pipe.instance_connector.flavor, None
-    )
     sync_times_remote_name = sql_item_name(
         sync_times_table, pipe.connector.flavor, None
     )

--- a/meerschaum/connectors/sql/_instance.py
+++ b/meerschaum/connectors/sql/_instance.py
@@ -96,15 +96,15 @@ def _drop_temporary_tables(self, debug: bool = False) -> SuccessTuple:
         sqlalchemy.select(temp_tables_table.c.table)
         .where(temp_tables_table.c.ready_to_drop.is_not(None))
     )
-    tables_to_drop = [
+    tables_to_drop = {
         table
         for table, ready_to_drop in _in_memory_temp_tables.items()
         if ready_to_drop
-    ]
+    }
     if not tables_to_drop:
         df = self.read(query, silent=True, debug=debug)
         tables_to_drop = (
-            list(df['table'])
+            set(df['table'])
             if df is not None
             else []
         )
@@ -126,7 +126,7 @@ def _drop_temporary_tables(self, debug: bool = False) -> SuccessTuple:
             sqlalchemy.delete(temp_tables_table)
             .where(temp_tables_table.c.table.in_(dropped_tables))
         )
-        delete_result = self.exec(delete_query, silent=True, debug=debug)
+        _ = self.exec(delete_query, silent=True, debug=debug)
 
     success = len(failed_tables) == 0
     msg = (

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -310,7 +310,7 @@ def enforce(self, _enforce: bool) -> None:
     """
     Set the `enforce` parameter for the pipe.
     """
-    self.parameters['_enforce'] = _enforce
+    self.parameters['enforce'] = _enforce
 
 
 def get_columns(self, *args: str, error: bool = False) -> Union[str, Tuple[str]]:

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import timedelta, datetime
 
 import meerschaum as mrsm
-from meerschaum.utils.typing import Optional, Any, Union, SuccessTuple, Iterator, TYPE_CHECKING
+from meerschaum.utils.typing import Any, Union, SuccessTuple, Iterator, TYPE_CHECKING
 from meerschaum.config import get_config
 from meerschaum.utils.warnings import warn
 
@@ -56,8 +56,7 @@ def fetch(
         warn(f"No `fetch()` function defined for connector '{self.connector}'")
         return None
 
-    from meerschaum.connectors import custom_types, get_connector_plugin
-    from meerschaum.utils.debug import dprint, _checkpoint
+    from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.misc import filter_arguments
 
     _chunk_hook = kw.pop('chunk_hook', None)

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -327,16 +327,16 @@ def get_chunks_success_message(
     header = (header + "\n") if header else ""
     stats_msg = items_str(
         (
-            ([f'inserted {num_inserted}'] if num_inserted else [])
-            + ([f'updated {num_updated}'] if num_updated else [])
-            + ([f'upserted {num_upserted}'] if num_upserted else [])
+            ([f'inserted {num_inserted:,}'] if num_inserted else [])
+            + ([f'updated {num_updated:,}'] if num_updated else [])
+            + ([f'upserted {num_upserted:,}'] if num_upserted else [])
         ) or ['synced 0'],
         quotes=False,
         and_=False,
     )
 
     success_msg = (
-        f"Successfully synced {len(chunk_success_tuples)} chunk"
+        f"Successfully synced {len(chunk_success_tuples):,} chunk"
         + ('s' if len(chunk_success_tuples) != 1 else '')
         + '\n(' + stats_msg
         + ' rows in total).'

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -162,7 +162,8 @@ def verify(
     )
 
     info(
-        f"Verifying {self}:\n    Syncing {len(chunk_bounds)} chunk" + ('s' if len(chunk_bounds) != 1 else '')
+        f"Verifying {self}:\n    Syncing {len(chunk_bounds)} chunk"
+        + ('s' if len(chunk_bounds) != 1 else '')
         + f" ({'un' if not bounded else ''}bounded)"
         + f" of size '{interval_str(chunk_interval)}'"
         + f" between '{begin_to_print}' and '{end_to_print}'."
@@ -194,6 +195,9 @@ def verify(
             **kwargs
         )
         chunk_msg = chunk_msg.strip()
+        if ' - ' not in chunk_msg:
+            chunk_label = f"{chunk_begin} - {chunk_end}"
+            chunk_msg = f'{chunk_label}\n{chunk_msg}'
         mrsm.pprint((chunk_success, chunk_msg))
         return chunk_begin_and_end, (chunk_success, chunk_msg)
 

--- a/meerschaum/jobs/__init__.py
+++ b/meerschaum/jobs/__init__.py
@@ -342,7 +342,7 @@ def check_restart_jobs(
 
 def _check_restart_jobs_against_lock(*args, **kwargs):
     from meerschaum.config.paths import CHECK_JOBS_LOCK_PATH
-    fasteners = mrsm.attempt_import('fasteners')
+    fasteners = mrsm.attempt_import('fasteners', lazy=False)
     lock = fasteners.InterProcessLock(CHECK_JOBS_LOCK_PATH)
     with lock:
         check_restart_jobs(*args, **kwargs)

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1263,7 +1263,7 @@ def df_from_literal(
         import ast
         try:
             val = ast.literal_eval(literal)
-        except Exception as e:
+        except Exception:
             warn(
                 "Failed to parse value from string:\n" + f"{literal}" +
                 "\n\nWill cast as a string instead."\

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -390,6 +390,7 @@ def parse_df_datetimes(
     strip_timezone: bool = False,
     chunksize: Optional[int] = None,
     dtype_backend: str = 'numpy_nullable',
+    ignore_all: bool = False,
     debug: bool = False,
 ) -> 'pd.DataFrame':
     """
@@ -413,6 +414,9 @@ def parse_df_datetimes(
         If `df` is not a DataFrame and new one needs to be constructed,
         use this as the datatypes backend.
         Accepted values are 'numpy_nullable' and 'pyarrow'.
+
+    ignore_all: bool, default False
+        If `True`, do not attempt to cast any columns to datetimes.
 
     debug: bool, default False
         Verbosity toggle.
@@ -504,7 +508,11 @@ def parse_df_datetimes(
             if 'datetime' in str(dtype)
         ]
     )
-    cols_to_inspect = [col for col in pdf.columns if col not in ignore_cols]
+    cols_to_inspect = [
+        col
+        for col in pdf.columns
+        if col not in ignore_cols
+    ] if not ignore_all else []
 
     if len(cols_to_inspect) == 0:
         if debug:

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -7,7 +7,7 @@ Utility functions for working with SQL data types.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import Dict, Union, Tuple, List
+from meerschaum.utils.typing import Dict, Union, Tuple
 
 NUMERIC_PRECISION_FLAVORS: Dict[str, Tuple[int, int]] = {
     'mariadb': (38, 20),

--- a/meerschaum/utils/formatting/__init__.py
+++ b/meerschaum/utils/formatting/__init__.py
@@ -57,18 +57,7 @@ def colored_fallback(*args, **kw):
     return ' '.join(args)
 
 def translate_rich_to_termcolor(*colors) -> tuple:
-    """Translate between rich and more_termcolor terminology.
-    This is probably prone to breaking.
-
-    Parameters
-    ----------
-    *colors :
-        
-
-    Returns
-    -------
-
-    """
+    """Translate between rich and more_termcolor terminology."""
     _colors = []
     for c in colors:
         _c_list = []
@@ -131,7 +120,7 @@ def _init():
     try:
         colorama.init(autoreset=False)
         success = True
-    except Exception as e:
+    except Exception:
         import traceback
         traceback.print_exc()
         _attrs['ANSI'], _attrs['UNICODE'], _attrs['CHARSET'] = False, False, 'ascii'
@@ -219,7 +208,7 @@ def get_console():
     rich_console = attempt_import('rich.console')
     try:
         console = rich_console.Console(force_terminal=True, color_system='truecolor')
-    except Exception as e:
+    except Exception:
         console = None
     return console
 
@@ -307,7 +296,6 @@ def format_success_tuple(
     calm: bool, default False
         If `True`, use the default emoji and color scheme.
     """
-    from meerschaum.config.static import STATIC_CONFIG
     _init()
     try:
         status = 'success' if tup[0] else 'failure'
@@ -381,12 +369,9 @@ def print_options(
         If `True`, print the option's number in the list (1 index).
 
     """
-    import os
     from meerschaum.utils.packages import import_rich
-    from meerschaum.utils.formatting import make_header, highlight_pipes
-    from meerschaum.actions import actions as _actions
-    from meerschaum.utils.misc import get_cols_lines, string_width, iterate_chunks
-
+    from meerschaum.utils.formatting import highlight_pipes
+    from meerschaum.utils.misc import get_cols_lines, string_width
 
     if options is None:
         options = {}
@@ -429,15 +414,10 @@ def print_options(
                 continue
             break
 
-    from meerschaum.utils.formatting import pprint, get_console
     from meerschaum.utils.packages import attempt_import
-    rich_columns = attempt_import('rich.columns')
-    rich_panel = attempt_import('rich.panel')
     rich_table = attempt_import('rich.table')
     Text = attempt_import('rich.text').Text
     box = attempt_import('rich.box')
-    Panel = rich_panel.Panel
-    Columns = rich_columns.Columns
     Table = rich_table.Table
 
     if _header is not None:

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -482,9 +482,9 @@ def print_pipes_results(
 
 
 def extract_stats_from_message(
-        message: str,
-        stat_keys: Optional[List[str]] = None,
-    ) -> Dict[str, int]:
+    message: str,
+    stat_keys: Optional[List[str]] = None,
+) -> Dict[str, int]:
     """
     Given a sync message, return the insert, update, upsert stats from within.
 
@@ -511,9 +511,9 @@ def extract_stats_from_message(
 
 
 def extract_stats_from_line(
-        line: str,
-        stat_keys: List[str],
-    ) -> Dict[str, int]:
+    line: str,
+    stat_keys: List[str],
+) -> Dict[str, int]:
     """
     Return the insert, update, upsert stats from a single line.
     """
@@ -523,6 +523,9 @@ def extract_stats_from_line(
         search_key = stat_key.lower()
         if search_key not in line.lower():
             continue
+
+        ### the count may be formatted with commas
+        line = line.replace(',', '')
 
         ### stat_text starts with the digits we want.
         try:

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -432,17 +432,17 @@ def test_mixed_offset_datetimes_sql(flavor: str):
     seed_docs1 = [{'dt': dateutil_parser.parse('2024-01-01 00:00:00-05:00'), 'num': 2}]
     seed_df0 = pd.DataFrame(seed_docs0)
     seed_df1 = pd.DataFrame(seed_docs1)
-    conn.to_sql(seed_df0, target, if_exists='replace')
-    conn.to_sql(seed_df1, target, if_exists='append')
+    conn.to_sql(seed_df0, target, if_exists='replace', debug=debug)
+    conn.to_sql(seed_df1, target, if_exists='append', debug=debug)
 
-    read_df = conn.read(target, dtype={'dt': 'datetime64[ns, UTC]'})
+    read_df = conn.read(target, dtype={'dt': 'datetime64[ns, UTC]'}, debug=debug)
     if len(set(read_df['dt'])) == 1:
         return
 
-    df = pipe.get_data(begin='2024-01-01', end='2024-01-01 00:01:00', debug=False)
+    df = pipe.get_data(begin='2024-01-01', end='2024-01-01 00:01:00', debug=debug)
     assert len(df) == 1
 
-    df = pipe.get_data(end='2024-01-01 00:01:00', debug=False)
+    df = pipe.get_data(end='2024-01-01 00:01:00', debug=debug)
     assert len(df) == 1
 
     inplace_pipe = mrsm.Pipe(conn, 'test_mixed_offset_datetimes', 'inplace', instance=conn)
@@ -456,17 +456,18 @@ def test_mixed_offset_datetimes_sql(flavor: str):
         },
     )
 
-    success, msg = inplace_pipe.sync(debug=True)
+    success, msg = inplace_pipe.sync(debug=debug)
     assert success, msg
 
     seed_docs2 = [{'dt': dateutil_parser.parse('2024-02-01 00:00:00-05:00'), 'num': 3}]
     seed_df2 = pd.DataFrame(seed_docs2)
-    conn.to_sql(seed_df2, target, if_exists='append')
+    conn.to_sql(seed_df2, target, if_exists='append', debug=debug)
 
     success, msg = inplace_pipe.sync(begin='2024-02-01 00:01:00', end='2024-02-01 05:01:00', debug=debug)
     assert success, msg
 
-    assert inplace_pipe.get_rowcount() == pipe.get_rowcount()
+    assert inplace_pipe.get_rowcount(debug=debug) == pipe.get_rowcount(debug=debug)
+    return pipe, inplace_pipe
 
 
 @pytest.mark.parametrize("flavor", get_flavors())
@@ -989,25 +990,22 @@ def test_enforce_false(flavor: str):
         columns={
             'datetime': 'dt',
         },
-        dtypes={
-            'num': 'decimal',
-        },
     )
     docs = [
-        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': Decimal('1.21')},
+        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 1.21},
     ]
     success, msg = pipe.sync(docs, debug=debug)
     assert success, msg
 
     df = pipe.get_data(['num'], debug=debug)
-    assert df['num'][0] == Decimal('1.21')
+    assert df['num'][0] == 1.21
     
     new_docs = [
-        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': Decimal('2.34567')},
+        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 2.34567},
     ]
     success, msg = pipe.sync(new_docs, debug=debug)
     assert success, msg
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
     assert df['dt'][0].tzinfo is not None
-    assert df['num'][0] == Decimal('2.34567')
+    assert df['num'][0] == 2.34567

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -992,20 +992,19 @@ def test_enforce_false(flavor: str):
         },
     )
     docs = [
-        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 1.21},
+        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 1},
     ]
     success, msg = pipe.sync(docs, debug=debug)
     assert success, msg
 
     df = pipe.get_data(['num'], debug=debug)
-    assert df['num'][0] == 1.21
+    assert df['num'][0] == 1
     
     new_docs = [
-        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 2.34567},
+        {'dt': datetime(2024, 12, 26, tzinfo=timezone.utc), 'num': 2},
     ]
     success, msg = pipe.sync(new_docs, debug=debug)
     assert success, msg
     df = pipe.get_data(debug=debug)
     assert len(df) == 1
-    assert df['dt'][0].tzinfo is not None
-    assert df['num'][0] == 2.34567
+    assert df['num'][0] == 2


### PR DESCRIPTION
# v2.7.3

- **Allow for dynamic targets in SQL queries.**  
  Include a pipe definition in double curly braces (à la Jinja) to substitute a pipe's target into a templated query.

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe('demo', 'template', target='foo', instance='sql:local')
  _ = pipe.register()

  downstream_pipe = mrsm.Pipe(
      'sql:local', 'template',
      instance='sql:local',
      parameters={
          'sql': "SELECT *\nFROM {{Pipe('demo', 'template', instance='sql:local')}}"
      },
  )

  conn = mrsm.get_connector('sql:local')
  print(conn.get_pipe_metadef(downstream_pipe))
  # WITH "definition" AS (
  #     SELECT *
  #     FROM "foo"
  # )
  # SELECT *
  # FROM "definition"
  ```

- **Add `--skip-enforce-dtypes`.**  
  To override a pipe's `enforce` parameter, pass `--skip-enforce-dtypes` to a sync.

- **Skip enforcing custom dtypes when `enforce=False`.**  
  To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.

- **Fix timezone-aware casts.**  
  A bug has been fixed where it was possible to mix timezone-aware and -naive casts in a single query. This patch ensures that this no longer occurs.

- **Explicitly cast timezone-aware datetimes as UTC in SQL syncs.**  
  By default, timezone-aware columns are now cast as time zone UTC in SQL. This may be skipped by setting `enforce` to `False`.
