### PR TITLE
⚡️ v2.7.7 Index performance improvements, add `drop indices` and `index pipes`, and more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.7.7
+
+- **Add actions `drop indices` and `index pipes`.**  
+  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `index()`:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe('demo', 'drop_indices', columns=['id'], instance='sql:local')
+  pipe.sync([{'id': 1}])
+  print(pipe.get_columns_indices())
+  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
+
+  pipe.drop_indices()
+  print(pipe.get_columns_indices())
+  # {}
+
+  pipe.index()
+  print(pipe.get_columns_indices())
+  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
+  ```
+
+- **Remove `CAST()` to datetime with selecting from a pipe's definition.**  
+  For some databases, casting to the same dtype causes the query optimizer to ignore the datetime index.
+
+- **Add `INCLUDE` clause to datetime index for MSSQL.**  
+  This is to coax the query optimizer into using the datetime axis.
+
+- **Remove redundant unique index.**  
+  The two competing unique indices have been combined into a single index (for the key `unique`). The unique constraint (when `upsert` is true) shares the name but has the prefix `UQ_` in place of `IX_`.
+
+- **Add pipe parameter `null_indices`.**  
+  Set the pipe parameter `null_indices` to `False` for a performance improvement in situations where null index values are not expected.
+
+- **Apply backtrack minutes when fetching integer datetimes.**  
+  Backtrack minutes are now applied to pipes with integer datetimes axes.
+
 ### v2.7.6
 
 - **Make temporary table names configurable.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.7.7
 
 - **Add actions `drop indices` and `index pipes`.**  
-  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `index()`:
+  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `create_indices()`:
 
   ```python
   import meerschaum as mrsm
@@ -21,7 +21,7 @@ This is the current release cycle, so stay tuned for future releases!
   print(pipe.get_columns_indices())
   # {}
 
-  pipe.index()
+  pipe.create_indices()
   print(pipe.get_columns_indices())
   # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
   ```

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,43 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.7.7
+
+- **Add actions `drop indices` and `index pipes`.**  
+  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `index()`:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe('demo', 'drop_indices', columns=['id'], instance='sql:local')
+  pipe.sync([{'id': 1}])
+  print(pipe.get_columns_indices())
+  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
+
+  pipe.drop_indices()
+  print(pipe.get_columns_indices())
+  # {}
+
+  pipe.index()
+  print(pipe.get_columns_indices())
+  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
+  ```
+
+- **Remove `CAST()` to datetime with selecting from a pipe's definition.**  
+  For some databases, casting to the same dtype causes the query optimizer to ignore the datetime index.
+
+- **Add `INCLUDE` clause to datetime index for MSSQL.**  
+  This is to coax the query optimizer into using the datetime axis.
+
+- **Remove redundant unique index.**  
+  The two competing unique indices have been combined into a single index (for the key `unique`). The unique constraint (when `upsert` is true) shares the name but has the prefix `UQ_` in place of `IX_`.
+
+- **Add pipe parameter `null_indices`.**  
+  Set the pipe parameter `null_indices` to `False` for a performance improvement in situations where null index values are not expected.
+
+- **Apply backtrack minutes when fetching integer datetimes.**  
+  Backtrack minutes are now applied to pipes with integer datetimes axes.
+
 ### v2.7.6
 
 - **Make temporary table names configurable.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -7,7 +7,7 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.7.7
 
 - **Add actions `drop indices` and `index pipes`.**  
-  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `index()`:
+  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `create_indices()`:
 
   ```python
   import meerschaum as mrsm
@@ -21,7 +21,7 @@ This is the current release cycle, so stay tuned for future releases!
   print(pipe.get_columns_indices())
   # {}
 
-  pipe.index()
+  pipe.create_indices()
   print(pipe.get_columns_indices())
   # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
   ```

