### PR TITLE
🐛 v2.9.2 Fix in-place PostGIS syncs, improve chunk bounds for verifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.9.1
+
+- **Fix in-place syncs with `GEOMETRY` columns.**
+  The query to retrieve `GEOMETRY` data types for PostGIS has been fixed.
+  
+- **Consolidate 1-minute chunks in `Pipe.get_chunk_bounds()`.**  
+  The chunk bounds returned from `Pipe.get_chunk_bounds()` (without specifiying an `end`) now consolidate the 1-minute chunk into the last chunk:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('demo', 'chunk_bounds', columns={'datetime': 'dt'}, instance='sql:local')
+  pipe.sync([
+      {'dt': '2025-01-01'},
+      {'dt': '2025-01-02'},
+  ])
+  mrsm.pprint(pipe.get_chunk_bounds(bounded=True))
+  # [
+  #   (
+  #       datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+  #       datetime.datetime(2025, 1, 2, 0, 1, tzinfo=datetime.timezone.utc)
+  #   )
+  # ] 
+  ```
+
+- **Remove unnecessary `CREATE SCHEMA IF EXISTS` checks.**
+- **Fix unsupported syntax for Python 3.8.**
+- **Truncate long connector keys in the Shell prompt.**
+- **Fix null location keys behavior for pipes cards.**
+
 ### v2.9.0 ― v2.9.1
 
 - **Add the dtype `geometry` (and `geography`).**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,35 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v2.9.1
+
+- **Fix in-place syncs with `GEOMETRY` columns.**
+  The query to retrieve `GEOMETRY` data types for PostGIS has been fixed.
+  
+- **Consolidate 1-minute chunks in `Pipe.get_chunk_bounds()`.**  
+  The chunk bounds returned from `Pipe.get_chunk_bounds()` (without specifiying an `end`) now consolidate the 1-minute chunk into the last chunk:
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe('demo', 'chunk_bounds', columns={'datetime': 'dt'}, instance='sql:local')
+  pipe.sync([
+      {'dt': '2025-01-01'},
+      {'dt': '2025-01-02'},
+  ])
+  mrsm.pprint(pipe.get_chunk_bounds(bounded=True))
+  # [
+  #   (
+  #       datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
+  #       datetime.datetime(2025, 1, 2, 0, 1, tzinfo=datetime.timezone.utc)
+  #   )
+  # ] 
+  ```
+
+- **Remove unnecessary `CREATE SCHEMA IF EXISTS` checks.**
+- **Fix unsupported syntax for Python 3.8.**
+- **Truncate long connector keys in the Shell prompt.**
+- **Fix null location keys behavior for pipes cards.**
+
 ### v2.9.0 ― v2.9.1
 
 - **Add the dtype `geometry` (and `geography`).**  

--- a/meerschaum/api/dash/pages/pipes.py
+++ b/meerschaum/api/dash/pages/pipes.py
@@ -7,13 +7,16 @@ Display pipes via a shareable URL.
 
 from meerschaum.api import CHECK_UPDATE
 from meerschaum.utils.packages import import_html, import_dcc
-from meerschaum.api.dash.components import download_dataframe
+from meerschaum.api.dash.components import download_dataframe, pages_navbar
 
 html, dcc = import_html(check_update=CHECK_UPDATE), import_dcc(check_update=CHECK_UPDATE)
 import dash_bootstrap_components as dbc
 
