### PR TITLE
✨ v2.9.5 Add the "Query Data" dropdown to the pipe cards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.9.2 – v2.9.3
+### v2.9.5
+
+- **Add the `Query Data` dropdown to pipes' cards.**  
+  Similar to the `Recent Data` dropdown, you can now explore a pipe's data with the `Query Data` dropdown. This supports `begin`, `end`, `params`, and `limit` filtering.
+  
+- **Additional fixes for in-place syncs on PostGIS.**  
+  Geometry columns are now correctly coalesced for PostGIS.
+
+### v2.9.2 – v2.9.4
 
 - **Fix in-place syncs with `GEOMETRY` columns.**
   The query to retrieve `GEOMETRY` data types for PostGIS has been fixed.

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,7 +4,15 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v2.9.2 – v2.9.3
+### v2.9.5
+
+- **Add the `Query Data` dropdown to pipes' cards.**  
+  Similar to the `Recent Data` dropdown, you can now explore a pipe's data with the `Query Data` dropdown. This supports `begin`, `end`, `params`, and `limit` filtering.
+  
+- **Additional fixes for in-place syncs on PostGIS.**  
+  Geometry columns are now correctly coalesced for PostGIS.
+
+### v2.9.2 – v2.9.4
 
 - **Fix in-place syncs with `GEOMETRY` columns.**
   The query to retrieve `GEOMETRY` data types for PostGIS has been fixed.

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -343,6 +343,7 @@ def accordion_items_from_pipe(
         items_titles['sql'] = '📃 SQL Query'
     items_titles.update({
         'recent-data': '🗃️ Recent Data',
+        'query-data': '🔍 Query Data',
         'sync-data': '📝 Sync Documents',
     })
 
@@ -668,6 +669,68 @@ def accordion_items_from_pipe(
         except Exception:
             table = html.P("Could not retrieve recent data.")
         items_bodies['recent-data'] = table
+
+    if 'query-data' in active_items:
+        query_editor = dash_ace.DashAceEditor(
+            value='{\n    \n}',
+            mode='norm',
+            tabSize=4,
+            theme='twilight',
+            id={'type': 'query-editor', 'index': json.dumps(pipe.meta)},
+            width='100%',
+            height='200px',
+            readOnly=False,
+            showGutter=True,
+            showPrintMargin=False,
+            highlightActiveLine=True,
+            wrapEnabled=True,
+            style={'min-height': '120px'},
+        )
+        query_data_button = dbc.Button(
+            "Query",
+            id={'type': 'query-data-button', 'index': json.dumps(pipe.meta)},
+        )
+
+        begin_end_input_group = dbc.InputGroup(
+            [
+                dbc.Input(
+                    id={'type': 'query-data-begin-input', 'index': json.dumps(pipe.meta)},
+                    placeholder="Begin",
+                ),
+                dbc.Input(
+                    id={'type': 'query-data-end-input', 'index': json.dumps(pipe.meta)},
+                    placeholder="End",
+                ),
+            ],
+            size="sm",
+        )
+
+        limit_input = dbc.Input(
+            type="number",
+            min=0,
+            max=100,
+            value=10,
+            step=1,
+            placeholder="Limit",
+            id={'type': 'limit-input', 'index': json.dumps(pipe.meta)},
+        )
+        query_result_div = html.Div(id={'type': 'query-result-div', 'index': json.dumps(pipe.meta)})
+
+        items_bodies['query-data'] = html.Div([
+            query_editor,
+            html.Br(),
+            dbc.Row(
+                [
+                    dbc.Col([query_data_button], lg=2, md=3, sm=4, xs=6, width=2),
+                    dbc.Col([begin_end_input_group], lg=3, md=3, sm=4, width=4),
+                    dbc.Col(html.Div([limit_input, dbc.FormText("Row Limit")]), lg=2, md=3, sm=4, xs=6, width=2),
+                ],
+                justify="between",
+            ),
+            dbc.Row([
+                dbc.Col([query_result_div], width=True),
+            ]),
+        ])
 
     if 'sync-data' in active_items:
         backtrack_df = pipe.get_backtrack_data(debug=debug, limit=1)

--- a/meerschaum/api/resources/static/css/dash.css
+++ b/meerschaum/api/resources/static/css/dash.css
@@ -80,3 +80,19 @@ a {
 .pages-offcanvas-accordion div {
   padding: 0 !important;
 }
+
+/* restyle radio items */
+.radio-group .form-check {
+  padding-left: 0;
+}
+
+.radio-group .btn-group > .form-check:not(:last-child) > .btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.radio-group .btn-group > .form-check:not(:first-child) > .btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -1px;
+}

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.9.4"
+__version__ = "2.9.5"

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -928,7 +928,7 @@ def to_sql(
             df[col] = df[col].apply(
                 functools.partial(
                     serialize_geometry,
-                    as_wkt=(self.flavor == 'mssql')
+                    geometry_format=('wkt' if self.flavor == 'mssql' else 'wkb_hex'),
                 )
             )
 

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -1138,10 +1138,10 @@ def enforce_dtypes(
         if parsed_geom_cols:
             if debug:
                 dprint(f"Converting to GeoDataFrame (geometry column: '{parsed_geom_cols[0]}')...")
-            df = geopandas.GeoDataFrame(df, geometry=parsed_geom_cols[0])
             try:
+                df = geopandas.GeoDataFrame(df, geometry=parsed_geom_cols[0])
                 df.rename_geometry(parsed_geom_cols[0], inplace=True)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
     df_dtypes = {c: str(t) for c, t in df.dtypes.items()}

--- a/meerschaum/utils/dtypes/__init__.py
+++ b/meerschaum/utils/dtypes/__init__.py
@@ -541,7 +541,6 @@ def serialize_bytes(data: bytes) -> str:
 def serialize_geometry(
     geom: Any,
     geometry_format: str = 'wkb_hex',
-    as_wkt: bool = False,
 ) -> Union[str, Dict[str, Any], None]:
     """
     Serialize geometry data as a hex-encoded well-known-binary string. 
@@ -588,7 +587,7 @@ def deserialize_bytes_string(data: Optional[str], force_hex: bool = False) -> Un
 
     Parameters
     ----------
-    data: str | None
+    data: Optional[str]
         The string to be deserialized into bytes.
         May be base64- or hex-encoded (prefixed with `'\\x'`).
 
@@ -625,7 +624,7 @@ def deserialize_base64(data: str) -> bytes:
     return base64.b64decode(data)
 
 
-def encode_bytes_for_bytea(data: bytes, with_prefix: bool = True) -> str | None:
+def encode_bytes_for_bytea(data: bytes, with_prefix: bool = True) -> Union[str, None]:
     """
     Return the given bytes as a hex string for PostgreSQL's `BYTEA` type.
     """

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -1838,10 +1838,9 @@ def get_null_replacement(typ: str, flavor: str) -> str:
     A value which may stand in place of NULL for this type.
     `'None'` is returned if a value cannot be determined.
     """
-    from meerschaum.utils.dtypes import are_dtypes_equal
     from meerschaum.utils.dtypes.sql import DB_FLAVORS_CAST_DTYPES
     if 'geometry' in typ.lower():
-        return '010100000000008058346FCDC100008058346FCDC1'
+        return "'010100000000008058346FCDC100008058346FCDC1'"
     if 'int' in typ.lower() or typ.lower() in ('numeric', 'number'):
         return '-987654321'
     if 'bool' in typ.lower() or typ.lower() == 'bit':


### PR DESCRIPTION
# v2.9.5

- **Add the `Query Data` dropdown to pipes' cards.**  
  Similar to the `Recent Data` dropdown, you can now explore a pipe's data with the `Query Data` dropdown. This supports `begin`, `end`, `params`, and `limit` filtering.
  
- **Additional fixes for in-place syncs on PostGIS.**  
  Geometry columns are now correctly coalesced for PostGIS.
