### PR TITLE
🐛 v3.0.2 Improve context handling in the CLI daemon.

### DIFF
--- a/meerschaum/_internal/cli/entry.py
+++ b/meerschaum/_internal/cli/entry.py
@@ -140,6 +140,7 @@ def entry_with_daemon(
         'patch_args': _patch_args,
         'env': env,
         'config': config,
+        'cwd': os.getcwd(),
     })
 
     accepted = False

--- a/meerschaum/_internal/cli/workers.py
+++ b/meerschaum/_internal/cli/workers.py
@@ -319,6 +319,9 @@ class ActionWorker:
             action_id = input_data.get('action_id', None)
             patch_args = input_data.get('patch_args', None)
             env = input_data.get('env', {})
+            old_cwd = os.getcwd()
+            cwd = input_data.get('cwd', os.getcwd())
+            os.chdir(cwd)
             config = input_data.get('config', {})
             self.write_output_data({
                 'state': 'accepted',
@@ -334,6 +337,8 @@ class ActionWorker:
                         _patch_args=patch_args,
                     )
                     print(STOP_TOKEN, flush=True, end='\n')
+
+            os.chdir(old_cwd)
 
             self.write_output_data({
                 'state': 'completed',

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -134,6 +134,8 @@ default_system_config = {
             'stop daemon',
             'show daemon',
             'restart daemon',
+            'install',
+            'upgrade',
             'reload',
             'start worker',
             'show log',

--- a/meerschaum/config/_read_config.py
+++ b/meerschaum/config/_read_config.py
@@ -185,7 +185,6 @@ def read_config(
                         import traceback
                         traceback.print_exc()
                         _config_key = {}
-                substitute = False
                 _single_key_config = (
                     search_and_substitute_config({key: _config_key}) if substitute
                     else {key: _config_key}

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.0.1"
+__version__ = "3.0.2.dev1"

--- a/meerschaum/plugins/__init__.py
+++ b/meerschaum/plugins/__init__.py
@@ -431,8 +431,6 @@ def sync_plugins_symlinks(debug: bool = False, warn: bool = True) -> None:
             ]
         ))
         plugins_to_be_symlinked.extend(packaged_plugin_paths)
-        if debug:
-            dprint(f"{plugins_to_be_symlinked=}")
 
         ### Check for duplicates.
         seen_plugins = defaultdict(lambda: 0)

--- a/meerschaum/plugins/__init__.py
+++ b/meerschaum/plugins/__init__.py
@@ -326,23 +326,22 @@ def sync_plugins_symlinks(debug: bool = False, warn: bool = True) -> None:
     """
     Update the plugins' internal symlinks. 
     """
+    from meerschaum.utils.warnings import error, warn as _warn, dprint
     global _synced_symlinks
     with _locks['_synced_symlinks']:
         if _synced_symlinks:
+            if debug:
+                dprint("Skip syncing symlinks...")
             return
 
     import os
     import pathlib
     import time
     from collections import defaultdict
-    import importlib.util
     from meerschaum.utils.misc import flatten_list, make_symlink, is_symlink
-    from meerschaum.utils.warnings import error, warn as _warn
     from meerschaum._internal.static import STATIC_CONFIG
-    from meerschaum.utils.venv import Venv, activate_venv, deactivate_venv, is_venv_active
     from meerschaum.config._paths import (
         PLUGINS_RESOURCES_PATH,
-        PLUGINS_ARCHIVES_RESOURCES_PATH,
         PLUGINS_INIT_PATH,
         PLUGINS_DIR_PATHS,
         PLUGINS_INTERNAL_LOCK_PATH,
@@ -432,6 +431,8 @@ def sync_plugins_symlinks(debug: bool = False, warn: bool = True) -> None:
             ]
         ))
         plugins_to_be_symlinked.extend(packaged_plugin_paths)
+        if debug:
+            dprint(f"{plugins_to_be_symlinked=}")
 
         ### Check for duplicates.
         seen_plugins = defaultdict(lambda: 0)
@@ -700,7 +701,11 @@ def load_plugins(
     Import Meerschaum plugins and update the actions dictionary.
     """
     global _loaded_plugins
+    from meerschaum.utils.warnings import dprint
+
     if skip_if_loaded and _loaded_plugins:
+        if debug:
+            dprint("Skip loading plugins...")
         return
 
     from inspect import isfunction, getmembers
@@ -714,6 +719,7 @@ def load_plugins(
         recursive = True,
         modules_venvs = True
     )
+
     ### I'm appending here to keep from redefining the modules list.
     new_modules = (
         [
@@ -784,7 +790,7 @@ def unload_plugins(
     """
     Unload the specified plugins from memory.
     """
-    global _loaded_plugins
+    global _loaded_plugins, _synced_symlinks
     import sys
     from meerschaum.config.paths import PLUGINS_RESOURCES_PATH, PLUGINS_INJECTED_RESOURCES_PATH
     from meerschaum.connectors import unload_plugin_connectors
@@ -792,6 +798,7 @@ def unload_plugins(
         from meerschaum.utils.warnings import dprint
 
     _loaded_plugins = False
+    _synced_symlinks = False
 
     plugins = plugins or get_plugins_names()
     if debug:
@@ -803,6 +810,7 @@ def unload_plugins(
     module_prefix = f"{PLUGINS_RESOURCES_PATH.stem}."
     loaded_modules = [mod_name for mod_name in sys.modules if mod_name.startswith(module_prefix)]
 
+    _ = sys.modules.pop(PLUGINS_RESOURCES_PATH.stem, None)
     for plugin_name in plugins:
         for mod_name in loaded_modules:
             if mod_name[len(PLUGINS_RESOURCES_PATH.stem):].startswith(plugin_name):


### PR DESCRIPTION
# v3.0.1 – v3.0.2

- **Change the working directory for each action exected by the CLI daemon.**  
  The CLI daemon now changes working directory to match the context of the calling client. This handles relative file paths in environment variables (e.g. `MRSM_PLUGINS_DIR`).

- **Fix environment variables handling within the CLI daemon.**  
  Certain environment variables interfered with the shell and the Daemon, and this case has been handled.

- **Reload the CLI daemon after upgrading packages.**  
  Installing or upgrading packages now reloads the CLI daemon.

- **Invalidate symlinks check cache when unloading plugins.**  
  Unloading plugins now reverts the internal `_synced_symlinks` check.

- **Unload the root `plugins` package when unloading plugins.**  
  The root `plugins` package is now unloaded when `unload_plugins()` is called. This invalidates lingering cache from previously loaded plugins.
