### PR TITLE
🐛 v3.0.3 Fix cache invalidation for `valkey` connectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.0.3
+
+- **Fix pipe page routing.**  
+  Links to specific pipes in the dashboard are now routed correctly.
+
+- **Fix cache invalidation for pipes using Valkey connectors.**  
+  Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.
+
 ### v3.0.1 – v3.0.2
 
 - **Change the working directory for each action exected by the CLI daemon.**  

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,6 +4,14 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.0.3
+
+- **Fix pipe page routing.**  
+  Links to specific pipes in the dashboard are now routed correctly.
+
+- **Fix cache invalidation for pipes using Valkey connectors.**  
+  Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.
+
 ### v3.0.1 – v3.0.2
 
 - **Change the working directory for each action exected by the CLI daemon.**  

--- a/meerschaum/api/dash/callbacks/dashboard.py
+++ b/meerschaum/api/dash/callbacks/dashboard.py
@@ -160,7 +160,8 @@ def update_page_layout_div(
     else:
         session_store_to_return = dash.no_update
 
-    base_path = '/'.join(pathname.split('/')[:2])
+    dashless_pathname = pathname[len('/dash'):] if pathname.startswith('/dash') else pathname
+    base_path = ('/dash/' + dashless_pathname.lstrip('/').split('/', maxsplit=1)[0]).rstrip('/')
     complete_path = (
         pathname.rstrip('/') + '/'
     ).rstrip('/')

--- a/meerschaum/api/dash/callbacks/pipes.py
+++ b/meerschaum/api/dash/callbacks/pipes.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Dict, Any
 
 import dash
 from dash.dependencies import Input, Output, State
-from dash import no_update
 from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 
@@ -172,8 +171,9 @@ def render_pipe_page_from_url(
     Input('pipes-metric-keys-dropdown', 'value'),
     Input('pipes-location-keys-dropdown', 'value'),
     Input('pipes-tags-dropdown', 'value'),
-    Input('instance-select', 'value'),
+    Input('pipes-instance-select', 'value'),
     Input('pipes-clear-all-button', 'n_clicks'),
+    prevent_initial_call=True,
 )
 def update_location_on_pipes_filter_change(
     connector_keys: Optional[List[str]],

--- a/meerschaum/api/dash/components.py
+++ b/meerschaum/api/dash/components.py
@@ -107,7 +107,7 @@ instance_select = dbc.Select(
         {'label': (i[:32] + '…') if len(i) > 32 else i, 'value': i}
         for i in get_connector_labels(*instance_types)
     ],
-    class_name='dbc_dark custom-select custom-select-sm',
+    class_name='dbc_dark custom-select custom-select-sm instance-select',
 )
 
 sign_out_button = dbc.Button(

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -1029,14 +1029,14 @@ def build_pipes_navbar(instance_keys: Optional[str] = None, with_instance_select
     Build the navbar from the selected instance keys.
     """
     instance_select = dbc.Select(
-        id='instance-select',
+        id='pipes-instance-select',
         size='sm',
         value=instance_keys or str(get_api_connector()),
         options=[
             {'label': (i[:32] + '…') if len(i) > 32 else i, 'value': i}
             for i in get_connector_labels(*instance_types)
         ],
-        class_name='dbc_dark custom-select custom-select-sm',
+        class_name='dbc_dark custom-select custom-select-sm instance-select',
     )
     instance_select_div_style = {} if with_instance_select else {'visibility': 'hidden'}
     instance_select_div = html.Div(instance_select, style=instance_select_div_style)

--- a/meerschaum/api/resources/static/css/dash.css
+++ b/meerschaum/api/resources/static/css/dash.css
@@ -65,7 +65,7 @@ a {
 #get-items-menu {
   width: 100%;
 }
-#instance-select {
+.instance-select {
   background-color : var(--bs-secondary) !important;
   color: white;
   margin-top: 5px;

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -151,6 +151,7 @@ default_system_config = {
             'debug',
             'bootstrap',
             'daemon',
+            'sql',
         ],
     },
     'experimental': {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"

--- a/meerschaum/utils/pipes.py
+++ b/meerschaum/utils/pipes.py
@@ -210,4 +210,7 @@ def is_pipe_registered(
     if debug:
         dprint(f'{ck}, {mk}, {lk}')
         dprint(f'{pipe}, {pipes}')
-    return ck in pipes and mk in pipes[ck] and lk in pipes[ck][mk]
+    try:
+        return ck in pipes and mk in pipes[ck] and lk in pipes[ck][mk]
+    except Exception:
+        return False


### PR DESCRIPTION
# v3.0.3

- **Fix pipe page routing.**  
  Links to specific pipes in the dashboard are now routed correctly.

- **Fix cache invalidation for pipes using Valkey connectors.**  
  Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.
