### PR TITLE
⚡️ v2.7.5 Add bulk insert for MSSQL, fix venv deactivation race conditions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add bulk inserts for MSSQL.**  
   To disable this behavior, set `system:connectors:sql:bulk_insert:mssql` to `false`. Bulk inserts for PostgreSQL-like flavors may now be disabled as well.
 
+- **Fix altering multiple column types for MSSQL.**  
+  When a table has multiple columns to be altered, each column will have its own `ALTER TABLE` query.
+
 - **Skip enforcing custom dtypes when `enforce=False`.**  
   To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add `--skip-enforce-dtypes`.**  
   To override a pipe's `enforce` parameter, pass `--skip-enforce-dtypes` to a sync.
 
+- **Add bulk inserts for MSSQL.**  
+  To disable this behavior, set `system:connectors:sql:bulk_insert:mssql` to `false`. Bulk inserts for PostgreSQL-like flavors may now be disabled as well.
+
 - **Skip enforcing custom dtypes when `enforce=False`.**  
   To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.3 – v2.7.4
+### v2.7.3 – v2.7.5
 
 - **Allow for dynamic targets in SQL queries.**  
   Include a pipe definition in double curly braces (à la Jinja) to substitute a pipe's target into a templated query.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -39,6 +39,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add bulk inserts for MSSQL.**  
   To disable this behavior, set `system:connectors:sql:bulk_insert:mssql` to `false`. Bulk inserts for PostgreSQL-like flavors may now be disabled as well.
 
+- **Fix altering multiple column types for MSSQL.**  
+  When a table has multiple columns to be altered, each column will have its own `ALTER TABLE` query.
+
 - **Skip enforcing custom dtypes when `enforce=False`.**  
   To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -36,6 +36,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add `--skip-enforce-dtypes`.**  
   To override a pipe's `enforce` parameter, pass `--skip-enforce-dtypes` to a sync.
 
+- **Add bulk inserts for MSSQL.**  
+  To disable this behavior, set `system:connectors:sql:bulk_insert:mssql` to `false`. Bulk inserts for PostgreSQL-like flavors may now be disabled as well.
+
 - **Skip enforcing custom dtypes when `enforce=False`.**  
   To avoid confusion, special Meerschaum data types (`numeric`, `json`, etc.) are not coerced into objects when `enforce=False`.
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,7 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.7.3 – v2.7.4
+### v2.7.3 – v2.7.5
 
 - **Allow for dynamic targets in SQL queries.**  
   Include a pipe definition in double curly braces (à la Jinja) to substitute a pipe's target into a templated query.

--- a/meerschaum/actions/sql.py
+++ b/meerschaum/actions/sql.py
@@ -21,7 +21,7 @@ def sql(
     nopretty: bool = False,
     debug: bool = False,
     **kw: Any
-):
+) -> SuccessTuple:
     """Execute a SQL query or launch an interactive CLI. All positional arguments are optional.
 
     Usage:
@@ -125,10 +125,9 @@ def sql(
     if result is False:
         return (False, f"Failed to execute query:\n\n{query}")
     
-    from meerschaum.utils.packages import attempt_import, import_pandas
+    from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.formatting import print_tuple, pprint
-    sqlalchemy_engine_result = attempt_import('sqlalchemy.engine.result')
-    pd = import_pandas()
+    _ = attempt_import('sqlalchemy.engine.result')
     if 'sqlalchemy' in str(type(result)):
         if not nopretty:
             print_tuple((True, f"Successfully executed query:\n\n{query}"))
@@ -145,3 +144,14 @@ def sql(
             )
 
     return (True, "Success")
+
+
+def _complete_sql(
+    action: Optional[List[str]] = None, **kw: Any
+) -> List[str]:
+    from meerschaum.utils.misc import get_connector_labels
+    _text = action[0] if action else ""
+    return [
+        label.split('sql:', maxsplit=1)[-1]
+        for label in get_connector_labels('sql', search_term=_text, ignore_exact_match=True)
+    ]

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -68,6 +68,12 @@ default_system_config = {
             'pandas': 'pandas',
         },
         'sql': {
+            'bulk_insert': {
+                'postgresql': True,
+                'citus': True,
+                'timescaledb': True,
+                'mssql': True,
+            },
             'instance': {
                 'stale_temporary_tables_minutes': 1440,
             },

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.5.dev1"
+__version__ = "2.7.5"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.4"
+__version__ = "2.7.5.dev1"

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -61,6 +61,7 @@ flavor_configs = {
         'engine': 'mssql+pyodbc',
         'create_engine': {
             'fast_executemany': True,
+            'use_insertmanyvalues': False,
             'isolation_level': 'AUTOCOMMIT',
             'use_setinputsizes': False,
             'pool_pre_ping': True,

--- a/meerschaum/utils/daemon/Daemon.py
+++ b/meerschaum/utils/daemon/Daemon.py
@@ -261,7 +261,10 @@ class Daemon:
         -------
         Nothing — this will exit the parent process.
         """
-        import platform, sys, os, traceback
+        import platform
+        import sys
+        import os
+        import traceback
         from meerschaum.utils.warnings import warn
         from meerschaum.config import get_config
         daemon = attempt_import('daemon')
@@ -1085,7 +1088,8 @@ class Daemon:
 
     def write_pickle(self) -> SuccessTuple:
         """Write the pickle file for the daemon."""
