### PR TITLE
🌎 v2.9.6 Project GeoJSON as WGS84.

### DIFF
--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.9.6.dev1"
+__version__ = "2.9.6"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "2.9.5"
+__version__ = "2.9.6.dev1"


### PR DESCRIPTION
# v2.9.6

- **Project geometry data to WGS84 (EPSG:4326) when serializing as GeoJSON.**  
  Setting `geometry_format` to `geojson` for `to_json()` (and `serialize_geometry()`) will project to WGS84 if a CRS is provided (to meet the 2016 GeoJSON specification).