### PR TITLE
🧹 v2.8.3 Clean up API endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.8.3
+
+- **Increase username limit to 60 characters.**
+
 ### v2.8.0 – v2.8.2
 
 - **Add batches to `Pipe.verify()`.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.8.3
 
 - **Increase username limit to 60 characters.**
+- **Add chunk retries to `Pipe.verify()`.**
+- **Add instance keys to remaining pipes endpoints.**
+- **Misc bugfixes.**
 
 ### v2.8.0 – v2.8.2
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,10 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.8.3
+
+- **Increase username limit to 60 characters.**
+
 ### v2.8.0 – v2.8.2
 
 - **Add batches to `Pipe.verify()`.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -7,6 +7,9 @@ This is the current release cycle, so stay tuned for future releases!
 ### v2.8.3
 
 - **Increase username limit to 60 characters.**
+- **Add chunk retries to `Pipe.verify()`.**
+- **Add instance keys to remaining pipes endpoints.**
+- **Misc bugfixes.**
 
 ### v2.8.0 – v2.8.2
 

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -338,7 +338,7 @@ def sync_pipe(
     connector_keys: str,
     metric_key: str,
     location_key: str,
-    data: Union[Dict[str, List[Any]], List[Dict[str, Any]], Dict[str, Dict[str, Any]]],
+    data: Union[List[Dict[Any, Any]], Dict[Any, Any]],
     instance_keys: Optional[str] = None,
     check_existing: bool = True,
     blocking: bool = True,

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -338,7 +338,7 @@ def sync_pipe(
     connector_keys: str,
     metric_key: str,
     location_key: str,
-    data: Union[Dict[str, List[Any]], List[Dict[str, Any]]],
+    data: Union[Dict[str, List[Any]], List[Dict[str, Any]], Dict[str, Dict[str, Any]]],
     instance_keys: Optional[str] = None,
     check_existing: bool = True,
     blocking: bool = True,

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -173,6 +173,9 @@ default_pipes_config = {
     'sync': {
         'filter_params_index_limit': 250,
     },
+    'verify': {
+        'max_chunks_syncs': 3,
+    },
 }
 default_plugins_config = {}
 default_experimental_config = {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.8.2"
+__version__ = "2.8.3.dev1"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.8.3.dev1"
+__version__ = "2.8.3"

--- a/meerschaum/config/static/__init__.py
+++ b/meerschaum/config/static/__init__.py
@@ -137,7 +137,7 @@ STATIC_CONFIG: Dict[str, Any] = {
             'pbkdf2_sha256__default_rounds': 1_000_000,
         },
         'min_username_length': 1,
-        'max_username_length': 26,
+        'max_username_length': 60,
         'min_password_length': 5,
     },
     'plugins': {

--- a/meerschaum/connectors/sql/_cli.py
+++ b/meerschaum/connectors/sql/_cli.py
@@ -100,7 +100,13 @@ def _cli_exit(
     ### yet defined (e.g. 'sql:local').
     cli_arg_str = self.DATABASE_URL
     if self.flavor in ('sqlite', 'duckdb'):
-        cli_arg_str = str(self.database)
+        cli_arg_str = (
+            str(self.database)
+            if 'database' in self.__dict__
+            else self.parse_uri(self.URI).get('database', None)
+        )
+        if not cli_arg_str:
+            raise ValueError(f"Cannot determine database from connector '{self}'.")
     if cli_arg_str.startswith('postgresql+psycopg://'):
         cli_arg_str = cli_arg_str.replace('postgresql+psycopg://', 'postgresql://')
 

--- a/meerschaum/connectors/sql/_create_engine.py
+++ b/meerschaum/connectors/sql/_create_engine.py
@@ -256,8 +256,11 @@ def create_engine(
         ) if not _uri else _uri
 
         ### Sometimes the timescaledb:// flavor can slip in.
-        if _uri and self.flavor in ('timescaledb',) and self.flavor in _uri:
-            engine_str = engine_str.replace(f'{self.flavor}', 'postgresql', 1)
+        if _uri and self.flavor in _uri:
+            if self.flavor == 'timescaledb':
+                engine_str = engine_str.replace(f'{self.flavor}', 'postgresql', 1)
+            elif _uri.startswith('postgresql://'):
+                engine_str = engine_str.replace('postgresql://', 'postgresql+psycopg2://')
 
     if debug:
         dprint(
@@ -303,7 +306,7 @@ def create_engine(
             echo         = debug,
             **_create_engine_args
         )
-    except Exception as e:
+    except Exception:
         warn(f"Failed to create connector '{self}':\n{traceback.format_exc()}", stack=False)
         engine = None
 

--- a/meerschaum/connectors/sql/_users.py
+++ b/meerschaum/connectors/sql/_users.py
@@ -43,7 +43,9 @@ def register_user(
         'password_hash': user.password_hash,
         'user_type': user.type,
         'attributes': (
-            json.dumps(user.attributes) if self.flavor not in json_flavors else user.attributes
+            json.dumps(user.attributes)
+            if self.flavor not in json_flavors
+            else user.attributes
         ),
     }
     if old_id is not None:
@@ -109,7 +111,7 @@ def edit_user(
     user_id = user.user_id if user.user_id is not None else self.get_user_id(user, debug=debug)
     if user_id is None:
         return False, (
-            f"User '{user.username}' does not exist. " +
+            f"User '{user.username}' does not exist. "
             f"Register user '{user.username}' before editing."
         )
     user.user_id = user_id

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -7,6 +7,7 @@ Verify the contents of a pipe by resyncing its interval.
 """
 
 from datetime import datetime, timedelta
+import time
 
 import meerschaum as mrsm
 from meerschaum.utils.typing import SuccessTuple, Any, Optional, Union, Tuple, Dict
@@ -183,6 +184,7 @@ def verify(
         )
     )
     message_header = f"{begin_to_print} - {end_to_print}"
+    max_chunks_syncs = mrsm.get_config('pipes', 'verify', 'max_chunks_syncs')
 
     info(
         f"Verifying {self}:\n    Syncing {len(chunk_bounds)} chunk"
@@ -239,15 +241,20 @@ def verify(
                     f"Row-counts are out-of-sync ({checked_rows_str})."
                 )
 
-        while num_syncs < MAX_CHUNKS_SYNCS
-        chunk_success, chunk_msg = self.sync(
-            begin=chunk_begin,
-            end=chunk_end,
-            params=params,
-            workers=_workers,
-            debug=debug,
-            **kwargs
-        ) if do_sync else (chunk_success, chunk_msg)
+        num_syncs = 0
+        while num_syncs < max_chunks_syncs:
+            chunk_success, chunk_msg = self.sync(
+                begin=chunk_begin,
+                end=chunk_end,
+                params=params,
+                workers=_workers,
+                debug=debug,
+                **kwargs
+            ) if do_sync else (chunk_success, chunk_msg)
+            if chunk_success:
+                break
+            num_syncs += 1
+            time.sleep(num_syncs**2)
         chunk_msg = chunk_msg.strip()
         if ' - ' not in chunk_msg:
             chunk_label = f"{chunk_begin} - {chunk_end}"

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -219,9 +219,9 @@ def verify(
                 debug=debug,
             )
             checked_rows_str = (
-                f"checked {existing_rowcount} row"
+                f"checked {existing_rowcount:,} row"
                 + ("s" if existing_rowcount != 1 else '')
-                + f" vs {remote_rowcount} remote"
+                + f" vs {remote_rowcount:,} remote"
             )
             if (
                 existing_rowcount is not None
@@ -239,6 +239,7 @@ def verify(
                     f"Row-counts are out-of-sync ({checked_rows_str})."
                 )
 
+        while num_syncs < MAX_CHUNKS_SYNCS
         chunk_success, chunk_msg = self.sync(
             begin=chunk_begin,
             end=chunk_end,
@@ -252,6 +253,7 @@ def verify(
             chunk_label = f"{chunk_begin} - {chunk_end}"
             chunk_msg = f'Verified chunk for {self}:\n{chunk_label}\n{chunk_msg}'
         mrsm.pprint((chunk_success, chunk_msg))
+
         return chunk_begin_and_end, (chunk_success, chunk_msg)
 
     ### If we have more than one chunk, attempt to sync the first one and return if its fails.

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -222,7 +222,7 @@ def filter_unseen_df(
     numeric_cols_precisions_scales = {
         col: get_numeric_precision_scale(None, typ)
         for col, typ in dtypes.items()
-        if col and typ and typ.startswith('numeric')
+        if col and str(typ).lower().startswith('numeric')
     }
 
     dt_dtypes = {

--- a/scripts/docker/image_setup.sh
+++ b/scripts/docker/image_setup.sh
@@ -48,6 +48,7 @@ if [ "$MRSM_DEP_GROUP" != "minimal" ]; then
       libgtk-3-dev \
       gir1.2-webkit2-4.0 \
       htop \
+      openssl \
       || exit 1
   fi
 


### PR DESCRIPTION
# v2.8.3

- **Increase username limit to 60 characters.**
- **Add chunk retries to `Pipe.verify()`.**
- **Add instance keys to remaining pipes endpoints.**
- **Misc bugfixes.**
