### PR TITLE
🔧 v2.7.6 Make temporary table names configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.7.6
+
+- **Make temporary table names configurable.**  
+  The values for temporary SQL tables may be set in `MRSM{system:connectors:sql:instance:temporary_target}`. The new default prefix is `'_'`, and the new default transaction length is 4. The values have been re-ordered to target, transaction ID, then label.
+
+- **Add connector completions to `copy pipes`.**  
+  When copying pipes, the connector keys prompt will offer auto-complete suggestions.
+
+- **Fix stale job results.**  
+  When polling for job results, the job result is dropped from in-memory cache to avoid overwriting the on-disk result.
+
+- **Format row counts and seconds into human-friendly text.**  
+  Row counts and sync durations are now formatted into human-friendly representations.
+
+- **Add digits to `generate_password()`.**  
+  Random strings from `meerschaum.utils.misc.generate_password()` may now contain digits.
+
 ### v2.7.3 – v2.7.5
 
 - **Allow for dynamic targets in SQL queries.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,23 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.7.6
+
+- **Make temporary table names configurable.**  
+  The values for temporary SQL tables may be set in `MRSM{system:connectors:sql:instance:temporary_target}`. The new default prefix is `'_'`, and the new default transaction length is 4. The values have been re-ordered to target, transaction ID, then label.
+
+- **Add connector completions to `copy pipes`.**  
+  When copying pipes, the connector keys prompt will offer auto-complete suggestions.
+
+- **Fix stale job results.**  
+  When polling for job results, the job result is dropped from in-memory cache to avoid overwriting the on-disk result.
+
+- **Format row counts and seconds into human-friendly text.**  
+  Row counts and sync durations are now formatted into human-friendly representations.
+
+- **Add digits to `generate_password()`.**  
+  Random strings from `meerschaum.utils.misc.generate_password()` may now contain digits.
+
 ### v2.7.3 – v2.7.5
 
 - **Allow for dynamic targets in SQL queries.**  

--- a/meerschaum/_internal/shell/Shell.py
+++ b/meerschaum/_internal/shell/Shell.py
@@ -742,8 +742,7 @@ class Shell(cmd.Cmd):
         """
         from meerschaum import get_connector
         from meerschaum.connectors.parse import parse_instance_keys
-        from meerschaum.utils.warnings import warn, info
-        from meerschaum.utils.misc import remove_ansi
+        from meerschaum.utils.warnings import info
 
         if action is None:
             action = []
@@ -829,7 +828,7 @@ class Shell(cmd.Cmd):
         """
         from meerschaum import get_connector
         from meerschaum.connectors.parse import parse_repo_keys
-        from meerschaum.utils.warnings import warn, info
+        from meerschaum.utils.warnings import info
 
         if action is None:
             action = []
@@ -878,7 +877,6 @@ class Shell(cmd.Cmd):
         
         Note that executors are API instances.
         """
-        from meerschaum import get_connector
         from meerschaum.connectors.parse import parse_executor_keys
         from meerschaum.utils.warnings import warn, info
         from meerschaum.jobs import get_executor_keys_from_context
@@ -894,7 +892,7 @@ class Shell(cmd.Cmd):
             executor_keys = get_executor_keys_from_context()
 
         if executor_keys == 'systemd' and get_executor_keys_from_context() != 'systemd':
-            warn(f"Cannot execute via `systemd`, falling back to `local`...", stack=False)
+            warn("Cannot execute via `systemd`, falling back to `local`...", stack=False)
             executor_keys = 'local'
         
         conn = parse_executor_keys(executor_keys, debug=debug)
@@ -935,7 +933,7 @@ class Shell(cmd.Cmd):
         if args['action'][0] not in shell_attrs['_actions']:
             try:
                 print(textwrap.dedent(getattr(self, f"do_{args['action'][0]}").__doc__))
-            except Exception as e:
+            except Exception:
                 print(f"No help on '{args['action'][0]}'.")
             return ""
         parse_help(args)

--- a/meerschaum/_internal/shell/ShellCompleter.py
+++ b/meerschaum/_internal/shell/ShellCompleter.py
@@ -7,13 +7,15 @@ Implement the prompt_toolkit Completer base class.
 """
 
 from __future__ import annotations