-        import pickle, traceback
+        import pickle
+        import traceback
         try:
             self.path.mkdir(parents=True, exist_ok=True)
             with open(self.pickle_path, 'wb+') as pickle_file:

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -831,7 +831,6 @@ def pip_install(
 
     """
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
-    from meerschaum.config import get_config
     from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.warnings import warn
     if args is None:
@@ -966,6 +965,10 @@ def pip_install(
 
         if '--target' not in _args and '-t' not in _args and not (not use_uv_pip and _uninstall):
             if venv is not None:
+                vtp = venv_target_path(venv, allow_nonexistent=True, debug=debug)
+                if not vtp.exists():
+                    if not init_venv(venv, force=True):
+                        vtp.mkdir(parents=True, exist_ok=True)
                 _args += ['--target', venv_target_path(venv, debug=debug)]
         elif (
             '--target' not in _args

--- a/meerschaum/utils/venv/_Venv.py
+++ b/meerschaum/utils/venv/_Venv.py
@@ -62,8 +62,13 @@ class Venv:
         If a `meerschaum.plugins.Plugin` was provided, its dependent virtual environments
         will also be activated.
         """
-        from meerschaum.utils.venv import active_venvs
+        from meerschaum.utils.venv import active_venvs, init_venv
         self._kwargs['previously_active_venvs'] = copy.deepcopy(active_venvs)
+        try:
+            return self._activate(debug=(debug or self._debug), **self._kwargs)
+        except OSError as e:
+            if not init_venv(self._venv, force=True):
+                raise e
         return self._activate(debug=(debug or self._debug), **self._kwargs)
 
 

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -176,23 +176,26 @@ def deactivate_venv(
     if sys.path is None:
         return False
 
-    target = venv_target_path(venv, allow_nonexistent=force, debug=debug).as_posix()
+    target = venv_target_path(venv, allow_nonexistent=True, debug=debug).as_posix()
     with LOCKS['sys.path']:
         if target in sys.path:
-            sys.path.remove(target)
+            try:
+                sys.path.remove(target)
+            except Exception:
+                pass
             try:
                 active_venvs_order.remove(venv)
-            except Exception as e:
+            except Exception:
                 pass
 
     return True
 
 
 def is_venv_active(
-        venv: str = 'mrsm',
-        color : bool = True,
-        debug: bool = False
-    ) -> bool:
+    venv: str = 'mrsm',
+    color : bool = True,
+    debug: bool = False
+) -> bool:
     """
     Check if a virtual environment is active.
 
@@ -663,10 +666,10 @@ def venv_exists(venv: Union[str, None], debug: bool = False) -> bool:
 
 
 def venv_target_path(
-        venv: Union[str, None],
-        allow_nonexistent: bool = False,
-        debug: bool = False,
-    ) -> 'pathlib.Path':
+    venv: Union[str, None],
+    allow_nonexistent: bool = False,
+    debug: bool = False,
+) -> 'pathlib.Path':
     """
     Return a virtual environment's site-package path.
 
@@ -683,7 +686,11 @@ def venv_target_path(
     The `pathlib.Path` object for the virtual environment's path.
 
     """
-    import os, sys, platform, pathlib, site
+    import os
+    import sys
+    import platform
+    import pathlib
+    import site
     from meerschaum.config._paths import VIRTENV_RESOURCES_PATH
     from meerschaum.config.static import STATIC_CONFIG
 

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -413,7 +413,7 @@ def init_venv(
         max_lock_seconds = 1.0
         step_sleep_seconds = 0.1
         init_venv_check_start = time.perf_counter()
-        while (time.perf_counter() - init_venv_check_start < max_lock_seconds):
+        while ((time.perf_counter() - init_venv_check_start) < max_lock_seconds):
             if not lock_path.exists():
                 break
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,6 @@ Test Meerschaum jobs.
 """
 
 import time
-import pytest
 
 import meerschaum as mrsm
 
@@ -16,18 +15,16 @@ def test_create_job():
     Test creating and running a new job.
     """
     sysargs = ['show', 'version', ':', '--loop', '--min-seconds', '0.1']
-    job = mrsm.Job(
-        'test', sysargs, executor_keys='local'
-    )
+    job = mrsm.Job('test', sysargs, executor_keys='local')
     job.delete()
     success, msg = job.start()
     assert success, msg
 
-    duration = 4.0
-    time.sleep(duration)
+    time.sleep(4.0)
 
     success, msg = job.stop()
     assert success, msg
+    time.sleep(1.0)
 
     success, msg = job.result
     assert success, msg

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -157,7 +157,6 @@ def test_infer_numeric_dtype(flavor: str):
     Ensure that `Decimal` objects are persisted as `numeric`.
     """
     from meerschaum.utils.formatting import pprint
-    from meerschaum.utils.misc import generate_password
     from meerschaum.utils.dtypes.sql import NUMERIC_PRECISION_FLAVORS
     scale, precision = NUMERIC_PRECISION_FLAVORS.get(
         flavor, NUMERIC_PRECISION_FLAVORS['mssql']
@@ -244,7 +243,6 @@ def test_infer_numeric_from_mixed_types(flavor: str):
     Ensure that new pipes with mixed int and floats as enforced as NUMERIC. 
     """
     from meerschaum.utils.formatting import pprint
-    from meerschaum.utils.misc import generate_password
     conn = conns[flavor]
     pipe = Pipe('test', 'infer_numeric', 'mixed', instance=conn)
     _ = pipe.delete(debug=debug)

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -142,7 +142,7 @@ def test_force_json_dtype(flavor: str):
     success, msg = pipe.sync([
         {'id': 1, 'a': json.dumps(['b', 'c'])},
         {'id': 2, 'a': json.dumps({'b': 1})},
-    ])
+    ], debug=debug)
     assert success, msg
     pprint(pipe.get_columns_types())
     df = pipe.get_data(debug=debug)


### PR DESCRIPTION
- **Add bulk inserts for MSSQL.**  
  To disable this behavior, set `system:connectors:sql:bulk_insert:mssql` to `false`. Bulk inserts for PostgreSQL-like flavors may now be disabled as well.