-layout = dbc.Container([
-    dcc.Location('pipes-location'),
-    download_dataframe,
-    html.Div(id='pipe-output-div'),
-])
+layout = [
+    pages_navbar,
+    dbc.Container([
+        dcc.Location('pipes-location'),
+        download_dataframe,
+        html.Div(id='pipe-output-div'),
+    ])
+]

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -55,6 +55,8 @@ window.addEventListener(
         if (typeof lk === "string"){
             quote_str = lk.includes(" ") ? "'" : "";
             location_keys_str += " " + quote_str + lk + quote_str;
+        } else if (lk === null) {
+            location_keys_str += " None";
         }
     }
     if (location_keys_str === " -l"){

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.9.1"
+__version__ = "2.9.2"

--- a/meerschaum/core/Pipe/_verify.py
+++ b/meerschaum/core/Pipe/_verify.py
@@ -282,6 +282,7 @@ def verify(
             )
         bounds_success_tuples[first_chunk_bounds] = (first_success, first_msg)
         info(f"Completed first chunk for {self}:\n    {first_label}\n")
+        chunk_bounds = chunk_bounds[1:]
 
     pool = get_pool(workers=workers)
     batches = self.get_chunk_bounds_batches(chunk_bounds, batchsize=batchsize, workers=workers)

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -542,7 +542,7 @@ def serialize_geometry(
     geom: Any,
     geometry_format: str = 'wkb_hex',
     as_wkt: bool = False,
-) -> Union[str, Dict[str, Any]]:
+) -> Union[str, Dict[str, Any], None]:
     """
     Serialize geometry data as a hex-encoded well-known-binary string. 
 
@@ -560,6 +560,8 @@ def serialize_geometry(
     -------
     A string containing the geometry data.
     """
+    if value_is_null(geom):
+        return None
     shapely = mrsm.attempt_import('shapely', lazy=False)
     if geometry_format == 'geojson':
         geojson_str = shapely.to_geojson(geom)
@@ -579,7 +581,7 @@ def deserialize_geometry(geom_wkb: Union[str, bytes]):
     return shapely.wkb.loads(geom_wkb)
 
 
-def deserialize_bytes_string(data: str | None, force_hex: bool = False) -> bytes | None:
+def deserialize_bytes_string(data: Optional[str], force_hex: bool = False) -> Union[bytes, None]:
     """
     Given a serialized ASCII string of bytes data, return the original bytes.
     The input data may either be base64- or hex-encoded.

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -1355,6 +1355,39 @@ def truncate_string_sections(item: str, delimeter: str = '_', max_len: int = 128
     return delimeter.join([s for i, s in new_sections])
 
 
+def truncate_text_for_display(
+    text: str,
+    max_length: int = 50,
+    suffix: str = '…',
+) -> str:
+    """
+    Truncate a potentially long string for display purposes.
+
+    Parameters
+    ----------
+    text: str
+        The string to be truncated.
+
+    max_length: int, default 60
+        The maximum length of `text` before truncation.
+
+    suffix: str, default '…'
+        The string to append to the length of `text` to indicate truncation.
+
+    Returns
+    -------
+    A string of length `max_length` or less.
+    """
+    text_length = len(text)
+    if text_length <= max_length:
+        return text
+
+    suffix_length = len(suffix)
+
+    truncated_text = text[:max_length - suffix_length]
+    return truncated_text + suffix
+
+
 def separate_negation_values(
     vals: Union[List[str], Tuple[str]],
     negation_prefix: Optional[str] = None,


### PR DESCRIPTION
# v2.9.1

- **Fix in-place syncs with `GEOMETRY` columns.**
  The query to retrieve `GEOMETRY` data types for PostGIS has been fixed.
  
- **Consolidate 1-minute chunks in `Pipe.get_chunk_bounds()`.**  
  The chunk bounds returned from `Pipe.get_chunk_bounds()` (without specifiying an `end`) now consolidate the 1-minute chunk into the last chunk:

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe('demo', 'chunk_bounds', columns={'datetime': 'dt'}, instance='sql:local')
  pipe.sync([
      {'dt': '2025-01-01'},
      {'dt': '2025-01-02'},
  ])
  mrsm.pprint(pipe.get_chunk_bounds(bounded=True))
  # [
  #   (
  #       datetime.datetime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
  #       datetime.datetime(2025, 1, 2, 0, 1, tzinfo=datetime.timezone.utc)
  #   )
  # ] 
  ```

- **Remove unnecessary `CREATE SCHEMA IF EXISTS` checks.**
- **Fix unsupported syntax for Python 3.8.**
- **Truncate long connector keys in the Shell prompt.**
- **Fix null location keys behavior for pipes cards.**