-from prompt_toolkit.completion import Completer, Completion
-from meerschaum.utils.typing import Optional
-from meerschaum.actions import get_shell, get_completer, get_main_action_name, get_action
+from meerschaum.actions import get_shell, get_main_action_name, get_action
 from meerschaum._internal.arguments import parse_line
 
 from meerschaum.utils.packages import attempt_import, ensure_readline
-prompt_toolkit = attempt_import('prompt_toolkit', lazy=False, install=True)
+
+prompt_toolkit_completion = attempt_import('prompt_toolkit.completion', lazy=False, install=True)
+Completer = prompt_toolkit_completion.Completer
+Completion = prompt_toolkit_completion.Completion
+
 
 class ShellCompleter(Completer):
     """
@@ -30,7 +32,6 @@ class ShellCompleter(Completer):
         yielded = []
         ensure_readline()
         parts = document.text.split('-')
-        ends_with_space = parts[0].endswith(' ')
         last_action_line = parts[0].split('+')[-1]
         part_0_subbed_spaces = last_action_line.replace(' ', '_')
         parsed_text = (part_0_subbed_spaces + '-'.join(parts[1:]))

--- a/meerschaum/actions/clear.py
+++ b/meerschaum/actions/clear.py
@@ -130,12 +130,15 @@ def _ask_with_rowcounts(
                     )
 
 
-    pipes_rowcounts = {p: p.get_rowcount(begin=begin, end=end, debug=debug) for p in pipes} 
+    pipes_rowcounts = {
+        pipe: pipe.get_rowcount(begin=begin, end=end, debug=debug)
+        for pipe in pipes
+    }
     print_options(
-        [str(p) + f'\n{rc}\n' for p, rc in pipes_rowcounts.items()],
+        [str(pipe) + f'\n{rowcount:,}\n' for pipe, rowcount in pipes_rowcounts.items()],
         header='Number of Rows to be Deleted'
     )
-    total_num_rows = sum([rc for p, rc in pipes_rowcounts.items()])
+    total_num_rows = sum([rowcount for rowcount in pipes_rowcounts.values()])
     question = (
         f"Are you sure you want to delete {total_num_rows:,} rows across {len(pipes)} pipe"
         + ('s' if len(pipes) != 1 else '')

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -282,7 +282,7 @@ def _sync_pipes(
     from meerschaum.utils.formatting._shell import clear_screen
     from meerschaum.utils.formatting import print_pipes_results
     from meerschaum.config.static import STATIC_CONFIG
-    from meercshaum.utils.misc import interval_str
+    from meerschaum.utils.misc import interval_str
 
     noninteractive_val = os.environ.get(STATIC_CONFIG['environment']['noninteractive'], None)
     noninteractive = str(noninteractive_val).lower() in ('1', 'true', 'yes')

--- a/meerschaum/actions/sync.py
+++ b/meerschaum/actions/sync.py
@@ -275,12 +275,14 @@ def _sync_pipes(
     import time
     import os
     import contextlib
+    from datetime import timedelta
 
     from meerschaum.utils.warnings import warn, info
     from meerschaum.utils.formatting._shell import progress
     from meerschaum.utils.formatting._shell import clear_screen
     from meerschaum.utils.formatting import print_pipes_results
     from meerschaum.config.static import STATIC_CONFIG
+    from meercshaum.utils.misc import interval_str
 
     noninteractive_val = os.environ.get(STATIC_CONFIG['environment']['noninteractive'], None)
     noninteractive = str(noninteractive_val).lower() in ('1', 'true', 'yes')
@@ -321,7 +323,7 @@ def _sync_pipes(
                     for pipe, (_success, _msg) in results_dict.items()
                     if not _success
                 ]
-        except Exception as e:
+        except Exception:
             import traceback
             traceback.print_exc()
             warn(
@@ -351,9 +353,9 @@ def _sync_pipes(
         success_msg = (
             "Successfully spawned threads for pipes:"
             if unblock
-            else f"Successfully synced pipes:"
+            else "Successfully synced pipes:"
         )
-        fail_msg = f"Failed to sync pipes:"
+        fail_msg = "Failed to sync pipes:"
         if results_dict:
             print_pipes_results(
                 results_dict,
@@ -362,8 +364,10 @@ def _sync_pipes(
                 nopretty = nopretty,
             )
 
+        lap_duration_text = interval_str(timedelta(seconds=(lap_end - lap_begin)))
+
         msg = (
-            f"It took {round(lap_end - lap_begin, 2)} seconds to sync " +
+            f"It took {lap_duration_text} to sync " +
             f"{len(success_pipes) + len(failure_pipes)} pipe" +
                 ("s" if (len(success_pipes) + len(failure_pipes)) != 1 else "") + "\n" +
             f"    ({len(success_pipes)} succeeded, {len(failure_pipes)} failed)."
@@ -385,26 +389,26 @@ def _sync_pipes(
 
 
 def _wrap_pipe(
-        pipe,
-        unblock: bool = False,
-        force: bool = False,
-        debug: bool = False,
-        min_seconds: int = 1,
-        workers = None,
-        verify: bool = False,
-        deduplicate: bool = False,
-        bounded: Optional[bool] = None,
-        chunk_interval: Union[timedelta, int, None] = None,
-        **kw
-    ):
+    pipe,
+    unblock: bool = False,
+    force: bool = False,
+    debug: bool = False,
+    min_seconds: int = 1,
+    workers = None,
+    verify: bool = False,
+    deduplicate: bool = False,
+    bounded: Optional[bool] = None,
+    chunk_interval: Union[timedelta, int, None] = None,
+    **kw
+):
     """
     Wrapper function for handling exceptions.
     """
     import time
     import traceback
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timezone
     import meerschaum as mrsm
-    from meerschaum.utils.typing import is_success_tuple, SuccessTuple
+    from meerschaum.utils.typing import is_success_tuple
     from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.venv import Venv
     from meerschaum.plugins import _pre_sync_hooks, _post_sync_hooks

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -12,7 +12,6 @@ import shlex
 from textwrap import dedent
 from urllib.parse import urlencode
 
-from dash.dependencies import Input, Output, State
 from meerschaum.utils.typing import List, Optional, Dict, Any, Tuple, Union
 from meerschaum.utils.misc import string_to_dict
 from meerschaum.utils.packages import attempt_import, import_dcc, import_html, import_pandas
@@ -76,7 +75,7 @@ def keys_from_state(
         try:
             #  params = string_to_dict(state['params-textarea.value'])
             params = string_to_dict(state['search-parameters-editor.value'])
-        except Exception as e:
+        except Exception:
             params = None
     else:
         params = None
@@ -506,7 +505,7 @@ def accordion_items_from_pipe(
 
         stats_rows = []
         if rowcount is not None:
-            stats_rows.append(html.Tr([html.Td("Row-count"), html.Td(f"{rowcount}")]))
+            stats_rows.append(html.Tr([html.Td("Row Count"), html.Td(f"{rowcount:,}")]))
         if interval is not None:
             stats_rows.append(
                 html.Tr([html.Td("Timespan"), html.Td(humanfriendly.format_timespan(interval))])

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -76,6 +76,11 @@ default_system_config = {
             },
             'instance': {
                 'stale_temporary_tables_minutes': 1440,
+                'temporary_target': {
+                    'prefix': '_',
+                    'transaction_id_length': 4,
+                    'separator': '_',
+                },
             },
             'chunksize': 100_000,
             'poolclass': 'sqlalchemy.pool.QueuePool',

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.5"
+__version__ = "2.7.6"

--- a/meerschaum/connectors/api/_misc.py
+++ b/meerschaum/connectors/api/_misc.py
@@ -20,11 +20,12 @@ def get_mrsm_version(self, **kw) -> Optional[str]:
             use_token=False,
             **kw
         ).json()
-    except Exception as e:
+    except Exception:
         return None
     if isinstance(j, dict) and 'detail' in j:
         return None
     return j
+
 
 def get_chaining_status(self, **kw) -> Optional[bool]:
     """
