### PR TITLE
🐛 v3.0.4 Fix Python 3.9 compatability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v3.0.3
+### v3.0.3 – v3.0.4
 
 - **Fix pipe page routing.**  
   Links to specific pipes in the dashboard are now routed correctly.
 
 - **Fix cache invalidation for pipes using Valkey connectors.**  
   Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.
+
+- **Fix Python 3.9 compatability.**  
+  An issue breaking Python 3.9 has been fixed.
+
+- **Disable `uv` when running inside a virtual environment.**
 
 ### v3.0.1 – v3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix Python 3.9 compatability.**  
   An issue breaking Python 3.9 has been fixed.
 
+- **Prevent resolving symlinks for pipe's parameters card.**  
+  The pipe card in dash will no longer resolve symlinks.
+
+- **Handle `pd.NA` values in JSON columns for `filter_unseen_df()`.**  
+  Non-string values (e.g. `pd.NA`) are now correctly handled for JSON columns in `filter_unseen_df()`. 
+
 - **Disable `uv` when running inside a virtual environment.**
 
 ### v3.0.1 – v3.0.2

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -4,13 +4,18 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
-### v3.0.3
+### v3.0.3 – v3.0.4
 
 - **Fix pipe page routing.**  
   Links to specific pipes in the dashboard are now routed correctly.
 
 - **Fix cache invalidation for pipes using Valkey connectors.**  
   Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.
+
+- **Fix Python 3.9 compatability.**  
+  An issue breaking Python 3.9 has been fixed.
+
+- **Disable `uv` when running inside a virtual environment.**
 
 ### v3.0.1 – v3.0.2
 

--- a/docs/mkdocs/news/changelog.md
+++ b/docs/mkdocs/news/changelog.md
@@ -15,6 +15,12 @@ This is the current release cycle, so stay tuned for future releases!
 - **Fix Python 3.9 compatability.**  
   An issue breaking Python 3.9 has been fixed.
 
+- **Prevent resolving symlinks for pipe's parameters card.**  
+  The pipe card in dash will no longer resolve symlinks.
+
+- **Handle `pd.NA` values in JSON columns for `filter_unseen_df()`.**  
+  Non-string values (e.g. `pd.NA`) are now correctly handled for JSON columns in `filter_unseen_df()`. 
+
 - **Disable `uv` when running inside a virtual environment.**
 
 ### v3.0.1 – v3.0.2

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -575,7 +575,7 @@ def accordion_items_from_pipe(
 
     if 'parameters' in active_items:
         parameters_editor = dash_ace.DashAceEditor(
-            value=yaml.dump(pipe.parameters),
+            value=yaml.dump(pipe.get_parameters(apply_symlinks=False, refresh=True, debug=debug)),
             mode='norm',
             tabSize=4,
             theme='twilight',

--- a/meerschaum/config/_default.py
+++ b/meerschaum/config/_default.py
@@ -152,6 +152,7 @@ default_system_config = {
             'bootstrap',
             'daemon',
             'sql',
+            'register plugin',
         ],
     },
     'experimental': {

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.0.3"
+__version__ = "3.0.4"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -6,6 +6,7 @@
 Interact with Pipes metadata via SQLConnector.
 """
 from __future__ import annotations
+import traceback
 from datetime import datetime, date, timedelta
 
 import meerschaum as mrsm
@@ -3102,7 +3103,6 @@ def get_pipe_columns_types(
         for col in pipe_table.columns:
             table_columns[str(col.name)] = str(col.type)
     except Exception as e:
-        import traceback
         traceback.print_exc()
         warn(e)
         table_columns = {}

--- a/meerschaum/core/Pipe/_cache.py
+++ b/meerschaum/core/Pipe/_cache.py
@@ -33,7 +33,10 @@ def _get_cache_conn_cache_key(pipe: mrsm.Pipe, cache_key: str) -> str:
     """
     Return the cache key to use in the cache connector.
     """
-    return f'.cache:pipes:{pipe.connector_keys.replace(':', '_')}:{pipe.metric_key}:{pipe.location_key}:{cache_key}'
+    ck = pipe.connector_keys.replace(':', '_')
+    mk = pipe.metric_key
+    lk = str(pipe.location_key)
+    return f'.cache:pipes:{ck}:{mk}:{lk}:{cache_key}'
 
 
 def _get_cache_connector(self) -> 'Union[None, ValkeyConnector]':

--- a/meerschaum/utils/dataframe.py
+++ b/meerschaum/utils/dataframe.py
@@ -375,7 +375,9 @@ def filter_unseen_df(
         if json_col not in delta_df.columns:
             continue
         try:
-            delta_df[json_col] = delta_df[json_col].apply(json.loads)
+            delta_df[json_col] = delta_df[json_col].apply(
+                lambda x: (json.loads(x) if isinstance(x, str) else x)
+            )
         except Exception:
             warn(f"Unable to deserialize JSON column '{json_col}':\n{traceback.format_exc()}")
 

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1924,6 +1924,11 @@ def is_uv_enabled() -> bool:
     if is_android():
         return False
 
+    from meerschaum.utils.venv import inside_venv
+
+    if inside_venv():
+        return False
+
     try:
         import yaml
     except ImportError:

--- a/meerschaum/utils/venv/__init__.py
+++ b/meerschaum/utils/venv/__init__.py
@@ -755,7 +755,8 @@ def venv_target_path(
 
     venv_root_path = (
         (VIRTENV_RESOURCES_PATH / venv)
-        if venv is not None else pathlib.Path(sys.prefix)
+        if venv is not None
+        else pathlib.Path(sys.prefix)
     )
     target_path = venv_root_path
 
@@ -773,12 +774,14 @@ def venv_target_path(
     python_folder = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
     if target_path.exists():
         target_path = (
-            (target_path / python_folder) if python_folder in os.listdir(target_path)
+            (target_path / python_folder)
+            if python_folder in os.listdir(target_path)
             else target_path
         )
     else:
         target_path = (
-            (target_path / python_folder) if platform.system() != 'Windows'
+            (target_path / python_folder)
+            if platform.system() != 'Windows'
             else target_path
         )
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -116,8 +116,8 @@ $PYTHON_BIN -m pytest \
   --ignore=test_root/ \
   --ignore=tests/data/ \
   --ignore=docs/ \
-  -n=auto \
   --ff \
+  -n=auto \
   -v; rc="$?"
 
 ### Cleanup

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 
+import sys
 import warnings
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -686,7 +687,7 @@ def test_nested_chunks(flavor: str):
     assert len(df) == num_docs
 
 
-#  @pytest.mark.skip(reason="Python 3.13 Dask, numpy compatability.")
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 @pytest.mark.parametrize("flavor", get_flavors())
 def test_sync_dask_dataframe(flavor: str):
     """


### PR DESCRIPTION
# v3.0.3 – v3.0.4

- **Fix pipe page routing.**  
  Links to specific pipes in the dashboard are now routed correctly.

- **Fix cache invalidation for pipes using Valkey connectors.**  
  Pipes using a `valkey` connector to store cache (rather than on-disk) will now correctly invalidate cache on demand.

- **Fix Python 3.9 compatability.**  
  An issue breaking Python 3.9 has been fixed.

- **Prevent resolving symlinks for pipe's parameters card.**  
  The pipe card in dash will no longer resolve symlinks.

- **Handle `pd.NA` values in JSON columns for `filter_unseen_df()`.**  
  Non-string values (e.g. `pd.NA`) are now correctly handled for JSON columns in `filter_unseen_df()`. 

- **Disable `uv` when running inside a virtual environment.**
