### PR TITLE
🔐 v2.8.4 Improve API allowed instance keys settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.8.4
+
+- **Allow for pattern matching in `allowed_instance_keys`.**  
+  You may now generalize the instances exposed by the API by using Unix-style patterns in the list `system:api:permissions:instances:allowed_instance_keys`:
+
+  ```json
+  {
+    "api": {
+      "permissions": {
+        "instances": {
+          "allowed_instance_keys": [
+            "valkey:*",
+            "*_dev"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+- **Return pipe attributes for the route `/pipes/{connector}/{metric}/{location}`.**  
+  The API routes `/pipes/{connector}/{metric}/{location}` and `/pipes/{connector}/{metric}/{location}/attributes` both return pipe attributes.
+
+- **Check entire batches for `verify rowcounts`.**  
+  The command `verify rowcounts` will now check batch boundaries before checking row-counts for individual chunks. This should moderately increase performance.
+
+- **Kill orphaned child processes when the parent job is killed.**  
+  Jobs created with pipeline arguments should now kill associated child processes.
+
+- **Add `--skip-hooks`.**  
+  The flag `--skip-hooks` prevents any sync hooks from firing when syncing pipes.
+
+- **Fix `allowed_instance_keys` enforcement.**
+
 ### v2.8.3
 
 - **Increase username limit to 60 characters.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add `--skip-hooks`.**  
   The flag `--skip-hooks` prevents any sync hooks from firing when syncing pipes.
 
+- **Remove datetime rounding from `parse_schedule()`.**  
+  Scheduled actions now behave as expected ― the current timestamp is no longer rounded to the nearest minute, which was causing issues with the `starting in` delay feature.
+
 - **Fix `allowed_instance_keys` enforcement.**
 
 ### v2.8.3

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,40 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.8.4
+
+- **Allow for pattern matching in `allowed_instance_keys`.**  
+  You may now generalize the instances exposed by the API by using Unix-style patterns in the list `system:api:permissions:instances:allowed_instance_keys`:
+
+  ```json
+  {
+    "api": {
+      "permissions": {
+        "instances": {
+          "allowed_instance_keys": [
+            "valkey:*",
+            "*_dev"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+- **Return pipe attributes for the route `/pipes/{connector}/{metric}/{location}`.**  
+  The API routes `/pipes/{connector}/{metric}/{location}` and `/pipes/{connector}/{metric}/{location}/attributes` both return pipe attributes.
+
+- **Check entire batches for `verify rowcounts`.**  
+  The command `verify rowcounts` will now check batch boundaries before checking row-counts for individual chunks. This should moderately increase performance.
+
+- **Kill orphaned child processes when the parent job is killed.**  
+  Jobs created with pipeline arguments should now kill associated child processes.
+
+- **Add `--skip-hooks`.**  
+  The flag `--skip-hooks` prevents any sync hooks from firing when syncing pipes.
+
+- **Fix `allowed_instance_keys` enforcement.**
+
 ### v2.8.3
 
 - **Increase username limit to 60 characters.**

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -36,6 +36,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Add `--skip-hooks`.**  
   The flag `--skip-hooks` prevents any sync hooks from firing when syncing pipes.
 
+- **Remove datetime rounding from `parse_schedule()`.**  
+  Scheduled actions now behave as expected ― the current timestamp is no longer rounded to the nearest minute, which was causing issues with the `starting in` delay feature.
+
 - **Fix `allowed_instance_keys` enforcement.**
 
 ### v2.8.3

--- a/docs/mkdocs/reference/api-instance/nginx.md
+++ b/docs/mkdocs/reference/api-instance/nginx.md
@@ -29,7 +29,7 @@ server {
         proxy_pass http://localhost:8000;
     }
 
-    location ~* /(ws|websocket)(/|$)
+    location ~* /(ws|websocket)(/|$) {
         proxy_pass http://localhost:8000$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -67,7 +67,7 @@ server {
         proxy_pass http://localhost:8000;
     }
     
-    location ~* /(ws|websocket)$ {
+    location ~* /(ws|websocket)(/|$) {
         proxy_pass http://localhost:8000$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/docs/mkdocs/reference/connectors/instance-connectors.md
+++ b/docs/mkdocs/reference/connectors/instance-connectors.md
@@ -169,7 +169,7 @@ Note that a pipe's attributes must be JSON-serializable, so objects like MongoDB
         pipe: mrsm.Pipe,
         debug: bool = False,
         **kwargs: Any
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Return the pipe's document from the internal `pipes` collection.
 
@@ -701,30 +701,30 @@ You may choose to implement `get_pipe_columns_indices()`, which returns a dictio
 
 ??? example
 
-```python
-def get_pipe_columns_indices(
-    debug: bool = False,
-) -> dict[str, list[dict[str, str]]]:
-    """
-    Return a dictionary mapping columns to metadata about related indices.
+    ```python
+    def get_pipe_columns_indices(
+        debug: bool = False,
+    ) -> dict[str, list[dict[str, str]]]:
+        """
+        Return a dictionary mapping columns to metadata about related indices.
 
-    Parameters
-    ----------
-    pipe: mrsm.Pipe
-        The pipe whose target table has related indices.
+        Parameters
+        ----------
+        pipe: mrsm.Pipe
+            The pipe whose target table has related indices.
 
-    Returns
-    -------
-    A list of dictionaries with the keys "type" and "name".
+        Returns
+        -------
+        A list of dictionaries with the keys "type" and "name".
 
-    Examples
-    --------
-    >>> pipe = mrsm.Pipe('demo', 'shirts', columns={'primary': 'id'}, indices={'size_color': ['color', 'size']})
-    >>> pipe.sync([{'color': 'red', 'size': 'M'}])
-    >>> pipe.get_columns_indices()
-    {'id': [{'name': 'demo_shirts_pkey', 'type': 'PRIMARY KEY'}], 'color': [{'name': 'IX_demo_shirts_color_size', 'type': 'INDEX'}], 'size': [{'name': 'IX_demo_shirts_color_size', 'type': 'INDEX'}]}
-    """
-```
+        Examples
+        --------
+        >>> pipe = mrsm.Pipe('demo', 'shirts', columns={'primary': 'id'}, indices={'size_color': ['color', 'size']})
+        >>> pipe.sync([{'color': 'red', 'size': 'M'}])
+        >>> pipe.get_columns_indices()
+        {'id': [{'name': 'demo_shirts_pkey', 'type': 'PRIMARY KEY'}], 'color': [{'name': 'IX_demo_shirts_color_size', 'type': 'INDEX'}], 'size': [{'name': 'IX_demo_shirts_color_size', 'type': 'INDEX'}]}
+        """
+    ```
 
 ## `#!python get_pipe_rowcount()`
 

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -368,6 +368,11 @@ groups['sync'].add_argument(
     ),
 )
 groups['sync'].add_argument(
+    '--skip-hooks', action='store_true', help=(
+        "Skip calling the sync hooks."
+    )
+)
+groups['sync'].add_argument(
     '--cache', action='store_true',
     help=(
         "When syncing or viewing a pipe's data, sync to a local database for later analysis."

--- a/meerschaum/actions/drop.py
+++ b/meerschaum/actions/drop.py
@@ -86,7 +86,7 @@ def _drop_pipes(
         pprint(success_dict)
 
     msg = (
-        f"Finished dropping {len(pipes)} pipes"
+        f"Finished dropping {len(pipes)} pipe"
         + ('s' if len(pipes) != 1 else '')
         + f"\n    ({successes} succeeded, {fails} failed)."
     )

--- a/meerschaum/actions/start.py
+++ b/meerschaum/actions/start.py
@@ -611,7 +611,9 @@ def _start_pipeline(
     do_n_times = (
         int(action[0].lstrip('x'))
         if action and is_int(action[0].lstrip('x'))
-        else 1
+        else (
+            1 if not loop else -1
+        )
     )
 
     params = params or {}
@@ -678,7 +680,6 @@ def _start_pipeline(
         warn("Cancelled pipeline.", stack=False)
         if proc is not None:
             _stop_process(proc)
-        success = False
         if msg == default_msg:
             msg = "Pipeline was cancelled."
 

--- a/meerschaum/actions/start.py
+++ b/meerschaum/actions/start.py
@@ -568,9 +568,9 @@ def _start_pipeline(
     Examples
     --------
 
-    `sync pipes -i sql:local + sync pipes -i sql:main :: -s 'daily'`
+    `sync pipes -i sql:local + sync pipes -i sql:main : -s 'daily'`
 
-    `show version + show arguments :: --loop`
+    `show version + show arguments : --loop`
 
     """
     import json
@@ -580,10 +580,11 @@ def _start_pipeline(
     from meerschaum.utils.warnings import info, warn
     from meerschaum.utils.misc import is_int
     from meerschaum.utils.venv import venv_exec
-    from meerschaum.utils.process import poll_process
+    from meerschaum.utils.process import poll_process, _stop_process
     fence_begin, fence_end = '<MRSM_RESULT>', '</MRSM_RESULT>'
 
-    success, msg = False, "Did not run pipeline."
+    default_msg = "Did not pipeline."
+    success, msg = False, default_msg
     def write_line(line):
         nonlocal success, msg
         decoded = line.decode('utf-8')
@@ -623,8 +624,9 @@ def _start_pipeline(
     if min_seconds is None:
         min_seconds = 1.0
 
+    proc = None
     def do_entry() -> None:
-        nonlocal success, msg
+        nonlocal success, msg, proc
         if timeout_seconds is None:
             success, msg = entry(sub_args_line, _patch_args=patch_args)
             return
@@ -674,6 +676,11 @@ def _start_pipeline(
         run_loop()
     except KeyboardInterrupt:
         warn("Cancelled pipeline.", stack=False)
+        if proc is not None:
+            _stop_process(proc)
+        success = False
+        if msg == default_msg:
+            msg = "Pipeline was cancelled."
 
     if do_n_times != 1:
         info(f"Ran pipeline {ran_n_times} time" + ('s' if ran_n_times != 1 else '') + '.')

--- a/meerschaum/api/__init__.py
+++ b/meerschaum/api/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from fnmatch import fnmatch
 
 import meerschaum as mrsm
 from meerschaum.utils.typing import Dict, Any, Optional, PipesDict
@@ -119,14 +120,19 @@ def get_api_connector(instance_keys: Optional[str] = None):
         )
 
     allowed_instance_keys = permissions_config.get(
-        'instance', {}
+        'instances', {}
     ).get(
         'allowed_instance_keys',
         ['*']
     )
-    if allowed_instance_keys != ['*'] and instance_keys not in allowed_instance_keys:
+    found_match: bool = False
+    for allowed_keys_pattern in allowed_instance_keys:
+        if fnmatch(instance_keys, allowed_keys_pattern):
+            found_match = True
+            break
+    if not found_match:
         raise APIPermissionError(
-            f"Instance keys '{instance_keys}' not in list of allowed instances."
+            f"Instance keys '{instance_keys}' does not match the allowed instances patterns."
         )
 
     with _locks[f'instance-{instance_keys}']:

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -272,7 +272,7 @@ async def get_pipes_by_connector_and_metric(
 
 
 @app.get(pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}', tags=['Pipes'])
-async def get_pipes_by_connector_and_metric_and_location(
+async def get_pipe_by_connector_and_metric_and_location(
     connector_keys: str,
     metric_key: str,
     location_key: str,
@@ -299,7 +299,7 @@ async def get_pipes_by_connector_and_metric_and_location(
             detail=f"location_key '{location_key}' not found."
         )
 
-    return str(pipes(instance_keys)[connector_keys][metric_key][location_key])
+    return pipes(instance_keys)[connector_keys][metric_key][location_key].attributes
 
 
 @app.get(pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/sync_time', tags=['Pipes'])
@@ -522,7 +522,6 @@ def get_pipe_csv(
     if params == 'null':
         params = None
     if params is not None:
-        import json
         try:
             _params = json.loads(params)
         except Exception:

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.8.3"
+__version__ = "2.8.4"

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -184,7 +184,7 @@ class SQLConnector(Connector):
         ### ensure flavor and label are set accordingly
         if 'flavor' not in self.__dict__:
             if flavor is None and 'uri' not in self.__dict__:
-                raise Exception(
+                raise ValueError(
                     f"    Missing flavor. Provide flavor as a key for '{self}'."
                 )
             self.flavor = flavor or self.parse_uri(self.__dict__['uri']).get('flavor', None)

--- a/meerschaum/jobs/systemd.py
+++ b/meerschaum/jobs/systemd.py
@@ -154,7 +154,7 @@ class SystemdExecutor(Executor):
             STATIC_CONFIG['environment']['systemd_delete_job']: (
                 '1'
                 if job.delete_after_completion
-                else '0',
+                else '0'
             ),
         })
 

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -58,7 +58,7 @@ packages: Dict[str, Dict[str, str]] = {
     '_internal'                      : {
         'apscheduler'                : (
                                        f"{_MRSM_PACKAGE_ARCHIVES_PREFIX}"
-                                       "APScheduler-4.0.0a5.post75+mrsm-py3-none-any.whl>=4.0.0a5"
+                                       "APScheduler-4.0.0a5.post87+mrsm-py3-none-any.whl>=4.0.0a5"
         ),
         'dataclass_wizard'           : 'dataclass-wizard>=0.28.0',
     },

--- a/meerschaum/utils/schedule.py
+++ b/meerschaum/utils/schedule.py
@@ -95,7 +95,7 @@ def schedule_function(
     A `SuccessTuple` upon exit.
     """
     import asyncio
-    from meerschaum.utils.misc import filter_keywords, round_time
+    from meerschaum.utils.misc import filter_keywords
 
     global _scheduler
     kw['debug'] = debug
@@ -103,7 +103,7 @@ def schedule_function(
 
     _ = mrsm.attempt_import('attrs', lazy=False)
     apscheduler = mrsm.attempt_import('apscheduler', lazy=False)
-    now = round_time(datetime.now(timezone.utc), timedelta(minutes=1))
+    now = datetime.now(timezone.utc)
     trigger = parse_schedule(schedule, now=now)
     _scheduler = apscheduler.AsyncScheduler(identity='mrsm-scheduler')
     try:
@@ -296,7 +296,7 @@ def parse_start_time(schedule: str, now: Optional[datetime] = None) -> datetime:
     dateutil_parser = mrsm.attempt_import('dateutil.parser')
     starting_parts = schedule.split(STARTING_KEYWORD)
     starting_str = ('now' if len(starting_parts) == 1 else starting_parts[-1]).strip()
-    now = now or round_time(datetime.now(timezone.utc), timedelta(minutes=1))
+    now = now or datetime.now(timezone.utc)
     try:
         if starting_str == 'now':
             starting_ts = now

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1548,7 +1548,7 @@ def get_update_queries(
     from meerschaum.utils.debug import dprint
     from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.dtypes.sql import DB_FLAVORS_CAST_DTYPES, get_pd_type_from_db_type
-    flavor = flavor or (connectable.flavor if isinstance(connectable, SQLConnector) else None)
+    flavor = flavor or getattr(connectable, 'flavor', None)
     if not flavor:
         raise ValueError("Provide a flavor if using a SQLAlchemy session.")
     if (

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -595,7 +595,7 @@ def venv_exec(
     as_proc: bool = False,
     capture_output: bool = True,
     debug: bool = False,
-) -> Union[bool, Tuple[int, bytes, bytes]]:
+) -> Union[bool, Tuple[int, bytes, bytes], 'subprocess.Popen']:
     """
     Execute Python code in a subprocess via a virtual environment's interpeter.
     Return `True` if the code successfully executes, `False` on failure.
@@ -630,6 +630,8 @@ def venv_exec(
     import subprocess
     import platform
     from meerschaum.utils.debug import dprint
+    from meerschaum.utils.process import _child_processes
+
     executable = venv_executable(venv=venv)
     cmd_list = [executable, '-c', code]
     if env is None:
@@ -656,6 +658,7 @@ def venv_exec(
         **group_kwargs
     )
     if as_proc:
+        _child_processes.append(process)
         return process
     stdout, stderr = process.communicate()
     exit_code = process.returncode


### PR DESCRIPTION
# v2.8.4

- **Allow for pattern matching in `allowed_instance_keys`.**  
  You may now generalize the instances exposed by the API by using Unix-style patterns in the list `system:api:permissions:instances:allowed_instance_keys`:

  ```json
  {
    "api": {
      "permissions": {
        "instances": {
          "allowed_instance_keys": [
            "valkey:*",
            "*_dev"
          ]
        }
      }
    }
  }
  ```

- **Return pipe attributes for the route `/pipes/{connector}/{metric}/{location}`.**  
  The API routes `/pipes/{connector}/{metric}/{location}` and `/pipes/{connector}/{metric}/{location}/attributes` both return pipe attributes.

- **Check entire batches for `verify rowcounts`.**  
  The command `verify rowcounts` will now check batch boundaries before checking row-counts for individual chunks. This should moderately increase performance.

- **Kill orphaned child processes when the parent job is killed.**  
  Jobs created with pipeline arguments should now kill associated child processes.

- **Add `--skip-hooks`.**  
  The flag `--skip-hooks` prevents any sync hooks from firing when syncing pipes.

- **Fix `allowed_instance_keys` enforcement.**