@@ -39,7 +40,7 @@ def get_chaining_status(self, **kw) -> Optional[bool]:
         )
         if not response:
             return None
-    except Exception as e:
+    except Exception:
         return None
 
     return response.json()

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -9,8 +9,7 @@ Register or fetch Pipes from the API
 from __future__ import annotations
 import time
 import json
-from io import StringIO
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import meerschaum as mrsm
 from meerschaum.utils.debug import dprint
@@ -178,11 +177,11 @@ def sync_pipe(
     """Sync a DataFrame into a Pipe."""
     from decimal import Decimal
     from meerschaum.utils.debug import dprint
-    from meerschaum.utils.misc import json_serialize_datetime, items_str
+    from meerschaum.utils.misc import json_serialize_datetime, items_str, interval_str
     from meerschaum.config import get_config
     from meerschaum.utils.packages import attempt_import
-    from meerschaum.utils.dataframe import get_numeric_cols, to_json, get_bytes_cols
-    begin = time.time()
+    from meerschaum.utils.dataframe import get_numeric_cols, to_json
+    begin = time.perf_counter()
     more_itertools = attempt_import('more_itertools')
     if df is None:
         msg = f"DataFrame is `None`. Cannot sync {pipe}."
@@ -304,9 +303,10 @@ def sync_pipe(
         num_success_chunks += 1
 
     success_tuple = True, (
-        f"It took {round(time.time() - begin, 2)} seconds to sync {rowcount} row"
+        f"It took {interval_str(timedelta(seconds=(time.perf_counter() - begin)))} "
+        + "to sync {rowcount:,} row"
         + ('s' if rowcount != 1 else '')
-        + f" across {num_success_chunks} chunk" + ('s' if num_success_chunks != 1 else '') +
+        + f" across {num_success_chunks:,} chunk" + ('s' if num_success_chunks != 1 else '') +
         f" to {pipe}."
     )
     return success_tuple
@@ -549,10 +549,9 @@ def create_metadata(
     if debug:
         dprint("Create metadata response: {response.text}")
     try:
-        metadata_response = json.loads(response.text)
+        _ = json.loads(response.text)
     except Exception as e:
         warn(f"Failed to create metadata on {self}:\n{e}")
-        metadata_response = False
     return False
 
 

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -69,6 +69,7 @@ class SQLConnector(Connector):
         get_pipe_schema,
         create_pipe_table_from_df,
         get_pipe_columns_indices,
+        get_temporary_target,
     )
     from ._plugins import (
         register_plugin,

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -778,6 +778,7 @@ def to_sql(
     import time
     import json
     from decimal import Decimal
+    from datetime import timedelta
     from meerschaum.utils.warnings import error, warn
     import warnings
     import functools
@@ -816,6 +817,7 @@ def to_sql(
         PD_TO_SQLALCHEMY_DTYPES_FLAVORS,
         get_db_type_from_pd_type,
     )
+    from meerschaum.utils.misc import interval_str
     from meerschaum.connectors.sql._create_engine import flavor_configs
     from meerschaum.utils.packages import attempt_import, import_pandas
     sqlalchemy = attempt_import('sqlalchemy', debug=debug)
@@ -998,7 +1000,13 @@ def to_sql(
 
     end = time.perf_counter()
     if success:
-        msg = f"It took {round(end - start, 2)} seconds to sync {len(df)} rows to {name}."
+        num_rows = len(df)
+        msg = (
+            f"It took {interval_str(timedelta(seconds=(end - start)))} "
+            + f"to sync {num_rows:,} row"
+            + ('s' if num_rows != 1 else '')
+            + f" to {name}."
+        )
     stats['start'] = start
     stats['end'] = end
     stats['duration'] = end - start

--- a/meerschaum/jobs/_Job.py
+++ b/meerschaum/jobs/_Job.py
@@ -313,6 +313,7 @@ class Job:
         if not cleanup_success:
             return cleanup_success, cleanup_msg
 
+        _ = self.daemon._properties.pop('result', None)
         return cleanup_success, f"Deleted {self}."
 
     def is_running(self) -> bool:

--- a/meerschaum/plugins/__init__.py
+++ b/meerschaum/plugins/__init__.py
@@ -126,8 +126,8 @@ def pre_sync_hook(
 
 
 def post_sync_hook(
-        function: Callable[[Any], Any],
-    ) -> Callable[[Any], Any]:
+    function: Callable[[Any], Any],
+) -> Callable[[Any], Any]:
     """
     Register a function as a sync hook to be executed upon completion of a sync.
     
@@ -143,10 +143,14 @@ def post_sync_hook(
     Examples
     --------
     >>> from meerschaum.plugins import post_sync_hook
+    >>> from meerschaum.utils.misc import interval_str
+    >>> from datetime import timedelta
     >>>
     >>> @post_sync_hook
     ... def log_sync(pipe, success_tuple, duration=None, **kwargs):
-    ...     print(f"It took {round(duration, 2)} seconds to sync {pipe}.")
+    ...     duration_delta = timedelta(seconds=duration)
+    ...     duration_text = interval_str(duration_delta)
+    ...     print(f"It took {duration_text} to sync {pipe}.")
     >>>
     """
     with _locks['_post_sync_hooks']:

--- a/meerschaum/utils/daemon/Daemon.py
+++ b/meerschaum/utils/daemon/Daemon.py
@@ -1017,7 +1017,8 @@ class Daemon:
 
     def read_pickle(self) -> Daemon:
         """Read a Daemon's pickle file and return the `Daemon`."""
-        import pickle, traceback
+        import pickle
+        import traceback
         if not self.pickle_path.exists():
             error(f"Pickle file does not exist for daemon '{self.daemon_id}'.")
 
@@ -1052,6 +1053,9 @@ class Daemon:
 
         if self._properties is None:
             self._properties = {}
+
+        if self._properties.get('result', None) is None:
+            _ = self._properties.pop('result', None)
 
         if _file_properties is not None:
             self._properties = apply_patch_to_config(

--- a/meerschaum/utils/daemon/__init__.py
+++ b/meerschaum/utils/daemon/__init__.py
@@ -37,7 +37,7 @@ def daemon_entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
     filtered_sysargs = [arg for arg in sysargs if arg not in ('-d', '--daemon')]
     try:
         label = shlex.join(filtered_sysargs) if sysargs else None
-    except Exception as e:
+    except Exception:
         label = ' '.join(filtered_sysargs) if sysargs else None
 
     name = _args.get('name', None)
@@ -45,7 +45,7 @@ def daemon_entry(sysargs: Optional[List[str]] = None) -> SuccessTuple:
     if name:
         try:
             daemon = Daemon(daemon_id=name)
-        except Exception as e:
+        except Exception:
             daemon = None
 
     if daemon is not None:

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -90,20 +90,21 @@ def add_method_to_class(
 
 
 def generate_password(length: int = 12) -> str:
-    """Generate a secure password of given length.
+    """
+    Generate a secure password of given length.
 
     Parameters
     ----------
-    length : int, default 12
+    length: int, default 12
         The length of the password.
 
     Returns
     -------
     A random password string.
-
     """
-    import secrets, string
-    return ''.join((secrets.choice(string.ascii_letters) for i in range(length)))
+    import secrets
+    import string
+    return ''.join((secrets.choice(string.ascii_letters + string.digits) for i in range(length)))
 
 def is_int(s : str) -> bool:
     """
@@ -121,7 +122,7 @@ def is_int(s : str) -> bool:
     """
     try:
         float(s)
-    except Exception as e:
+    except Exception:
         return False
     
     return float(s).is_integer()

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -337,14 +337,14 @@ def get_install_no_version(install_name: str) -> str:
 
 import_versions = {}
 def determine_version(
-        path: pathlib.Path,
-        import_name: Optional[str] = None,
-        venv: Optional[str] = 'mrsm',
-        search_for_metadata: bool = True,
-        split: bool = True,
-        warn: bool = False,
-        debug: bool = False,
-    ) -> Union[str, None]:
+    path: pathlib.Path,
+    import_name: Optional[str] = None,
+    venv: Optional[str] = 'mrsm',
+    search_for_metadata: bool = True,
+    split: bool = True,
+    warn: bool = False,
+    debug: bool = False,
+) -> Union[str, None]:
     """
     Determine a module's `__version__` string from its filepath.
     
@@ -381,11 +381,8 @@ def determine_version(
     with _locks['import_versions']:
         if venv not in import_versions:
             import_versions[venv] = {}
-    import importlib.metadata
-    import re, os
+    import os
     old_cwd = os.getcwd()
-    if debug:
-        from meerschaum.utils.debug import dprint
     from meerschaum.utils.warnings import warn as warn_function
     if import_name is None:
         import_name = path.parent.stem if path.stem == '__init__' else path.stem
@@ -395,7 +392,10 @@ def determine_version(
     _version = None
     module_parent_dir = (
         path.parent.parent if path.stem == '__init__' else path.parent
-    ) if path is not None else venv_target_path(venv, debug=debug)
+    ) if path is not None else venv_target_path(venv, allow_nonexistent=True, debug=debug)
+
+    if not module_parent_dir.exists():
+        return None
 
     installed_dir_name = _import_to_dir_name(import_name)
     clean_installed_dir_name = installed_dir_name.lower().replace('-', '_')
@@ -403,7 +403,11 @@ def determine_version(
     ### First, check if a dist-info directory exists.
     _found_versions = []
     if search_for_metadata:
-        for filename in os.listdir(module_parent_dir):
+        try:
+            filenames = os.listdir(module_parent_dir)
+        except FileNotFoundError:
+            filenames = []
+        for filename in filenames:
             if not filename.endswith('.dist-info'):
                 continue
             filename_lower = filename.lower()
@@ -430,7 +434,7 @@ def determine_version(
         try:
             os.chdir(module_parent_dir)
             _version = importlib_metadata.metadata(import_name)['Version']
-        except Exception as e:
+        except Exception:
             _version = None
         finally:
             os.chdir(old_cwd)

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -698,7 +698,7 @@ def need_update(
             (not semver.Version.parse(version).match(required_version))
             if required_version else False
         )
-    except AttributeError as e:
+    except AttributeError:
         pip_install(_import_to_install_name('semver'), venv='mrsm', debug=debug)
         semver = manually_import_module('semver', venv='mrsm', debug=debug)
         return (
@@ -724,10 +724,10 @@ def need_update(
 
 
 def get_pip(
-        venv: Optional[str] = 'mrsm',
-        color: bool = True,
-        debug: bool = False,
-    ) -> bool:
+    venv: Optional[str] = 'mrsm',
+    color: bool = True,
+    debug: bool = False,
+) -> bool:
     """
     Download and run the get-pip.py script.
 
@@ -747,7 +747,8 @@ def get_pip(
     A bool indicating success.
 
     """
-    import sys, subprocess
+    import sys
+    import subprocess
     from meerschaum.utils.misc import wget
     from meerschaum.config._paths import CACHE_RESOURCES_PATH
     from meerschaum.config.static import STATIC_CONFIG
@@ -755,7 +756,7 @@ def get_pip(
     dest = CACHE_RESOURCES_PATH / 'get-pip.py'
     try:
         wget(url, dest, color=False, debug=debug)
-    except Exception as e:
+    except Exception:
         print(f"Failed to fetch pip from '{url}'. Please install pip and restart Meerschaum.") 
         sys.exit(1)
     if venv is not None:
@@ -776,6 +777,7 @@ def pip_install(
     _uninstall: bool = False,
     _from_completely_uninstall: bool = False,
     _install_uv_pip: bool = True,
+    _use_uv_pip: bool = True,
     color: bool = True,
     silent: bool = False,
     debug: bool = False,
@@ -835,10 +837,7 @@ def pip_install(
     from meerschaum.utils.warnings import warn
     if args is None:
         args = ['--upgrade'] if not _uninstall else []
-    if color:
-        ANSI, UNICODE = True, True
-    else:
-        ANSI, UNICODE = False, False
+    ANSI = True if color else False
     if check_wheel:
         have_wheel = venv_contains_package('wheel', venv=venv, debug=debug)
 
@@ -877,7 +876,8 @@ def pip_install(
             )
 
     use_uv_pip = (
-        venv_contains_package('uv', venv=None, debug=debug)
+        _use_uv_pip
+        and venv_contains_package('uv', venv=None, debug=debug)
         and uv_bin is not None
         and venv is not None
         and is_uv_enabled()

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -136,7 +136,7 @@ packages['sql'] = {
     'numpy'                          : 'numpy>=1.18.5',
     'pandas'                         : 'pandas[parquet]>=2.0.1',
     'pyarrow'                        : 'pyarrow>=16.1.0',
-    'dask'                           : 'dask[complete]>=2024.5.1',
+    'dask'                           : 'dask[complete]>=2024.12.1',
     'partd'                          : 'partd>=1.4.2',
     'pytz'                           : 'pytz',
     'joblib'                         : 'joblib>=0.17.0',

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -455,6 +455,15 @@ def init_venv(
             print(f"Moving '{vtp}' to '{temp_vtp}'...")
         shutil.move(vtp, temp_vtp)
 
+    if venv_path.exists():
+        if debug:
+            print(f"Removing '{venv_path}'...")
+        try:
+            shutil.rmtree(venv_path)
+        except Exception as e:
+            if debug:
+                print(f"Failed to remove '{venv_path}' ({e}). Continuing...")
+
     wait_for_lock()
     update_lock(True)
 

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -410,7 +410,7 @@ def init_venv(
             pass
 
     def wait_for_lock():
-        max_lock_seconds = 1.0
+        max_lock_seconds = 2.0
         step_sleep_seconds = 0.1
         init_venv_check_start = time.perf_counter()
         while ((time.perf_counter() - init_venv_check_start) < max_lock_seconds):
@@ -450,6 +450,9 @@ def init_venv(
     temp_vtp = VENVS_CACHE_RESOURCES_PATH / str(venv)
     rename_vtp = vtp.exists() and not temp_vtp.exists()
 
+    wait_for_lock()
+    update_lock(True)
+
     if rename_vtp:
         if debug:
             print(f"Moving '{vtp}' to '{temp_vtp}'...")
@@ -463,9 +466,6 @@ def init_venv(
         except Exception as e:
             if debug:
                 print(f"Failed to remove '{venv_path}' ({e}). Continuing...")
-
-    wait_for_lock()
-    update_lock(True)
 
     if uv is not None:
         _venv_success = run_python_package(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -20,11 +20,11 @@ def test_create_job():
     success, msg = job.start()
     assert success, msg
 
-    time.sleep(4.0)
+    time.sleep(1.0)
 
     success, msg = job.stop()
     assert success, msg
-    time.sleep(1.0)
+    time.sleep(0.1)
 
     success, msg = job.result
     assert success, msg

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -20,7 +20,7 @@ def test_create_job():
     success, msg = job.start()
     assert success, msg
 
-    time.sleep(1.0)
+    time.sleep(4.0)
 
     success, msg = job.stop()
     assert success, msg

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -465,7 +465,6 @@ def test_mixed_offset_datetimes_sql(flavor: str):
     assert success, msg
 
     assert inplace_pipe.get_rowcount(debug=debug) == pipe.get_rowcount(debug=debug)
-    return pipe, inplace_pipe
 
 
 @pytest.mark.parametrize("flavor", get_flavors())


### PR DESCRIPTION
# v2.7.6

- **Make temporary table names configurable.**  
  The values for temporary SQL tables may be set in `MRSM{system:connectors:sql:instance:temporary_target}`. The new default prefix is `'_'`, and the new default transaction length is 4. The values have been re-ordered to target, transaction ID, then label.

- **Add connector completions to `copy pipes`.**  
  When copying pipes, the connector keys prompt will offer auto-complete suggestions.

- **Fix stale job results.**  
  When polling for job results, the job result is dropped from in-memory cache to avoid overwriting the on-disk result.

- **Format row counts and seconds into human-friendly text.**  
  Row counts and sync durations are now formatted into human-friendly representations.

- **Add digits to `generate_password()`.**  
  Random strings from `meerschaum.utils.misc.generate_password()` may now contain digits.