--- a/docs/mkdocs/reference/connectors/instance-connectors.md
+++ b/docs/mkdocs/reference/connectors/instance-connectors.md
@@ -491,9 +491,9 @@ You may use the built-in method [`pipe.filter_existing()`](https://docs.meerscha
 
 For situations where the source and instance connectors are the same, the method `#!python sync_pipe_inplace()` allows you to bypass loading DataFrames into RAM and instead handle the syncs remotely. See the [`#!python SQLConnector.sync_pipe_inplace()`](https://docs.meerschaum.io/connectors/sql/SQLConnector.html#meerschaum.connectors.sql.SQLConnector.SQLConnector.sync_pipe_inplace) method for reference.
 
-### `#!python index_pipe()` (optional)
+### `#!python create_pipe_indices()` (optional)
 
-If syncing to your instance connector involves indexing a pipe's target table, you may find it useful to implement the methods `index_pipe()`. See the method [`#!python SQLConnector.index_pipe()`](https://docs.meerschaum.io/meerschaum/connectors.html#SQLConnector.index_pipe) for reference.
+If syncing to your instance connector involves indexing a pipe's target table, you may find it useful to implement the method `create_pipe_indices()`. See the method [`#!python SQLConnector.create_pipe_indices()`](https://docs.meerschaum.io/meerschaum/connectors.html#SQLConnector.create_pipe_indices) for reference.
 
 
 ## `#!python clear_pipe()`

--- a/docs/mkdocs/reference/pipes/parameters.md
+++ b/docs/mkdocs/reference/pipes/parameters.md
@@ -120,6 +120,10 @@ parameters:
     FROM weather
 ```
 
+## `null_indices`
+
+Toggle whether a pipe will allow null indices (default `True`). Set this to `False` for a performance improvement in situations where null index values are not expected.
+
 ## `tags`
 
 A list of a pipe's [tags](/reference/pipes/tags/), e.g.:

--- a/meerschaum/actions/drop.py
+++ b/meerschaum/actions/drop.py
@@ -6,52 +6,65 @@ Functions for dropping elements
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, Union, Any, Optional, Sequence, List
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
+
 
 def drop(
-        action: Optional[List[str]] = None,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
     """
     Drop pipe data (maintaining registration) or tables.
     """
     from meerschaum.actions import choose_subaction
     options = {
         'pipes'  : _drop_pipes,
+        'indices': _drop_indices,
+        'index': _drop_indices,
+        'indexes': _drop_indices,
     }
     return choose_subaction(action, options, **kw)
 
 
 def _drop_pipes(
-        action: Optional[List[str]] = None,
-        yes: bool = False,
-        force: bool = False,
-        noask: bool = False,
-        debug: bool = False,
-        **kw: Any
-    ) -> SuccessTuple:
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
     """
     Drop pipes' tables but keep pipe metadata registration.
     """
-    from meerschaum.utils.prompt import prompt, yes_no
+    from meerschaum.utils.prompt import yes_no
     from meerschaum import get_pipes
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.formatting import pprint
+
     pipes = get_pipes(as_list=True, debug=debug, **kw)
     if len(pipes) == 0:
         return False, "No pipes to drop."
+
     question = (
         "Are you sure you want to drop these tables?\n    "
-        + "Data will be lost and will need to be resynced.\n\n"
+        "Data will be lost and will need to be resynced.\n\n"
     )
-    for p in pipes:
-        question += f"    - {p.target}" + "\n"
+    seen_targets = set()
+    for pipe in pipes:
+        target = pipe.target
+        if target in seen_targets:
+            continue
+        question += f"    - {target}" + "\n"
+        seen_targets.add(target)
+
     question += '\n'
     if force:
         answer = True
     else:
         answer = yes_no(question, default='n', noask=noask, yes=yes)
+
     if not answer:
         return False, "No pipes were dropped."
 
@@ -59,22 +72,87 @@ def _drop_pipes(
     successes, fails = 0, 0
     msg = ""
 
-    for p in pipes:
-        success_tup = p.drop(debug=debug)
-        success_dict[p] = success_tup[1]
-        if success_tup[0]:
+    for pipe in pipes:
+        drop_success, drop_msg = pipe.drop(debug=debug)
+        success_dict[pipe] = drop_msg
+        if drop_success:
             successes += 1
         else:
             fails += 1
-            warn(success_tup[1], stack=False)
+            warn(drop_msg, stack=False)
     
     if debug:
         dprint("Results for dropping pipes.")
         pprint(success_dict)
 
     msg = (
-        f"Finished dropping {len(pipes)} pipes\n" + 
-        f"    ({successes} succeeded, {fails} failed)."
+        f"Finished dropping {len(pipes)} pipes"
+        + ('s' if len(pipes) != 1 else '')
+        + f"\n    ({successes} succeeded, {fails} failed)."
+    )
+    return successes > 0, msg
+
+
+def _drop_indices(
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Drop pipes' tables but keep pipe metadata registration.
+    """
+    from meerschaum.utils.prompt import yes_no
+    from meerschaum import get_pipes
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.debug import dprint
+    from meerschaum.utils.formatting import pprint
+
+    pipes = get_pipes(as_list=True, debug=debug, **kw)
+    if len(pipes) == 0:
+        return False, "No pipes to drop."
+
+    question = "Are you sure you want to drop these indices?\n\n"
+    for pipe in pipes:
+        indices = pipe.get_indices()
+        if not indices:
+            continue
+        question += f"{pipe}\n"
+        for ix_key, index_name in indices.items():
+            question += f"    - {index_name}\n"
+
+    question += '\n'
+    if force:
+        answer = True
+    else:
+        answer = yes_no(question, default='n', noask=noask, yes=yes)
+
+    if not answer:
+        return False, "No pipes were dropped."
+
+    success_dict = {}
+    successes, fails = 0, 0
+    msg = ""
+
+    for pipe in pipes:
+        drop_success, drop_msg = pipe.drop_indices(debug=debug)
+        success_dict[pipe] = drop_msg
+        if drop_success:
+            successes += 1
+        else:
+            fails += 1
+            warn(drop_msg, stack=False)
+    
+    if debug:
+        dprint("Results for dropping indices.")
+        pprint(success_dict)
+
+    msg = (
+        f"Finished dropping indices for {len(pipes)} pipe"
+        + ('s' if len(pipes) != 1 else '')
+        + f"\n    ({successes} succeeded, {fails} failed)."
     )
     return successes > 0, msg
 

--- a/meerschaum/actions/drop.py
+++ b/meerschaum/actions/drop.py
@@ -114,12 +114,12 @@ def _drop_indices(
     if len(pipes) == 0:
         return False, "No pipes to drop."
 
-    question = "Are you sure you want to drop these indices?\n\n"
+    question = "Are you sure you want to drop these indices?\n"
     for pipe in pipes:
         indices = pipe.get_indices()
         if not indices:
             continue
-        question += f"{pipe}\n"
+        question += f"\n{pipe}\n"
         for ix_key, index_name in indices.items():
             question += f"    - {index_name}\n"
 

--- a/meerschaum/actions/index.py
+++ b/meerschaum/actions/index.py
@@ -36,7 +36,7 @@ def _index_pipes(
     Create pipes' indices.
     """
     from meerschaum import get_pipes
-    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.warnings import warn, info
 
     pipes = get_pipes(as_list=True, debug=debug, **kw)
     if len(pipes) == 0:
@@ -47,7 +47,8 @@ def _index_pipes(
     msg = ""
 
     for pipe in pipes:
-        index_success, index_msg = pipe.index(debug=debug)
+        info(f"Creating indices for {pipe}...")
+        index_success, index_msg = pipe.create_indices(debug=debug)
         success_dict[pipe] = index_msg
         if index_success:
             successes += 1

--- a/meerschaum/actions/index.py
+++ b/meerschaum/actions/index.py
@@ -1,0 +1,70 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Functions for indexing tables.
+"""
+
+from __future__ import annotations
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
+
+
+def index(
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Create pipes' indices.
+    """
+    from meerschaum.actions import choose_subaction
+    options = {
+        'pipes'  : _index_pipes,
+    }
+    return choose_subaction(action, options, **kw)
+
+
+def _index_pipes(
+    action: Optional[List[str]] = None,
+    yes: bool = False,
+    force: bool = False,
+    noask: bool = False,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Create pipes' indices.
+    """
+    from meerschaum import get_pipes
+    from meerschaum.utils.warnings import warn
+
+    pipes = get_pipes(as_list=True, debug=debug, **kw)
+    if len(pipes) == 0:
+        return False, "No pipes to index."
+
+    success_dict = {}
+    successes, fails = 0, 0
+    msg = ""
+
+    for pipe in pipes:
+        index_success, index_msg = pipe.index(debug=debug)
+        success_dict[pipe] = index_msg
+        if index_success:
+            successes += 1
+        else:
+            fails += 1
+            warn(index_msg, stack=False)
+    
+    msg = (
+        f"Finished indexing {len(pipes)} pipes"
+        + ('s' if len(pipes) != 1 else '')
+        + f"\n    ({successes} succeeded, {fails} failed)."
+    )
+    return successes > 0, msg
+
+
+### NOTE: This must be the final statement of the module.
+###       Any subactions added below these lines will not
+###       be added to the `help` docstring.
+from meerschaum.actions import choices_docstring as _choices_docstring
+index.__doc__ += _choices_docstring('index')

--- a/meerschaum/actions/register.py
+++ b/meerschaum/actions/register.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import meerschaum as mrsm
 from meerschaum.utils.typing import SuccessTuple, Any, List, Optional, Dict
 
+
 def register(
     action: Optional[List[str]] = None,
     **kw: Any
@@ -70,10 +71,9 @@ def _register_pipes(
         `connector_keys` and `metric_keys`.
         If `location_keys` is empty, assume [`None`].
     """
-    from meerschaum import get_pipes, get_connector
+    from meerschaum import get_pipes
     from meerschaum.utils.debug import dprint
-    from meerschaum.utils.warnings import warn, info
-    from meerschaum.utils.misc import items_str
+    from meerschaum.utils.warnings import warn
     from meerschaum.config._patch import apply_patch_to_config
 
     if connector_keys is None:
@@ -164,10 +164,8 @@ def _register_plugins(
     from meerschaum.utils.debug import dprint
     from meerschaum.plugins import reload_plugins, get_plugins_names
     from meerschaum.connectors.parse import parse_repo_keys
-    from meerschaum.config import get_config
-    from meerschaum.utils.warnings import warn, error, info
+    from meerschaum.utils.warnings import warn, info
     from meerschaum.core import Plugin
-    from meerschaum import get_connector
     from meerschaum.utils.formatting import print_tuple
     from meerschaum.utils.prompt import prompt, yes_no
 
@@ -179,7 +177,7 @@ def _register_plugins(
     repo_connector = parse_repo_keys(repository)
     if repo_connector.__dict__.get('type', None) != 'api':
         return False, (
-            f"Can only upload plugins to the Meerschaum API." +
+            "Can only upload plugins to the Meerschaum API." +
             f"Connector '{repo_connector}' is of type " +
             f"'{repo_connector.get('type', type(repo_connector))}'."
         )
@@ -283,13 +281,11 @@ def _register_users(
     """
     from meerschaum.config import get_config
     from meerschaum.config.static import STATIC_CONFIG
-    from meerschaum import get_connector
     from meerschaum.connectors.parse import parse_instance_keys
-    from meerschaum.utils.debug import dprint
-    from meerschaum.utils.warnings import warn, error, info
+    from meerschaum.utils.warnings import warn, info
     from meerschaum.core import User
     from meerschaum.utils.formatting import print_tuple
-    from meerschaum.utils.prompt import prompt, get_password, get_email
+    from meerschaum.utils.prompt import get_password, get_email
     if mrsm_instance is None:
         mrsm_instance = get_config('meerschaum', 'instance')
     instance_connector = parse_instance_keys(mrsm_instance)
@@ -325,7 +321,7 @@ def _register_users(
                 minimum_length = STATIC_CONFIG['users']['min_password_length']
             )
             email = get_email(username, allow_omit=True)
-        except Exception as e:
+        except Exception:
             return False, (
                 "Aborted registering users " +
                 ', '.join(

--- a/meerschaum/actions/sql.py
+++ b/meerschaum/actions/sql.py
@@ -127,7 +127,7 @@ def sql(
     
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.formatting import print_tuple, pprint
-    _ = attempt_import('sqlalchemy.engine.result')
+    _ = attempt_import('sqlalchemy.engine.result', lazy=False)
     if 'sqlalchemy' in str(type(result)):
         if not nopretty:
             print_tuple((True, f"Successfully executed query:\n\n{query}"))

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -688,3 +688,21 @@ def get_pipe_columns_indices(
     Return a dictionary of column names and related indices.
     """
     return get_pipe(connector_keys, metric_key, location_key).get_columns_indices()
+
+
+@app.get(
+    pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/indices/names',
+    tags=['Pipes']
+)
+def get_pipe_index_names(
+    connector_keys: str,
+    metric_key: str,
+    location_key: str,
+    curr_user=(
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> Dict[str, List[Dict[str, str]]]:
+    """
+    Return a dictionary of index keys and index names.
+    """
+    return get_pipe(connector_keys, metric_key, location_key).get_indices()

--- a/meerschaum/api/routes/_plugins.py
+++ b/meerschaum/api/routes/_plugins.py
@@ -29,7 +29,7 @@ from meerschaum.core import Plugin
 starlette_responses = attempt_import('starlette.responses', warn=False)
 FileResponse = starlette_responses.FileResponse
 
-sqlalchemy = attempt_import('sqlalchemy')
+sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 plugins_endpoint = endpoints['plugins']
 
 @app.post(plugins_endpoint + '/{name}', tags=['Plugins'])

--- a/meerschaum/api/routes/_users.py
+++ b/meerschaum/api/routes/_users.py
@@ -7,36 +7,34 @@ Routes for managing users
 """
 
 from __future__ import annotations
+
 from meerschaum.utils.typing import (
-    Optional, Union, SuccessTuple, Any, Mapping, Sequence, Dict, List
+    Union, SuccessTuple, Any, Dict, List
 )
 
 from meerschaum.utils.packages import attempt_import
 from meerschaum.api import (
-    fastapi, app, endpoints, get_api_connector, pipes, get_pipe,
-    manager, debug, check_allow_chaining, DISALLOW_CHAINING_MESSAGE,
+    fastapi, app, endpoints, get_api_connector, manager,
+    debug, check_allow_chaining, DISALLOW_CHAINING_MESSAGE,
     no_auth, private,
 )
 from meerschaum.utils.misc import string_to_dict
 from meerschaum.config import get_config
-from meerschaum.api.tables import get_tables
-from starlette.responses import Response, JSONResponse
 from meerschaum.core import User
-import os, pathlib, datetime
 
-import meerschaum.core
-sqlalchemy = attempt_import('sqlalchemy')
+sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 users_endpoint = endpoints['users']
 
 import fastapi
 from fastapi import HTTPException, Form
 
+
 @app.get(users_endpoint + "/me", tags=['Users'])
 def read_current_user(
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> Dict[str, Union[str, int]]:
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> Dict[str, Union[str, int]]:
     """
     Get information about the currently logged-in user.
     """
@@ -58,12 +56,13 @@ def read_current_user(
         ),
     }
 
+
 @app.get(users_endpoint, tags=['Users'])
 def get_users(
-        curr_user = (
-            fastapi.Depends(manager) if private else None
-        ),
-    ) -> List[str]:
+    curr_user = (
+        fastapi.Depends(manager) if private else None
+    ),
+) -> List[str]:
     """
     Get a list of the registered users.
     """
@@ -72,15 +71,15 @@ def get_users(
 
 @app.post(users_endpoint + "/register", tags=['Users'])
 def register_user(
-        username: str = Form(None),
-        password: str = Form(None),
-        attributes: str = Form(None),
-        type: str = Form(None),
-        email: str = Form(None),
-        curr_user = (
-            fastapi.Depends(manager) if private else None
-        ),
-    ) -> SuccessTuple:
+    username: str = Form(None),
+    password: str = Form(None),
+    attributes: str = Form(None),
+    type: str = Form(None),
+    email: str = Form(None),
+    curr_user = (
+        fastapi.Depends(manager) if private else None
+    ),
+) -> SuccessTuple:
     """
     Register a new user.
     """
@@ -90,7 +89,7 @@ def register_user(
     if attributes is not None:
         try:
             attributes = string_to_dict(attributes)
-        except Exception as e:
+        except Exception:
             return False, f"Invalid dictionary string received for attributes."
 
     allow_users = get_config('system', 'api', 'permissions', 'registration', 'users')
@@ -114,22 +113,22 @@ def register_user(
 
 @app.post(users_endpoint + "/edit", tags=['Users'])
 def edit_user(
-        username: str = Form(None),
-        password: str = Form(None),
-        type: str = Form(None),
-        email: str = Form(None),
-        attributes: str = Form(None),
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> SuccessTuple:
+    username: str = Form(None),
+    password: str = Form(None),
+    type: str = Form(None),
+    email: str = Form(None),
+    attributes: str = Form(None),
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> SuccessTuple:
     """
     Edit an existing user.
     """
     if attributes is not None:
         try:
             attributes = string_to_dict(attributes)
-        except Exception as e:
+        except Exception:
             return False, f"Invalid dictionary string received for attributes."
 
     user = User(username, password, email=email, attributes=attributes)
@@ -144,11 +143,11 @@ def edit_user(
 
 @app.get(users_endpoint + "/{username}/id", tags=['Users'])
 def get_user_id(
-        username : str,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> Union[int, None]:
+    username : str,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> Union[int, None]:
     """
     Get a user's ID.
     """
@@ -157,23 +156,24 @@ def get_user_id(
 
 @app.get(users_endpoint + "/{username}/attributes", tags=['Users'])
 def get_user_attributes(
-        username : str,
-        curr_user = (
-            fastapi.Depends(manager) if private else None
-        ),
-    ) -> Union[Dict[str, Any], None]:
+    username : str,
+    curr_user = (
+        fastapi.Depends(manager) if private else None
+    ),
+) -> Union[Dict[str, Any], None]:
     """
     Get a user's attributes.
     """
     return get_api_connector().get_user_attributes(User(username), debug=debug)
 
+
 @app.delete(users_endpoint + "/{username}", tags=['Users'])
 def delete_user(
-        username: str,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> SuccessTuple:
+    username: str,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> SuccessTuple:
     """
     Delete a user.
     """
@@ -193,11 +193,11 @@ def delete_user(
 
 @app.get(users_endpoint + '/{username}/password_hash', tags=['Users'])
 def get_user_password_hash(
-        username: str,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> str:
+    username: str,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> str:
     """
     If configured to allow chaining, return a user's password_hash.
     """
@@ -205,13 +205,14 @@ def get_user_password_hash(
         raise HTTPException(status_code=403, detail=DISALLOW_CHAINING_MESSAGE)
     return get_api_connector().get_user_password_hash(User(username), debug=debug)
 
+
 @app.get(users_endpoint + '/{username}/type', tags=['Users'])
 def get_user_type(
-        username : str,
-        curr_user = (
-            fastapi.Depends(manager) if not no_auth else None
-        ),
-    ) -> str:
+    username : str,
+    curr_user = (
+        fastapi.Depends(manager) if not no_auth else None
+    ),
+) -> str:
     """
     If configured to allow chaining, return a user's type.
     """

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.7.6"
+__version__ = "2.7.7"

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -757,3 +757,23 @@ def get_pipe_columns_indices(
         warn(response.text)
         return None
     return j
+
+
+def get_pipe_index_names(self, pipe: mrsm.Pipe, debug: bool = False) -> Dict[str, str]:
+    """
+    Return the templated index names.
+    """
+    r_url = pipe_r_url(pipe) + '/indices/names'
+    response = self.get(
+        r_url,
+        debug=debug
+    )
+    j = response.json()
+    if isinstance(j, dict) and 'detail' in j and len(j.keys()) == 1:
+        warn(j['detail'])
+        return None
+    if not isinstance(j, dict):
+        warn(response.text)
+        return None
+    return j
+

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -70,6 +70,9 @@ class SQLConnector(Connector):
         create_pipe_table_from_df,
         get_pipe_columns_indices,
         get_temporary_target,
+        index_pipe,
+        drop_pipe_indices,
+        get_pipe_index_names,
     )
     from ._plugins import (
         register_plugin,

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -70,7 +70,7 @@ class SQLConnector(Connector):
         create_pipe_table_from_df,
         get_pipe_columns_indices,
         get_temporary_target,
-        index_pipe,
+        create_pipe_indices,
         drop_pipe_indices,
         get_pipe_index_names,
     )
@@ -225,7 +225,7 @@ class SQLConnector(Connector):
                 return None
 
             from meerschaum.utils.packages import attempt_import
-            sqlalchemy_orm = attempt_import('sqlalchemy.orm')
+            sqlalchemy_orm = attempt_import('sqlalchemy.orm', lazy=False)
             session_factory = sqlalchemy_orm.sessionmaker(self.engine)
             self._Session = sqlalchemy_orm.scoped_session(session_factory)
 
@@ -293,7 +293,7 @@ class SQLConnector(Connector):
         Return the metadata bound to this configured schema.
         """
         from meerschaum.utils.packages import attempt_import
-        sqlalchemy = attempt_import('sqlalchemy')
+        sqlalchemy = attempt_import('sqlalchemy', lazy=False)
         if '_metadata' not in self.__dict__:
             self._metadata = sqlalchemy.MetaData(schema=self.schema)
         return self._metadata
@@ -371,7 +371,7 @@ class SQLConnector(Connector):
             self.__dict__['schema'] = None
             return None
 
-        sqlalchemy = mrsm.attempt_import('sqlalchemy')
+        sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
         _schema = sqlalchemy.inspect(self.engine).default_schema_name
         self.__dict__['schema'] = _schema
         return _schema

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -186,7 +186,7 @@ def create_engine(
     """Create a sqlalchemy engine by building the engine string."""
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.warnings import error, warn
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     import urllib
     import copy
     ### Install and patch required drivers.

--- a/meerschaum/connectors/sql/_fetch.py
+++ b/meerschaum/connectors/sql/_fetch.py
@@ -148,7 +148,6 @@ def get_pipe_metadef(
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.sql import sql_item_name, dateadd_str, build_where
     from meerschaum.utils.dtypes.sql import get_db_type_from_pd_type
-    from meerschaum.utils.misc import is_int
     from meerschaum.config import get_config
 
     dt_col = pipe.columns.get('datetime', None)
@@ -191,7 +190,7 @@ def get_pipe_metadef(
         else begin
     )
 
-    if begin and end and begin >= end:
+    if begin not in (None, '') and end is not None and begin >= end:
         begin = None
 
     if dt_name:
@@ -203,7 +202,7 @@ def get_pipe_metadef(
                 begin=begin,
                 db_type=db_dt_typ,
             )
-            if begin
+            if begin not in ('', None)
             else None
         )
         end_da = (
@@ -214,7 +213,7 @@ def get_pipe_metadef(
                 begin=end,
                 db_type=db_dt_typ,
             )
-            if end
+            if end is not None
             else None
         )
 
@@ -228,11 +227,7 @@ def get_pipe_metadef(
 
     has_where = 'where' in meta_def.lower()[meta_def.lower().rfind('definition'):]
     if dt_name and (begin_da or end_da):
-        definition_dt_name = (
-            dateadd_str(self.flavor, 'minute', 0, f"{definition_name}.{dt_name}", db_type=db_dt_typ)
-            if not is_int((begin_da or end_da))
-            else f"{definition_name}.{dt_name}"
-        )
+        definition_dt_name = f"{definition_name}.{dt_name}"
         meta_def += "\n" + ("AND" if has_where else "WHERE") + " "
         has_where = True
         if begin_da:

--- a/meerschaum/connectors/sql/_instance.py
+++ b/meerschaum/connectors/sql/_instance.py
@@ -25,7 +25,7 @@ def _log_temporary_tables_creation(
     """
     from meerschaum.utils.misc import items_str
     from meerschaum.connectors.sql.tables import get_tables
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     temp_tables_table = get_tables(
         mrsm_instance=self,
         create=create,
@@ -86,7 +86,7 @@ def _drop_temporary_tables(self, debug: bool = False) -> SuccessTuple:
     """
     from meerschaum.utils.misc import items_str
     from meerschaum.connectors.sql.tables import get_tables
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     temp_tables_table = get_tables(
         mrsm_instance=self,
         create=False,
@@ -150,7 +150,7 @@ def _drop_old_temporary_tables(
     """
     from meerschaum.config import get_config
     from meerschaum.connectors.sql.tables import get_tables
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     temp_tables_table = get_tables(mrsm_instance=self, create=False, debug=debug)['temp_tables']
     last_check = getattr(self, '_stale_temporary_tables_check_timestamp', 0)
     now_ts = time.perf_counter()

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -561,7 +561,7 @@ def get_create_index_queries(
         )
     )
     primary_key_db_type = (
-        get_db_type_from_pd_type(pipe.dtypes.get(primary_key, 'int'), self.flavor)
+        get_db_type_from_pd_type(pipe.dtypes.get(primary_key, 'int') or 'int', self.flavor)
         if primary_key
         else None
     )
@@ -1526,7 +1526,7 @@ def create_pipe_table_from_df(
     from meerschaum.utils.dtypes.sql import get_db_type_from_pd_type
     primary_key = pipe.columns.get('primary', None)
     primary_key_typ = (
-        pipe.dtypes.get(primary_key, str(df.dtypes.get(primary_key)))
+        pipe.dtypes.get(primary_key, str(df.dtypes.get(primary_key, 'int')))
         if primary_key
         else None
     )
@@ -3175,7 +3175,9 @@ def get_add_columns_queries(
         col: get_db_type_from_pd_type(
             df_cols_types[col],
             self.flavor
-        ) for col in new_cols
+        )
+        for col in new_cols
+        if col and df_cols_types.get(col, None)
     }
 
     alter_table_query = "ALTER TABLE " + sql_item_name(
@@ -3567,6 +3569,7 @@ def get_to_sql_dtype(
     return {
         col: get_db_type_from_pd_type(typ, self.flavor, as_sqlalchemy=True)
         for col, typ in df_dtypes.items()
+        if col and typ
     }
 
 

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -923,7 +923,7 @@ def get_drop_index_queries(
         if ix_unquoted.lower() not in existing_indices:
             continue
 
-        if ix_key == 'unique' and upsert and self.flavor not in ('sqlite',):
+        if ix_key == 'unique' and upsert and self.flavor not in ('sqlite',) and not is_hypertable:
             constraint_name_unquoted = ix_unquoted.replace('IX_', 'UQ_')
             constraint_name = sql_item_name(constraint_name_unquoted, self.flavor)
             constraint_or_index = (

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -306,9 +306,28 @@ def fetch_pipes_keys(
     return [(row[0], row[1], row[2]) for row in rows]
 
 
+def index_pipe(
+    self,
+    pipe: mrsm.Pipe,
+    columns: Optional[List[str]] = None,
+    debug: bool = False,
+) -> SuccessTuple:
+    """
+    Create a pipe's indices.
+    """
+    success = self.create_indices(pipe, columns=columns, debug=debug)
+    msg = (
+        "Success"
+        if success
+        else f"Failed to create indices for {pipe}."
+    )
+    return success, msg
+
+
 def create_indices(
     self,
     pipe: mrsm.Pipe,
+    columns: Optional[List[str]] = None,
     indices: Optional[List[str]] = None,
     debug: bool = False
 ) -> bool:
@@ -318,29 +337,51 @@ def create_indices(
     from meerschaum.utils.debug import dprint
     if debug:
         dprint(f"Creating indices for {pipe}...")
+
     if not pipe.indices:
         warn(f"{pipe} has no index columns; skipping index creation.", stack=False)
         return True
 
+    cols_to_include = set((columns or []) + (indices or [])) or None
+
     _ = pipe.__dict__.pop('_columns_indices', None)
     ix_queries = {
-        ix: queries
-        for ix, queries in self.get_create_index_queries(pipe, debug=debug).items()
-        if indices is None or ix in indices
+        col: queries
+        for col, queries in self.get_create_index_queries(pipe, debug=debug).items()
+        if cols_to_include is None or col in cols_to_include
     }
     success = True
-    for ix, queries in ix_queries.items():
+    for col, queries in ix_queries.items():
         ix_success = all(self.exec_queries(queries, debug=debug, silent=False))
         success = success and ix_success
         if not ix_success:
-            warn(f"Failed to create index on column: {ix}")
+            warn(f"Failed to create index on column: {col}")
 
     return success
+
+
+def drop_pipe_indices(
+    self,
+    pipe: mrsm.Pipe,
+    columns: Optional[List[str]] = None,
+    debug: bool = False,
+) -> SuccessTuple:
+    """
+    Drop a pipe's indices.
+    """
+    success = self.drop_indices(pipe, columns=columns, debug=debug)
+    msg = (
+        "Success"
+        if success
+        else f"Failed to drop indices for {pipe}."
+    )
+    return success, msg
 
 
 def drop_indices(
     self,
     pipe: mrsm.Pipe,
+    columns: Optional[List[str]] = None,
     indices: Optional[List[str]] = None,
     debug: bool = False
 ) -> bool:
@@ -350,23 +391,80 @@ def drop_indices(
     from meerschaum.utils.debug import dprint
     if debug:
         dprint(f"Dropping indices for {pipe}...")
-    if not pipe.columns:
-        warn(f"Unable to drop indices for {pipe} without columns.", stack=False)
+
+    if not pipe.indices:
+        warn(f"No indices to drop for {pipe}.", stack=False)
         return False
+
+    cols_to_include = set((columns or []) + (indices or [])) or None
+
     ix_queries = {
-        ix: queries
-        for ix, queries in self.get_drop_index_queries(pipe, debug=debug).items()
-        if indices is None or ix in indices
+        col: queries
+        for col, queries in self.get_drop_index_queries(pipe, debug=debug).items()
+        if cols_to_include is None or col in cols_to_include
     }
     success = True
-    for ix, queries in ix_queries.items():
-        ix_success = all(self.exec_queries(queries, debug=debug, silent=True))
+    for col, queries in ix_queries.items():
+        ix_success = all(self.exec_queries(queries, debug=debug, silent=(not debug)))
         if not ix_success:
             success = False
             if debug:
-                dprint(f"Failed to drop index on column: {ix}")
+                dprint(f"Failed to drop index on column: {col}")
     return success
 
+
+def get_pipe_index_names(self, pipe: mrsm.Pipe) -> Dict[str, str]:
+    """
+    Return a dictionary mapping index keys to their names on the database.
+
+    Returns
+    -------
+    A dictionary of index keys to column names.
+    """
+    from meerschaum.utils.sql import DEFAULT_SCHEMA_FLAVORS
+    _parameters = pipe.parameters
+    _index_template = _parameters.get('index_template', "IX_{schema_str}{target}_{column_names}")
+    _schema = self.get_pipe_schema(pipe)
+    if _schema is None:
+        _schema = (
+            DEFAULT_SCHEMA_FLAVORS.get(self.flavor, None)
+            if self.flavor != 'mssql'
+            else None
+        )
+    schema_str = '' if _schema is None else f'{_schema}_'
+    schema_str = ''
+    _indices = pipe.indices
+    _target = pipe.target
+    _column_names = {
+        ix: (
+            '_'.join(cols)
+            if isinstance(cols, (list, tuple))
+            else str(cols)
+        )
+        for ix, cols in _indices.items()
+        if cols
+    }
+    _index_names = {
+        ix: _index_template.format(
+            target=_target,
+            column_names=column_names,
+            connector_keys=pipe.connector_keys,
+            metric_key=pipe.metric_key,
+            location_key=pipe.location_key,
+            schema_str=schema_str,
+        )
+        for ix, column_names in _column_names.items()
+    }
+    ### NOTE: Skip any duplicate indices.
+    seen_index_names = {}
+    for ix, index_name in _index_names.items():
+        if index_name in seen_index_names:
+            continue
+        seen_index_names[index_name] = ix
+    return {
+        ix: index_name
+        for index_name, ix in seen_index_names.items()
+    }
 
 def get_create_index_queries(
     self,
@@ -407,7 +505,11 @@ def get_create_index_queries(
 
     upsert = pipe.parameters.get('upsert', False) and (self.flavor + '-upsert') in UPDATE_QUERIES
     static = pipe.parameters.get('static', False)
+    null_indices = pipe.parameters.get('null_indices', True)
     index_names = pipe.get_indices()
+    unique_index_name_unquoted = index_names.get('unique', None) or f'IX_{pipe.target}_unique'
+    if upsert:
+        _ = index_names.pop('unique', None)
     indices = pipe.indices
     existing_cols_types = pipe.get_columns_types(debug=debug)
     existing_cols_pd_types = {
@@ -420,11 +522,11 @@ def get_create_index_queries(
     existing_clustered_primary_keys = []
     for col, col_indices in existing_cols_indices.items():
         for col_ix_doc in col_indices:
-            existing_ix_names.add(col_ix_doc.get('name', None))
+            existing_ix_names.add(col_ix_doc.get('name', '').lower())
             if col_ix_doc.get('type', None) == 'PRIMARY KEY':
-                existing_primary_keys.append(col)
+                existing_primary_keys.append(col.lower())
                 if col_ix_doc.get('clustered', True):
-                    existing_clustered_primary_keys.append(col)
+                    existing_clustered_primary_keys.append(col.lower())
 
     _datetime = pipe.get_columns('datetime', error=False)
     _datetime_name = (
@@ -471,6 +573,19 @@ def get_create_index_queries(
         if not existing_clustered_primary_keys and _datetime is not None
         else "NONCLUSTERED"
     )
+    include_columns_str = "\n    ,".join(
+        [
+            sql_item_name(col, flavor=self.flavor) for col in existing_cols_types
+            if col != _datetime
+        ]
+    ).rstrip(',')
+    include_clause = (
+        (
+            f"\nINCLUDE (\n    {include_columns_str}\n)"
+        )
+        if datetime_clustered == 'NONCLUSTERED'
+        else ''
+    )
 
     _id_index_name = (
         sql_item_name(index_names['id'], self.flavor, None)
@@ -516,7 +631,7 @@ def get_create_index_queries(
             if self.flavor == 'mssql':
                 dt_query = (
                     f"CREATE {datetime_clustered} INDEX {_datetime_index_name} "
-                    f"ON {_pipe_name} ({_datetime_name})"
+                    f"\nON {_pipe_name} ({_datetime_name}){include_clause}"
                 )
             else:
                 dt_query = (
@@ -530,7 +645,7 @@ def get_create_index_queries(
     primary_queries = []
     if (
         primary_key is not None
-        and primary_key not in existing_primary_keys
+        and primary_key.lower() not in existing_primary_keys
         and not static
     ):
         if autoincrement and primary_key not in existing_cols_pd_types:
@@ -659,7 +774,10 @@ def get_create_index_queries(
     other_index_names = {
         ix_key: ix_unquoted
         for ix_key, ix_unquoted in index_names.items()
-        if ix_key not in ('datetime', 'id', 'primary') and ix_unquoted not in existing_ix_names
+        if (
+            ix_key not in ('datetime', 'id', 'primary')
+            and ix_unquoted.lower() not in existing_ix_names
+        )
     }
     for ix_key, ix_unquoted in other_index_names.items():
         ix_name = sql_item_name(ix_unquoted, self.flavor, None)
@@ -684,24 +802,29 @@ def get_create_index_queries(
     coalesce_indices_cols_str = ', '.join(
         [
             (
-                "COALESCE("
-                + sql_item_name(ix, self.flavor)
-                + ", "
-                + get_null_replacement(existing_cols_types[ix], self.flavor)
-                + ") "
-            ) if ix_key != 'datetime' else (sql_item_name(ix, self.flavor))
+                (
+                    "COALESCE("
+                    + sql_item_name(ix, self.flavor)
+                    + ", "
+                    + get_null_replacement(existing_cols_types[ix], self.flavor)
+                    + ") "
+                )
+                if ix_key != 'datetime' and null_indices
+                else sql_item_name(ix, self.flavor)
+            )
             for ix_key, ix in pipe.columns.items()
             if ix and ix in existing_cols_types
         ]
     )
-    unique_index_name = sql_item_name(pipe.target + '_unique_index', self.flavor)
-    constraint_name = sql_item_name(pipe.target + '_constraint', self.flavor)
+    unique_index_name = sql_item_name(unique_index_name_unquoted, self.flavor)
+    constraint_name_unquoted = unique_index_name_unquoted.replace('IX_', 'UQ_')
+    constraint_name = sql_item_name(constraint_name_unquoted, self.flavor)
     add_constraint_query = (
         f"ALTER TABLE {_pipe_name} ADD CONSTRAINT {constraint_name} UNIQUE ({indices_cols_str})"
     )
     unique_index_cols_str = (
         indices_cols_str
-        if self.flavor not in COALESCE_UNIQUE_INDEX_FLAVORS
+        if self.flavor not in COALESCE_UNIQUE_INDEX_FLAVORS or not null_indices
         else coalesce_indices_cols_str
     )
     create_unique_index_query = (
@@ -737,21 +860,33 @@ def get_drop_index_queries(
         return {}
     if not pipe.exists(debug=debug):
         return {}
+
+    from collections import defaultdict
     from meerschaum.utils.sql import (
         sql_item_name,
         table_exists,
         hypertable_queries,
         DROP_IF_EXISTS_FLAVORS,
     )
-    drop_queries = {}
+    drop_queries = defaultdict(lambda: [])
     schema = self.get_pipe_schema(pipe)
-    schema_prefix = (schema + '_') if schema else ''
+    index_schema = schema if self.flavor != 'mssql' else None
     indices = {
-        col: schema_prefix + ix
-        for col, ix in pipe.get_indices().items()
+        ix_key: ix
+        for ix_key, ix in pipe.get_indices().items()
     }
-    pipe_name = sql_item_name(pipe.target, self.flavor, self.get_pipe_schema(pipe))
+    cols_indices = pipe.get_columns_indices(debug=debug)
+    existing_indices = set()
+    clustered_ix = None
+    for col, ix_metas in cols_indices.items():
+        for ix_meta in ix_metas:
+            ix_name = ix_meta.get('name', None)
+            if ix_meta.get('clustered', False):
+                clustered_ix = ix_name
+            existing_indices.add(ix_name.lower())
+    pipe_name = sql_item_name(pipe.target, self.flavor, schema)
     pipe_name_no_schema = sql_item_name(pipe.target, self.flavor, None)
+    upsert = pipe.upsert
 
     if self.flavor not in hypertable_queries:
         is_hypertable = False
@@ -759,7 +894,7 @@ def get_drop_index_queries(
         is_hypertable_query = hypertable_queries[self.flavor].format(table_name=pipe_name)
         is_hypertable = self.value(is_hypertable_query, silent=True, debug=debug) is not None
 
-    if_exists_str = "IF EXISTS" if self.flavor in DROP_IF_EXISTS_FLAVORS else ""
+    if_exists_str = "IF EXISTS " if self.flavor in DROP_IF_EXISTS_FLAVORS else ""
     if is_hypertable:
         nuke_queries = []
         temp_table = '_' + pipe.target + '_temp_migration'
@@ -769,21 +904,41 @@ def get_drop_index_queries(
             nuke_queries.append(f"DROP TABLE {if_exists_str} {temp_table_name}")
         nuke_queries += [
             f"SELECT * INTO {temp_table_name} FROM {pipe_name}",
-            f"DROP TABLE {if_exists_str} {pipe_name}",
+            f"DROP TABLE {if_exists_str}{pipe_name}",
             f"ALTER TABLE {temp_table_name} RENAME TO {pipe_name_no_schema}",
         ]
         nuke_ix_keys = ('datetime', 'id')
         nuked = False
         for ix_key in nuke_ix_keys:
             if ix_key in indices and not nuked:
-                drop_queries[ix_key] = nuke_queries
+                drop_queries[ix_key].extend(nuke_queries)
                 nuked = True
 
-    drop_queries.update({
-        ix_key: ["DROP INDEX " + sql_item_name(ix_unquoted, self.flavor, None)]
-        for ix_key, ix_unquoted in indices.items()
-        if ix_key not in drop_queries
-    })
+    for ix_key, ix_unquoted in indices.items():
+        if ix_key in drop_queries:
+            continue
+        if ix_unquoted.lower() not in existing_indices:
+            continue
+
+        if ix_key == 'unique' and upsert and self.flavor != 'sqlite':
+            constraint_name_unquoted = ix_unquoted.replace('IX_', 'UQ_')
+            constraint_name = sql_item_name(constraint_name_unquoted, self.flavor)
+            drop_queries[ix_key].append(
+                f"ALTER TABLE {pipe_name}\n"
+                f"DROP CONSTRAINT {constraint_name}"
+            )
+
+        query = (
+            f"DROP INDEX {if_exists_str}"
+            + sql_item_name(ix_unquoted, self.flavor, index_schema)
+        )
+        if self.flavor == 'mssql':
+            query += f"\nON {pipe_name}"
+            if ix_unquoted == clustered_ix:
+                query += "\nWITH (ONLINE = ON, MAXDOP = 4)"
+        drop_queries[ix_key].append(query)
+
+
     return drop_queries
 
 
@@ -1777,6 +1932,7 @@ def sync_pipe(
             patch_schema=self.internal_schema,
             datetime_col=(dt_col if dt_col in update_df.columns else None),
             identity_insert=(autoincrement and primary_key in update_df.columns),
+            null_indices=pipe.null_indices,
             debug=debug,
         )
         update_results = self.exec_queries(
@@ -2077,13 +2233,19 @@ def sync_pipe_inplace(
         _ = clean_up_temp_tables()
         return True, f"Inserted {new_count}, updated 0 rows."
 
-    dt_col_name_da = dateadd_str(flavor=self.flavor, begin=dt_col_name, db_type=dt_db_type)
+    min_dt_col_name_da = dateadd_str(
+        flavor=self.flavor, begin=f"MIN({dt_col_name})", db_type=dt_db_type,
+    )
+    max_dt_col_name_da = dateadd_str(
+        flavor=self.flavor, begin=f"MAX({dt_col_name})", db_type=dt_db_type,
+    )
+
     (new_dt_bounds_success, new_dt_bounds_msg), new_dt_bounds_results = session_execute(
         session,
         [
             "SELECT\n"
-            f"    MIN({dt_col_name_da}) AS {sql_item_name('min_dt', self.flavor)},\n"
-            f"    MAX({dt_col_name_da}) AS {sql_item_name('max_dt', self.flavor)}\n"
+            f"    {min_dt_col_name_da} AS {sql_item_name('min_dt', self.flavor)},\n"
+            f"    {max_dt_col_name_da} AS {sql_item_name('max_dt', self.flavor)}\n"
             f"FROM {temp_table_names['new' if not upsert else 'update']}\n"
             f"WHERE {dt_col_name} IS NOT NULL"
         ],
@@ -2350,6 +2512,7 @@ def sync_pipe_inplace(
             patch_schema=internal_schema,
             datetime_col=pipe.columns.get('datetime', None),
             flavor=self.flavor,
+            null_indices=pipe.null_indices,
             debug=debug,
         )
         if on_cols else []
@@ -2643,7 +2806,7 @@ def get_pipe_rowcount(
         _cols_names = ['*']
 
     src = (
-        f"SELECT {', '.join(_cols_names)} FROM {_pipe_name}"
+        f"SELECT {', '.join(_cols_names)}\nFROM {_pipe_name}"
         if not remote
         else get_pipe_query(pipe)
     )
@@ -2652,15 +2815,17 @@ def get_pipe_rowcount(
     if begin is not None or end is not None:
         query += "\nWHERE"
     if begin is not None:
-        query += f"""
-        {dt_name} >= {dateadd_str(self.flavor, datepart='minute', number=0, begin=begin, db_type=dt_db_type)}
-        """
+        query += (
+            f"\n    {dt_name} >= "
+            + dateadd_str(self.flavor, datepart='minute', number=0, begin=begin, db_type=dt_db_type)
+        )
     if end is not None and begin is not None:
-        query += "AND"
+        query += "\n    AND"
     if end is not None:
-        query += f"""
-        {dt_name} <  {dateadd_str(self.flavor, datepart='minute', number=0, begin=end, db_type=dt_db_type)}
-        """
+        query += (
+            f"\n    {dt_name} <  "
+            + dateadd_str(self.flavor, datepart='minute', number=0, begin=end, db_type=dt_db_type)
+        )
     if params is not None:
         from meerschaum.utils.sql import build_where
         existing_cols = pipe.get_columns_types(debug=debug)
@@ -2782,13 +2947,21 @@ def clear_pipe(
         valid_params = {k: v for k, v in params.items() if k in existing_cols}
     clear_query = (
         f"DELETE FROM {pipe_name}\nWHERE 1 = 1\n"
-        + ('  AND ' + build_where(valid_params, self, with_where=False) if valid_params else '')
+        + ('\n    AND ' + build_where(valid_params, self, with_where=False) if valid_params else '')
         + (
-            f'  AND {dt_name} >= ' + dateadd_str(self.flavor, 'day', 0, begin, db_type=dt_db_type)
-            if begin is not None else ''
+            (
+                f'\n    AND {dt_name} >= '
+                + dateadd_str(self.flavor, 'day', 0, begin, db_type=dt_db_type)
+            )
+            if begin is not None
+            else ''
         ) + (
-            f'  AND {dt_name} < ' + dateadd_str(self.flavor, 'day', 0, end, db_type=dt_db_type)
-            if end is not None else ''
+            (
+                f'\n    AND {dt_name} <  '
+                + dateadd_str(self.flavor, 'day', 0, end, db_type=dt_db_type)
+            )
+            if end is not None
+            else ''
         )
     )
     success = self.exec(clear_query, silent=True, debug=debug) is not None

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -55,7 +55,7 @@ def register_pipe(
         parameters = {}
 
     import json
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     values = {
         'connector_keys' : pipe.connector_keys,
         'metric_key'     : pipe.metric_key,
@@ -118,7 +118,7 @@ def edit_pipe(
     pipes_tbl = get_tables(mrsm_instance=self, create=(not pipe.temporary), debug=debug)['pipes']
 
     import json
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     values = {
         'parameters': (
@@ -176,7 +176,10 @@ def fetch_pipes_keys(
     from meerschaum.config.static import STATIC_CONFIG
     import json
     from copy import deepcopy
-    sqlalchemy, sqlalchemy_sql_functions = attempt_import('sqlalchemy', 'sqlalchemy.sql.functions')
+    sqlalchemy, sqlalchemy_sql_functions = attempt_import(
+        'sqlalchemy',
+        'sqlalchemy.sql.functions', lazy=False,
+    )
     coalesce = sqlalchemy_sql_functions.coalesce
 
     if connector_keys is None:
@@ -246,7 +249,7 @@ def fetch_pipes_keys(
 
     q = sqlalchemy.select(*select_cols).where(sqlalchemy.and_(True, *_where))
     for c, vals in cols.items():
-        if not isinstance(vals, (list, tuple)) or not vals or not c in pipes_tbl.c:
+        if not isinstance(vals, (list, tuple)) or not vals or c not in pipes_tbl.c:
             continue
         _in_vals, _ex_vals = separate_negation_values(vals)
         q = q.where(coalesce(pipes_tbl.c[c], 'None').in_(_in_vals)) if _in_vals else q
@@ -306,7 +309,7 @@ def fetch_pipes_keys(
     return [(row[0], row[1], row[2]) for row in rows]
 
 
-def index_pipe(
+def create_pipe_indices(
     self,
     pipe: mrsm.Pipe,
     columns: Optional[List[str]] = None,
@@ -951,7 +954,7 @@ def delete_pipe(
     Delete a Pipe's registration.
     """
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     if not pipe.id:
         return False, f"{pipe} is not registered."

--- a/meerschaum/connectors/sql/_plugins.py
+++ b/meerschaum/connectors/sql/_plugins.py
@@ -21,9 +21,8 @@ def register_plugin(
     **kw: Any
 ) -> SuccessTuple:
     """Register a new plugin to the plugins table."""
-    from meerschaum.utils.warnings import warn, error
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     from meerschaum.utils.sql import json_flavors
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
@@ -85,7 +84,7 @@ def get_plugin_id(
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = (
         sqlalchemy
@@ -95,8 +94,9 @@ def get_plugin_id(
     
     try:
         return int(self.value(query, debug=debug))
-    except Exception as e:
+    except Exception:
         return None
+
 
 def get_plugin_version(
     self,
@@ -110,7 +110,7 @@ def get_plugin_version(
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     query = sqlalchemy.select(plugins_tbl.c.version).where(plugins_tbl.c.plugin_name == plugin.name)
     return self.value(query, debug=debug)
 
@@ -126,7 +126,7 @@ def get_plugin_user_id(
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = (
         sqlalchemy
@@ -136,7 +136,7 @@ def get_plugin_user_id(
 
     try:
         return int(self.value(query, debug=debug))
-    except Exception as e:
+    except Exception:
         return None
 
 def get_plugin_username(
@@ -152,7 +152,7 @@ def get_plugin_username(
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     users = get_tables(mrsm_instance=self, debug=debug)['users']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = (
         sqlalchemy.select(users.c.username)
@@ -177,7 +177,7 @@ def get_plugin_attributes(
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = (
         sqlalchemy
@@ -219,7 +219,7 @@ def get_plugins(
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = sqlalchemy.select(plugins_tbl.c.plugin_name)
     if user_id is not None:
@@ -246,19 +246,14 @@ def delete_plugin(
     **kw: Any
 ) -> SuccessTuple:
     """Delete a plugin from the plugins table."""
-    from meerschaum.utils.warnings import warn, error
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     from meerschaum.connectors.sql.tables import get_tables
     plugins_tbl = get_tables(mrsm_instance=self, debug=debug)['plugins']
 
     plugin_id = self.get_plugin_id(plugin, debug=debug)
     if plugin_id is None:
         return True, f"Plugin '{plugin}' was not registered."
-
-    bind_variables = {
-        'plugin_id' : plugin_id,
-    }
 
     query = sqlalchemy.delete(plugins_tbl).where(plugins_tbl.c.plugin_id == plugin_id)
     result = self.exec(query, debug=debug)

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -154,7 +154,7 @@ def read(
             dtype[col] = 'datetime64[ns]'
 
     pool = get_pool(workers=workers)
-    sqlalchemy = attempt_import("sqlalchemy")
+    sqlalchemy = attempt_import("sqlalchemy", lazy=False)
     default_chunksize = self._sys_config.get('chunksize', None)
     chunksize = chunksize if chunksize != -1 else default_chunksize
     if chunksize is None and as_iterator:
@@ -443,7 +443,6 @@ def value(
 
     """
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
     if self.flavor == 'duckdb':
         use_pandas = True
     if use_pandas:
@@ -454,9 +453,6 @@ def value(
 
     _close = kw.get('close', True)
     _commit = kw.get('commit', (self.flavor != 'mssql'))
-
-    #  _close = True
-    #  _commit = True
 
     try:
         result, connection = self.exec(
@@ -556,7 +552,7 @@ def exec(
         )
 
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import("sqlalchemy")
+    sqlalchemy = attempt_import("sqlalchemy", lazy=False)
     if debug:
         dprint(f"[{self}] Executing query:\n{query}")
 
@@ -659,7 +655,7 @@ def exec_queries(
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy, sqlalchemy_orm = attempt_import('sqlalchemy', 'sqlalchemy.orm')
+    sqlalchemy, sqlalchemy_orm = attempt_import('sqlalchemy', 'sqlalchemy.orm', lazy=False)
     session = sqlalchemy_orm.Session(self.engine)
 
     result = None
@@ -820,7 +816,7 @@ def to_sql(
     from meerschaum.utils.misc import interval_str
     from meerschaum.connectors.sql._create_engine import flavor_configs
     from meerschaum.utils.packages import attempt_import, import_pandas
-    sqlalchemy = attempt_import('sqlalchemy', debug=debug)
+    sqlalchemy = attempt_import('sqlalchemy', debug=debug, lazy=False)
     pd = import_pandas()
     is_dask = 'dask' in df.__module__
 

--- a/meerschaum/connectors/sql/_uri.py
+++ b/meerschaum/connectors/sql/_uri.py
@@ -13,14 +13,14 @@ from meerschaum.utils.packages import attempt_import
 
 @classmethod
 def from_uri(
-        cls,
-        uri: str,
-        label: Optional[str] = None,
-        as_dict: bool = False,
-    ) -> Union[
-        'meerschaum.connectors.SQLConnector',
-        Dict[str, Union[str, int]],
-    ]:
+    cls,
+    uri: str,
+    label: Optional[str] = None,
+    as_dict: bool = False,
+) -> Union[
+    'meerschaum.connectors.SQLConnector',
+    Dict[str, Union[str, int]],
+]:
     """
     Create a new SQLConnector from a URI string.
 
@@ -97,7 +97,7 @@ def parse_uri(uri: str) -> Dict[str, Any]:
     >>> 
     """
     from urllib.parse import parse_qs, urlparse
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     parser = sqlalchemy.engine.url.make_url
     params = parser(uri).translate_connect_args()
     params['flavor'] = uri.split(':')[0].split('+')[0]

--- a/meerschaum/connectors/sql/_users.py
+++ b/meerschaum/connectors/sql/_users.py
@@ -19,10 +19,9 @@ def register_user(
     **kw: Any
 ) -> SuccessTuple:
     """Register a new user."""
-    from meerschaum.utils.warnings import warn, error, info
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.sql import json_flavors
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     valid_tuple = valid_username(user.username)
     if not valid_tuple[0]:
@@ -103,9 +102,8 @@ def edit_user(
 ) -> SuccessTuple:
     """Update an existing user's metadata."""
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     from meerschaum.connectors.sql.tables import get_tables
-    from meerschaum.utils.sql import json_flavors
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
 
     user_id = user.user_id if user.user_id is not None else self.get_user_id(user, debug=debug)
@@ -158,7 +156,7 @@ def get_user_id(
     """If a user is registered, return the `user_id`."""
     ### ensure users table exists
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     from meerschaum.connectors.sql.tables import get_tables
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
 
@@ -183,7 +181,7 @@ def get_user_attributes(
     ### ensure users table exists
     from meerschaum.utils.warnings import warn
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     from meerschaum.connectors.sql.tables import get_tables
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
 
@@ -199,14 +197,14 @@ def get_user_attributes(
         try:
             result = dict(result)
             _parsed = True
-        except Exception as e:
+        except Exception:
             _parsed = False
         if not _parsed:
             try:
                 import json
                 result = json.loads(result)
                 _parsed = True
-            except Exception as e:
+            except Exception:
                 _parsed = False
         if not _parsed:
             warn(f"Received unexpected type for attributes: {result}")
@@ -223,7 +221,7 @@ def delete_user(
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
     plugins = get_tables(mrsm_instance=self, debug=debug)['plugins']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     user_id = user.user_id if user.user_id is not None else self.get_user_id(user, debug=debug)
 
@@ -256,7 +254,7 @@ def get_users(
     from meerschaum.connectors.sql.tables import get_tables
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     query = sqlalchemy.select(users_tbl.c.username)
 
@@ -277,7 +275,7 @@ def get_user_password_hash(
     from meerschaum.connectors.sql.tables import get_tables
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     if user.user_id is not None:
         user_id = user.user_id
@@ -308,7 +306,7 @@ def get_user_type(
     from meerschaum.connectors.sql.tables import get_tables
     users_tbl = get_tables(mrsm_instance=self, debug=debug)['users']
     from meerschaum.utils.packages import attempt_import
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
     user_id = user.user_id if user.user_id is not None else self.get_user_id(user, debug=debug)
 

--- a/meerschaum/connectors/sql/tables/__init__.py
+++ b/meerschaum/connectors/sql/tables/__init__.py
@@ -17,10 +17,10 @@ _sequence_flavors = {'duckdb', 'oracle'}
 _skip_index_names_flavors = {'mssql',}
 
 def get_tables(
-        mrsm_instance: Optional[Union[str, InstanceConnector]] = None,
-        create: bool = True,
-        debug: Optional[bool] = None
-    ) -> Union[Dict[str, 'sqlalchemy.Table'], bool]:
+    mrsm_instance: Optional[Union[str, InstanceConnector]] = None,
+    create: bool = True,
+    debug: Optional[bool] = None
+) -> Union[Dict[str, 'sqlalchemy.Table'], bool]:
     """
     Create tables on the database and return the `sqlalchemy` tables.
 
@@ -51,7 +51,7 @@ def get_tables(
     sqlalchemy, sqlalchemy_dialects_postgresql = attempt_import(
         'sqlalchemy',
         'sqlalchemy.dialects.postgresql',
-        lazy = False
+        lazy=False,
     )
     if not sqlalchemy:
         error(f"Failed to import sqlalchemy. Is sqlalchemy installed?")
@@ -205,13 +205,12 @@ def get_tables(
 
 
 def create_tables(
-        conn: 'meerschaum.connectors.SQLConnector',
-        tables: Optional[Dict[str, 'sqlalchemy.Table']] = None,
-    ) -> bool:
+    conn: 'meerschaum.connectors.SQLConnector',
+    tables: Optional[Dict[str, 'sqlalchemy.Table']] = None,
+) -> bool:
     """
     Create the tables on the database.
     """
-    from meerschaum.utils.sql import get_rename_table_queries, table_exists
     _tables = tables if tables is not None else get_tables(conn)
 
     try:
@@ -225,10 +224,10 @@ def create_tables(
 
 
 def create_schemas(
-        conn: 'meerschaum.connectors.SQLConnector',
-        schemas: List[str],
-        debug: bool = False,
-    ) -> bool:
+    conn: 'meerschaum.connectors.SQLConnector',
+    schemas: List[str],
+    debug: bool = False,
+) -> bool:
     """
     Create the internal Meerschaum schema on the database.
     """
@@ -238,7 +237,7 @@ def create_schemas(
     if conn.flavor in NO_SCHEMA_FLAVORS:
         return True
 
-    sqlalchemy_schema = attempt_import('sqlalchemy.schema')
+    _ = attempt_import('sqlalchemy.schema', lazy=False)
     successes = {}
     skip_if_not_exists = conn.flavor in SKIP_IF_EXISTS_FLAVORS
     if_not_exists_str = ("IF NOT EXISTS " if not skip_if_not_exists else "")

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -143,7 +143,7 @@ class Pipe:
     )
     from ._delete import delete
     from ._drop import drop, drop_indices
-    from ._index import index
+    from ._index import create_indices
     from ._clear import clear
     from ._deduplicate import deduplicate
     from ._bootstrap import bootstrap

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -107,6 +107,7 @@ class Pipe:
         static,
         tzinfo,
         enforce,
+        null_indices,
         get_columns,
         get_columns_types,
         get_columns_indices,
@@ -141,7 +142,8 @@ class Pipe:
         get_bound_time,
     )
     from ._delete import delete
-    from ._drop import drop
+    from ._drop import drop, drop_indices
+    from ._index import index
     from ._clear import clear
     from ._deduplicate import deduplicate
     from ._bootstrap import bootstrap
@@ -165,6 +167,7 @@ class Pipe:
         autoincrement: Optional[bool] = None,
         static: Optional[bool] = None,
         enforce: Optional[bool] = None,
+        null_indices: Optional[bool] = None,
         mrsm_instance: Optional[Union[str, InstanceConnector]] = None,
         cache: bool = False,
         debug: bool = False,
@@ -223,9 +226,13 @@ class Pipe:
         static: Optional[bool], default None
             If `True`, set `static` in the parameters.
 
-        enforce: Optionanl[bool], default None
+        enforce: Optional[bool], default None
             If `False`, skip data type enforcement.
             Default behavior is `True`.
+
+        null_indices: Optional[bool], default None
+            Set to `False` if there will be no null values in the index columns.
+            Defaults to `True`.
 
         temporary: bool, default False
             If `True`, prevent instance tables (pipes, users, plugins) from being created.
@@ -329,6 +336,9 @@ class Pipe:
 
         if isinstance(enforce, bool):
             self._attributes['parameters']['enforce'] = enforce
+
+        if isinstance(null_indices, bool):
+            self._attributes['parameters']['null_indices'] = null_indices
 
         ### NOTE: The parameters dictionary is {} by default.
         ###       A Pipe may be registered without parameters, then edited,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -488,7 +488,7 @@ def get_columns_indices(
 
     self.__dict__['_columns_indices'] = _columns_indices
     self.__dict__['_columns_indices_timestamp'] = now
-    return _columns_indices or {}
+    return {k: v for k, v in _columns_indices.items() if k and v} or {}
 
 
 def get_id(self, **kw: Any) -> Union[int, None]:

--- a/meerschaum/core/Pipe/_drop.py
+++ b/meerschaum/core/Pipe/_drop.py
@@ -7,7 +7,7 @@ Drop a Pipe's table but keep its registration
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, Any
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
 
 
 def drop(
@@ -39,9 +39,80 @@ def drop(
             warn(_drop_cache_tuple[1])
 
     with Venv(get_connector_plugin(self.instance_connector)):
-        result = self.instance_connector.drop_pipe(self, debug=debug, **kw)
+        if hasattr(self.instance_connector, 'drop_pipe'):
+            result = self.instance_connector.drop_pipe(self, debug=debug, **kw)
+        else:
+            result = (
+                False,
+                (
+                    "Cannot drop pipes for instance connectors of type "
+                    f"'{self.instance_connector.type}'."
+                )
+            )
+
 
     _ = self.__dict__.pop('_exists', None)
     _ = self.__dict__.pop('_exists_timestamp', None)
+
+    return result
+
+
+def drop_indices(
+    self,
+    columns: Optional[List[str]] = None,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Call the Pipe's instance connector's `drop_indices()` method.
+
+    Parameters
+    ----------
+    columns: Optional[List[str]] = None
+        If provided, only drop indices in the given list.
+
+    debug: bool, default False:
+        Verbosity toggle.
+
+    Returns
+    -------
+    A `SuccessTuple` of success, message.
+
+    """
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.venv import Venv
+    from meerschaum.connectors import get_connector_plugin
+
+    _ = self.__dict__.pop('_columns_indices', None)
+    _ = self.__dict__.pop('_columns_indices_timestamp', None)
+    _ = self.__dict__.pop('_columns_types_timestamp', None)
+    _ = self.__dict__.pop('_columns_types', None)
+
+    if self.cache_pipe is not None:
+        _drop_cache_tuple = self.cache_pipe.drop_indices(columns=columns, debug=debug, **kw)
+        if not _drop_cache_tuple[0]:
+            warn(_drop_cache_tuple[1])
+
+    with Venv(get_connector_plugin(self.instance_connector)):
+        if hasattr(self.instance_connector, 'drop_pipe_indices'):
+            result = self.instance_connector.drop_pipe_indices(
+                self,
+                columns=columns,
+                debug=debug,
+                **kw
+            )
+        else:
+            result = (
+                False,
+                (
+                    "Cannot drop indices for instance connectors of type "
+                    f"'{self.instance_connector.type}'."
+                )
+            )
+
+    _ = self.__dict__.pop('_columns_indices', None)
+    _ = self.__dict__.pop('_columns_indices_timestamp', None)
+    _ = self.__dict__.pop('_columns_types_timestamp', None)
+    _ = self.__dict__.pop('_columns_types', None)
 
     return result

--- a/meerschaum/core/Pipe/_index.py
+++ b/meerschaum/core/Pipe/_index.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
 
 
-def index(
+def create_indices(
     self,
     columns: Optional[List[str]] = None,
     debug: bool = False,
     **kw: Any
 ) -> SuccessTuple:
     """
-    Call the Pipe's instance connector's `index_pipe()` method.
+    Call the Pipe's instance connector's `create_pipe_indices()` method.
 
     Parameters
     ----------
@@ -44,8 +44,13 @@ def index(
             warn(cache_msg)
 
     with Venv(get_connector_plugin(self.instance_connector)):
-        if hasattr(self.instance_connector, 'index_pipe'):
-            result = self.instance_connector.index_pipe(self, columns=columns, debug=debug, **kw)
+        if hasattr(self.instance_connector, 'create_pipe_indices'):
+            result = self.instance_connector.create_pipe_indices(
+                self,
+                columns=columns,
+                debug=debug,
+                **kw
+            )
         else:
             result = (
                 False,

--- a/meerschaum/core/Pipe/_index.py
+++ b/meerschaum/core/Pipe/_index.py
@@ -1,0 +1,63 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Index a pipe's table.
+"""
+
+from __future__ import annotations
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
+
+
+def index(
+    self,
+    columns: Optional[List[str]] = None,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Call the Pipe's instance connector's `index_pipe()` method.
+
+    Parameters
+    ----------
+    debug: bool, default False:
+        Verbosity toggle.
+
+    Returns
+    -------
+    A `SuccessTuple` of success, message.
+
+    """
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.venv import Venv
+    from meerschaum.connectors import get_connector_plugin
+
+    _ = self.__dict__.pop('_columns_indices', None)
+    _ = self.__dict__.pop('_columns_indices_timestamp', None)
+    _ = self.__dict__.pop('_columns_types_timestamp', None)
+    _ = self.__dict__.pop('_columns_types', None)
+
+    if self.cache_pipe is not None:
+        cache_success, cache_msg = self.cache_pipe.index(columns=columns, debug=debug, **kw)
+        if not cache_success:
+            warn(cache_msg)
+
+    with Venv(get_connector_plugin(self.instance_connector)):
+        if hasattr(self.instance_connector, 'index_pipe'):
+            result = self.instance_connector.index_pipe(self, columns=columns, debug=debug, **kw)
+        else:
+            result = (
+                False,
+                (
+                    "Cannot create indices for instance connectors of type "
+                    f"'{self.instance_connector.type}'."
+                )
+            )
+
+    _ = self.__dict__.pop('_columns_indices', None)
+    _ = self.__dict__.pop('_columns_indices_timestamp', None)
+    _ = self.__dict__.pop('_columns_types_timestamp', None)
+    _ = self.__dict__.pop('_columns_types', None)
+
+    return result

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -536,7 +536,7 @@ def get_db_type_from_pd_type(
     from meerschaum.utils.packages import attempt_import
     from meerschaum.utils.dtypes import are_dtypes_equal, MRSM_ALIAS_DTYPES
     from meerschaum.utils.misc import parse_arguments_str
-    sqlalchemy_types = attempt_import('sqlalchemy.types')
+    sqlalchemy_types = attempt_import('sqlalchemy.types', lazy=False)
 
     types_registry = (
         PD_TO_DB_DTYPES_FLAVORS

--- a/meerschaum/utils/dtypes/sql.py
+++ b/meerschaum/utils/dtypes/sql.py
@@ -559,7 +559,7 @@ def get_db_type_from_pd_type(
         found_db_type = True
 
     if not found_db_type:
-        warn(f"Unknown Pandas data type '{pd_type}'. Falling back to 'TEXT'.")
+        warn(f"Unknown Pandas data type '{pd_type}'. Falling back to 'TEXT'.", stacklevel=3)
         return (
             'TEXT'
             if not as_sqlalchemy

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -43,6 +43,9 @@ SKIP_IF_EXISTS_FLAVORS = {'mssql', 'oracle'}
 DROP_IF_EXISTS_FLAVORS = {
     'timescaledb', 'postgresql', 'citus', 'mssql', 'mysql', 'mariadb', 'sqlite',
 }
+DROP_INDEX_IF_EXISTS_FLAVORS = {
+    'mssql', 'timescaledb', 'postgresql', 'oracle', 'sqlite', 'citus',
+}
 SKIP_AUTO_INCREMENT_FLAVORS = {'citus', 'duckdb'}
 COALESCE_UNIQUE_INDEX_FLAVORS = {'timescaledb', 'postgresql', 'citus'}
 UPDATE_QUERIES = {

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1066,7 +1066,7 @@ def table_exists(
     -------
     A `bool` indicating whether or not the table exists on the database.
     """
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     schema = schema or connector.schema
     insp = sqlalchemy.inspect(connector.engine)
     truncated_table_name = truncate_item_name(str(table), connector.flavor)
@@ -1119,7 +1119,7 @@ def get_sqlalchemy_table(
     if refresh:
         connector.metadata.clear()
     tables = get_tables(mrsm_instance=connector, debug=debug, create=False)
-    sqlalchemy = attempt_import('sqlalchemy')
+    sqlalchemy = attempt_import('sqlalchemy', lazy=False)
     truncated_table_name = truncate_item_name(str(table), connector.flavor)
     table_kwargs = {
         'autoload_with': connector.engine,
@@ -1189,7 +1189,7 @@ def get_table_cols_types(
     """
     import textwrap
     from meerschaum.connectors import SQLConnector
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     flavor = flavor or getattr(connectable, 'flavor', None)
     if not flavor:
         raise ValueError("Please provide a database flavor.")
@@ -1341,7 +1341,7 @@ def get_table_cols_indices(
     import textwrap
     from collections import defaultdict
     from meerschaum.connectors import SQLConnector
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     flavor = flavor or getattr(connectable, 'flavor', None)
     if not flavor:
         raise ValueError("Please provide a database flavor.")
@@ -2367,7 +2367,7 @@ def session_execute(
     A `SuccessTuple` indicating the queries were successfully executed.
     If `with_results`, return the `SuccessTuple` and a list of results.
     """
-    sqlalchemy = mrsm.attempt_import('sqlalchemy')
+    sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
     if not isinstance(queries, list):
         queries = [queries]
     successes, msgs, results = [], [], []

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -44,7 +44,7 @@ DROP_IF_EXISTS_FLAVORS = {
     'timescaledb', 'postgresql', 'citus', 'mssql', 'mysql', 'mariadb', 'sqlite',
 }
 DROP_INDEX_IF_EXISTS_FLAVORS = {
-    'mssql', 'timescaledb', 'postgresql', 'oracle', 'sqlite', 'citus',
+    'mssql', 'timescaledb', 'postgresql', 'sqlite', 'citus',
 }
 SKIP_AUTO_INCREMENT_FLAVORS = {'citus', 'duckdb'}
 COALESCE_UNIQUE_INDEX_FLAVORS = {'timescaledb', 'postgresql', 'citus'}

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -2011,7 +2011,12 @@ def _get_create_table_query_from_dtypes(
         autoincrement = False
 
     cols_types = (
-        [(primary_key, get_db_type_from_pd_type(dtypes.get(primary_key, 'int'), flavor=flavor))]
+        [
+            (
+                primary_key,
+                get_db_type_from_pd_type(dtypes.get(primary_key, 'int') or 'int', flavor=flavor)
+            )
+        ]
         if primary_key
         else []
     ) + [

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -24,7 +24,7 @@ def test_create_job():
 
     success, msg = job.stop()
     assert success, msg
-    time.sleep(0.1)
+    time.sleep(1.0)
 
     success, msg = job.result
     assert success, msg

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -922,6 +922,7 @@ def test_autoincrement_primary_key(flavor: str):
         parameters={
             'autoincrement': True,
         },
+        dtypes={'id': 'int'},
     )
     success, msg = pipe.sync([
         {'color': 'red'},
@@ -1125,7 +1126,6 @@ def test_create_drop_indices(flavor):
         'test', 'indices', 'drop',
         instance=conn,
         columns={'primary': 'Id', 'datetime': 'dt'},
-        indices={'unnecessary_id': 'AnotherId'},
         upsert=True,
     )
     docs = [

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1118,7 +1118,7 @@ def test_create_drop_indices(flavor):
     Verify that pipes are able to drop and rebuild indices.
     """
     conn = conns[flavor]
-    if conn.type not in ('sql', 'api'):
+    if conn.type not in ('sql',):
         return
     pipe = mrsm.Pipe('test', 'indices', 'drop', instance=conn)
     pipe.delete()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1151,7 +1151,7 @@ def test_create_drop_indices(flavor):
     cols_indices = pipe.get_columns_indices(debug=debug) 
     assert len(cols_indices) <= len(og_cols_indices)
 
-    success, msg = pipe.index(debug=debug)
+    success, msg = pipe.create_indices(debug=debug)
     assert success, msg
 
     cols_indices = pipe.get_columns_indices(debug=debug) 


### PR DESCRIPTION
# v2.7.7

- **Add actions `drop indices` and `index pipes`.**  
  You may now drop and create indices on pipes with the actions `drop indices` and `index pipes` or the pipe methods `drop_indices()` and `index()`:

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe('demo', 'drop_indices', columns=['id'], instance='sql:local')
  pipe.sync([{'id': 1}])
  print(pipe.get_columns_indices())
  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}

  pipe.drop_indices()
  print(pipe.get_columns_indices())
  # {}

  pipe.index()
  print(pipe.get_columns_indices())
  # {'id': [{'name': 'IX_demo_drop_indices_id', 'type': 'INDEX'}]}
  ```

- **Remove `CAST()` to datetime with selecting from a pipe's definition.**  
  For some databases, casting to the same dtype causes the query optimizer to ignore the datetime index.

- **Add `INCLUDE` clause to datetime index for MSSQL.**  
  This is to coax the query optimizer into using the datetime axis.

- **Remove redundant unique index.**  
  The two competing unique indices have been combined into a single index (for the key `unique`). The unique constraint (when `upsert` is true) shares the name but has the prefix `UQ_` in place of `IX_`.

- **Add pipe parameter `null_indices`.**  
  Set the pipe parameter `null_indices` to `False` for a performance improvement in situations where null index values are not expected.

- **Apply backtrack minutes when fetching integer datetimes.**  
  Backtrack minutes are now applied to pipes with integer datetimes axes.
