### PR TITLE
🐛 v3.2.4 Fix multiplexed sync times and improve chunksize logic for integer pipes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v3.2.4
 
-- **Fix parametrized sync times.**  
-  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
-
 - **Improvde default chunksize for integer pipes.**  
   Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
 
@@ -72,7 +69,11 @@ This is the current release cycle, so stay tuned for future releases!
   ```
 
 - **Add `flush pipes` and `flush indices`.**  
-  For convenience, the action `flush` is equivalent to `drop + sync`.
+  For convenience, the action `flush` is equivalent to `drop + sync` without arguments and `clear + sync` with filters (`--begin`, `--end`, `--params`).
+
+- **Fix parametrized sync times.**  
+  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
+
 
 ### v3.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.2.4
+
+- **Fix parametrized sync times.**  
+  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
+
+- **Improvde default chunksize for integer pipes.**  
+  Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe(
+      'demo', 'chunksize', 'int',
+      instance='sql:memory',
+      parameters={
+          "columns": {
+              "datetime": "ts",
+              "id": "id",
+          },
+          "dtypes": {
+              "ts": "int",
+          },
+          "precision": "ms", # millisecond
+          "fetch": {
+              "backtrack_minutes": 1440,
+          },
+          "verify": {
+              "chunk_minutes": 1440 * 30, # 30 days
+          }
+      },
+  )
+
+  print(f"{pipe.get_chunk_interval()=}")
+  # pipe.get_chunk_interval()=2592000000
+  print(f"{pipe.get_backtrack_interval()=}")
+  # pipe.get_backtrack_interval()=86400000
+
+  pipe.precision = 's'
+  print(f"{pipe.get_chunk_interval()=}")
+  # pipe.get_chunk_interval()=2592000
+  print(f"{pipe.get_backtrack_interval()=}")
+  # pipe.get_backtrack_interval()=86400
+
+  simple_pipe = mrsm.Pipe(
+      'demo', 'chunksize', 'int_no_precision',
+      instance='sql:memory',
+      parameters={
+          'columns': {
+              'datetime': 'id',
+          },
+          'dtypes': {
+              'id': 'int',
+          },
+          "precision": None, # omitted precision defaults to literal chunksize value (previous behavior)
+          "fetch": {
+              "backtrack_minutes": 100,
+          },
+          'verify': {
+              'chunk_minutes': 10000,
+          },
+      },
+  )
+  print(f"{simple_pipe.get_chunk_interval()=}")
+  # simple_pipe.get_chunk_interval()=10000
+  print(f"{simple_pipe.get_backtrack_interval()=}")
+  # simple_pipe.get_backtrack_interval()=100
+  ```
+
+- **Add `flush pipes` and `flush indices`.**  
+  For convenience, the action `flush` is equivalent to `drop + sync`.
+
 ### v3.2.3
 
 - **Fix environment isolation for `compose` projects.**  

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -6,9 +6,6 @@ This is the current release cycle, so stay tuned for future releases!
 
 ### v3.2.4
 
-- **Fix parametrized sync times.**  
-  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
-
 - **Improvde default chunksize for integer pipes.**  
   Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
 
@@ -72,7 +69,11 @@ This is the current release cycle, so stay tuned for future releases!
   ```
 
 - **Add `flush pipes` and `flush indices`.**  
-  For convenience, the action `flush` is equivalent to `drop + sync`.
+  For convenience, the action `flush` is equivalent to `drop + sync` without arguments and `clear + sync` with filters (`--begin`, `--end`, `--params`).
+
+- **Fix parametrized sync times.**  
+  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
+
 
 ### v3.2.3
 

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -4,6 +4,76 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.2.4
+
+- **Fix parametrized sync times.**  
+  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
+
+- **Improvde default chunksize for integer pipes.**  
+  Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
+
+  ```python
+  import meerschaum as mrsm
+  pipe = mrsm.Pipe(
+      'demo', 'chunksize', 'int',
+      instance='sql:memory',
+      parameters={
+          "columns": {
+              "datetime": "ts",
+              "id": "id",
+          },
+          "dtypes": {
+              "ts": "int",
+          },
+          "precision": "ms", # millisecond
+          "fetch": {
+              "backtrack_minutes": 1440,
+          },
+          "verify": {
+              "chunk_minutes": 1440 * 30, # 30 days
+          }
+      },
+  )
+
+  print(f"{pipe.get_chunk_interval()=}")
+  # pipe.get_chunk_interval()=2592000000
+  print(f"{pipe.get_backtrack_interval()=}")
+  # pipe.get_backtrack_interval()=86400000
+
+  pipe.precision = 's'
+  print(f"{pipe.get_chunk_interval()=}")
+  # pipe.get_chunk_interval()=2592000
+  print(f"{pipe.get_backtrack_interval()=}")
+  # pipe.get_backtrack_interval()=86400
+
+  simple_pipe = mrsm.Pipe(
+      'demo', 'chunksize', 'int_no_precision',
+      instance='sql:memory',
+      parameters={
+          'columns': {
+              'datetime': 'id',
+          },
+          'dtypes': {
+              'id': 'int',
+          },
+          "precision": None, # omitted precision defaults to literal chunksize value (previous behavior)
+          "fetch": {
+              "backtrack_minutes": 100,
+          },
+          'verify': {
+              'chunk_minutes': 10000,
+          },
+      },
+  )
+  print(f"{simple_pipe.get_chunk_interval()=}")
+  # simple_pipe.get_chunk_interval()=10000
+  print(f"{simple_pipe.get_backtrack_interval()=}")
+  # simple_pipe.get_backtrack_interval()=100
+  ```
+
+- **Add `flush pipes` and `flush indices`.**  
+  For convenience, the action `flush` is equivalent to `drop + sync`.
+
 ### v3.2.3
 
 - **Fix environment isolation for `compose` projects.**  

--- a/docs/zensical/overrides/main.html
+++ b/docs/zensical/overrides/main.html
@@ -1,6 +1,1 @@
 {% extends "base.html" %}
-
-{% block announce %}
-
-<div style="color: white;"><b>Meerschaum 3.0 is here!</b> Check the <a href="/news/changelog">Changelog</a> for all the new features.</div>
-{% endblock %}

--- a/meerschaum/_internal/entry.py
+++ b/meerschaum/_internal/entry.py
@@ -223,12 +223,16 @@ def entry_without_daemon(
                 [
                     (
                         make_header(
-                            shlex.join(_sysargs)
-                            + "\n  ("
-                            + interval_str(
-                                timedelta(seconds=(steps_times[i][1] - steps_times[i][0]))
-                            )
-                            + ")"
+                            (
+                                shlex.join(_sysargs)
+                                + "\n  ("
+                                + interval_str(
+                                    timedelta(seconds=(steps_times[i][1] - steps_times[i][0]))
+                                )
+                                + ")"
+                            ),
+                            left_pad=4,
+                            top=False,
                         )
                         + '\n    ' + _msg + '\n'
                     )
@@ -236,23 +240,37 @@ def entry_without_daemon(
                 ]
             )
         )
-    )
+    ).rstrip('\n')
     has_fail = results[-1][0] is False
     fail_ix = len(results) - 1
     fail_sysargs = chained_sysargs[fail_ix] if has_fail else None
     fail_msg = results[-1][1] if has_fail else ''
     fails_msg = (
         'Failed to complete step:\n\n'
-        + make_header(shlex.join(fail_sysargs))
+        + make_header(shlex.join(fail_sysargs), left_pad=4, top=False)
         + '\n    '
         + fail_msg
 
     ) if not results[-1][0] else ''
 
+    duration_summary_msg = make_header(
+        (
+            f"| {len(success_messages)} step"
+            + ('s' if len(success_messages) != 1 else '') 
+            + f" in {interval_str(total_time_delta)} |"
+        ),
+        top=True,
+        top_pad=3,
+        left_pad=4,
+        ruler='-'
+    ) if total_time_delta is not None else ""
+
     msg = (
         successes_msg
-        + ('\n\n' if any_success else '')
+        + ('\n\n' if fails_msg else '')
         + fails_msg
+        + duration_summary_msg
+
     ).rstrip() if len(chained_sysargs) > 1 else results[0][1]
 
     if _systemd_result_path:

--- a/meerschaum/actions/__init__.py
+++ b/meerschaum/actions/__init__.py
@@ -67,7 +67,7 @@ def get_action(
     """
     Return a function corresponding to the given action list.
     This may be a custom action with an underscore, in which case, allow for underscores.
-    This may also be a subactions, which is handled by `get_subactions()`
+    This may also be a subaction, which is handled by `get_subactions()`
     """
     if _actions is None:
         _actions = actions

--- a/meerschaum/actions/drop.py
+++ b/meerschaum/actions/drop.py
@@ -111,7 +111,7 @@ def _drop_indices(
     **kw: Any
 ) -> SuccessTuple:
     """
-    Drop pipes' tables but keep pipe metadata registration.
+    Drop pipes' indices.
     """
     from meerschaum.utils.prompt import yes_no
     from meerschaum import get_pipes

--- a/meerschaum/actions/flush.py
+++ b/meerschaum/actions/flush.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Functions for flushing and recreating pipes and indices.
+"""
+
+from __future__ import annotations
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
+
+
+def flush(
+    action: Optional[List[str]] = None,
+    **kw: Any
+) -> SuccessTuple:
+    """
+    Drop and resync pipes or indices.
+    """
+    from meerschaum.actions import choose_subaction
+    options = {
+        'pipes'  : _flush_pipes,
+        'indices': _flush_indices,
+        'index': _flush_indices,
+        'indexes': _flush_indices,
+    }
+    return choose_subaction(action, options, **kw)
+
+
+def _flush_pipes(**kwargs: Any) -> SuccessTuple:
+    """
+    Drop and resync pipes.
+    Equivalent to `drop pipes + sync pipes`.
+    """
+    from meerschaum.actions import get_action
+    drop_pipes_func = get_action(['drop', 'pipes'])
+    drop_success, drop_message = drop_pipes_func(**kwargs)
+    if not drop_success:
+        return drop_success, drop_message
+
+    sync_pipes_func = get_action(['sync', 'pipes'])
+    sync_success, sync_message = sync_pipes_func(**kwargs)
+    return sync_success, sync_message
+
+
+def _flush_indices(
+    **kwargs: Any
+) -> SuccessTuple:
+    """
+    Drop and rebuild pipes' indices.
+    """
+    from meerschaum.actions import get_action
+    drop_indices_func = get_action(['drop', 'indices'])
+    drop_success, drop_message = drop_indices_func(**kwargs)
+    if not drop_success:
+        return drop_success, drop_message
+
+    index_pipes_func = get_action(['index', 'pipes'])
+    index_success, index_message = index_pipes_func(**kwargs)
+    return index_success, index_message
+
+
+### NOTE: This must be the final statement of the module.
+###       Any subactions added below these lines will not
+###       be added to the `help` docstring.
+from meerschaum.actions import choices_docstring as _choices_docstring
+drop.__doc__ += _choices_docstring('flush')

--- a/meerschaum/actions/flush.py
+++ b/meerschaum/actions/flush.py
@@ -7,7 +7,9 @@ Functions for flushing and recreating pipes and indices.
 """
 
 from __future__ import annotations
-from meerschaum.utils.typing import SuccessTuple, Any, Optional, List
+
+from datetime import datetime
+from meerschaum.utils.typing import SuccessTuple, Any, Optional, List, Union, Dict
 
 
 def flush(
@@ -27,19 +29,37 @@ def flush(
     return choose_subaction(action, options, **kw)
 
 
-def _flush_pipes(**kwargs: Any) -> SuccessTuple:
+def _flush_pipes(
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    **kwargs: Any
+) -> SuccessTuple:
     """
     Drop and resync pipes.
     Equivalent to `drop pipes + sync pipes`.
     """
     from meerschaum.actions import get_action
-    drop_pipes_func = get_action(['drop', 'pipes'])
-    drop_success, drop_message = drop_pipes_func(**kwargs)
-    if not drop_success:
-        return drop_success, drop_message
+    drop_or_clear_pipes_func = get_action([
+        ('drop' if begin is None and end is None and not params else 'clear'),
+        'pipes'
+    ])
+    drop_or_clear_success, drop_or_clear_message = drop_or_clear_pipes_func(
+        begin=begin,
+        end=end,
+        params=params,
+        **kwargs
+    )
+    if not drop_or_clear_success:
+        return drop_or_clear_success, drop_or_clear_message
 
     sync_pipes_func = get_action(['sync', 'pipes'])
-    sync_success, sync_message = sync_pipes_func(**kwargs)
+    sync_success, sync_message = sync_pipes_func(
+        begin=begin,
+        end=end,
+        params=params,
+        **kwargs
+    )
     return sync_success, sync_message
 
 
@@ -64,4 +84,4 @@ def _flush_indices(
 ###       Any subactions added below these lines will not
 ###       be added to the `help` docstring.
 from meerschaum.actions import choices_docstring as _choices_docstring
-drop.__doc__ += _choices_docstring('flush')
+flush.__doc__ += _choices_docstring('flush')

--- a/meerschaum/actions/stack.py
+++ b/meerschaum/actions/stack.py
@@ -38,10 +38,6 @@ def stack(
     from meerschaum.config.stack import NECESSARY_FILES, write_stack
     import meerschaum.config
     from meerschaum.config._patch import apply_patch_to_config
-    from meerschaum.utils.packages import (
-        attempt_import, run_python_package, venv_contains_package,
-        pip_install,
-    )
     from meerschaum.config._sync import sync_files
     from meerschaum.config import get_config
     from meerschaum.utils.debug import dprint
@@ -113,20 +109,7 @@ def stack(
         has_builtin_compose = False
 
     if not has_builtin_compose:
-        _compose_venv = 'mrsm'
-        _ = attempt_import('compose', lazy=False, venv=_compose_venv, debug=debug)
-
-        ### If docker-compose is installed globally, don't use the `mrsm` venv.
-        if not venv_contains_package('compose', _compose_venv):
-            _compose_venv = None
-
-        if not venv_contains_package('packaging', _compose_venv):
-            if not pip_install('packaging', venv=_compose_venv, debug=debug):
-                warn(f"Unable to install `packaging` into venv '{_compose_venv}'.")
-
-        if not venv_contains_package('yaml', _compose_venv):
-            if not pip_install('pyyaml', venv=_compose_venv, debug=debug):
-                warn(f"Unable to install `pyyaml` into venv '{_compose_venv}'.")
+        return False, "Docker Compose is not available."
 
     if 'down' in sysargs and '-v' in sysargs:
         if not yes_no(
@@ -147,23 +130,11 @@ def stack(
     stdout = None if not _capture_output else subprocess.PIPE
     stderr = stdout
 
-    has_binary_compose = pathlib.Path('/usr/bin/docker-compose').exists()
     proc = subprocess.Popen(
-        (
-            ['docker', 'compose'] if has_builtin_compose
-            else ['docker-compose']
-        ) + cmd_list,
+        ['docker', 'compose'] + cmd_list,
         cwd=paths.STACK_COMPOSE_PATH.parent,
         stdout=stdout,
         stderr=stderr,
-        env=stack_env_dict,
-    ) if (has_builtin_compose or has_binary_compose) else run_python_package(
-        'compose',
-        args=cmd_list,
-        cwd=[paths.STACK_COMPOSE_PATH.parent],
-        venv=_compose_venv,
-        capture_output=_capture_output,
-        as_proc=True,
         env=stack_env_dict,
     )
     try:
@@ -176,7 +147,9 @@ def stack(
         captured_stderr = captured_stderr.decode()
     success = rc == 0
     msg = (
-        "Success" if success else f"Failed to execute commands:\n{cmd_list}"
+        "Success"
+        if success
+        else f"Failed to execute commands:\n{cmd_list}"
     ) if not _capture_output else captured_stdout
 
     return success, msg

--- a/meerschaum/api/resources/static/js/terminado.js
+++ b/meerschaum/api/resources/static/js/terminado.js
@@ -54,8 +54,8 @@ function make_terminal(element, options, ws_url) {
     ws.send(
       JSON.stringify([
         "set_size",
-        terminal_options.rows,
-        terminal_options.cols,
+        term.rows,
+        term.cols,
         element.innerHeight,
         element.innerWidth,
       ]),

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -185,23 +185,24 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 
     function calculate_size() {
+        var lh = termOptions.lineHeight || 1.0;
+        var dpr = window.devicePixelRatio || 1.0;
         var measure = document.createElement("div");
         measure.style.fontFamily = termOptions.fontFamily;
         measure.style.fontSize = termOptions.fontSize + "px";
-        measure.style.lineHeight = "1";
+        measure.style.fontKerning = "none";
         measure.style.position = "absolute";
         measure.style.visibility = "hidden";
         measure.style.whiteSpace = "pre";
-        measure.innerText = "W";
+        measure.innerText = "W".repeat(32);
         document.body.appendChild(measure);
-
-        var rect = measure.getBoundingClientRect();
-        var termColWidth = rect.width || 10;
-        var termRowHeight = Math.ceil(termOptions.fontSize * (termOptions.lineHeight || 1.0));
+        // Mirror xterm.js v6 CharSizeService + DimensionService formulas exactly
+        var charWidth = measure.offsetWidth / 32;
+        var charHeight = measure.offsetHeight;
         document.body.removeChild(measure);
-
-        var rows = Math.max(2, Math.floor((window.innerHeight - 10) / termRowHeight));
-        var cols = Math.max(3, Math.floor((window.innerWidth - 10) / termColWidth));
+        var cellHeight = Math.floor(Math.ceil(charHeight * dpr) * lh) / dpr;
+        var rows = Math.max(2, Math.floor((window.innerHeight - 10) / cellHeight));
+        var cols = Math.max(3, Math.floor((window.innerWidth - 10) / charWidth));
         return {rows: rows, cols: cols};
     }
 

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -175,6 +175,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var termOptions = {
         fontFamily: '"DejaVu Sans Mono", "Liberation Mono", monospace',
         fontSize: 16,
+        lineHeight: 1.2,
         allowProposedApi: true,
         scrollback: 100000,
         cursorBlink: true,
@@ -187,6 +188,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var measure = document.createElement("div");
         measure.style.fontFamily = termOptions.fontFamily;
         measure.style.fontSize = termOptions.fontSize + "px";
+        measure.style.lineHeight = "1";
         measure.style.position = "absolute";
         measure.style.visibility = "hidden";
         measure.style.whiteSpace = "pre";
@@ -194,8 +196,8 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.appendChild(measure);
 
         var rect = measure.getBoundingClientRect();
-        var termRowHeight = rect.height || 20;
         var termColWidth = rect.width || 10;
+        var termRowHeight = (termOptions.fontSize * termOptions.lineHeight) || 20;
         document.body.removeChild(measure);
 
         var rows = Math.max(2, Math.floor((window.innerHeight - 10) / termRowHeight));

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -187,10 +187,12 @@ document.addEventListener('DOMContentLoaded', function() {
     function calculate_size() {
         var lh = termOptions.lineHeight || 1.0;
         var dpr = window.devicePixelRatio || 1.0;
-        var measure = document.createElement("div");
+        var measure = document.createElement("span");
         measure.style.fontFamily = termOptions.fontFamily;
         measure.style.fontSize = termOptions.fontSize + "px";
         measure.style.fontKerning = "none";
+        measure.style.lineHeight = "normal";
+        measure.style.display = "inline-block";
         measure.style.position = "absolute";
         measure.style.visibility = "hidden";
         measure.style.whiteSpace = "pre";
@@ -226,6 +228,22 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!event.wasClean && event.code !== 1005) {
           window.terminal_initialized = false;
           reconnectTimeout = setTimeout(init_webterm, 1000);
+        }
+      }
+      // After term.open(), xterm inserts .xterm-screen sized to rows*cellHeight.
+      // Measure it to get xterm's actual cell dimensions and resize to fill the viewport.
+      var screen = xterm_div.querySelector('.xterm-screen');
+      if (screen) {
+        var screenRect = screen.getBoundingClientRect();
+        if (screenRect.height > 0 && screenRect.width > 0) {
+          var actualCellH = screenRect.height / size.rows;
+          var actualCellW = screenRect.width / size.cols;
+          var fitRows = Math.max(2, Math.floor((window.innerHeight - 10) / actualCellH));
+          var fitCols = Math.max(3, Math.floor((window.innerWidth - 10) / actualCellW));
+          if (fitRows !== size.rows || fitCols !== size.cols) {
+            window.terminal.term.resize(fitCols, fitRows);
+            size = {rows: fitRows, cols: fitCols};
+          }
         }
       }
       window.terminal_initialized = true;

--- a/meerschaum/api/resources/templates/termpage.html
+++ b/meerschaum/api/resources/templates/termpage.html
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         var rect = measure.getBoundingClientRect();
         var termColWidth = rect.width || 10;
-        var termRowHeight = (termOptions.fontSize * termOptions.lineHeight) || 20;
+        var termRowHeight = Math.ceil(termOptions.fontSize * (termOptions.lineHeight || 1.0));
         document.body.removeChild(measure);
 
         var rows = Math.max(2, Math.floor((window.innerHeight - 10) / termRowHeight));

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.2.3"
+__version__ = "3.2.4"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2683,21 +2683,21 @@ def get_sync_time(
 
     base_query = (
         f"SELECT {dt_col_name}\n"
-        f"FROM {src_name}{where}\n"
+        f"FROM {src_name}\n"
         f"ORDER BY {dt_col_name} {ASC_or_DESC}\n"
         f"LIMIT 1"
     )
     if self.flavor == 'mssql':
         base_query = (
             f"SELECT TOP 1 {dt_col_name}\n"
-            f"FROM {src_name}{where}\n"
+            f"FROM {src_name}\n"
             f"ORDER BY {dt_col_name} {ASC_or_DESC}"
         )
     elif self.flavor == 'oracle':
         base_query = (
             "SELECT * FROM (\n"
             f"    SELECT {dt_col_name}\n"
-            f"    FROM {src_name}{where}\n"
+            f"    FROM {src_name}\n"
             f"    ORDER BY {dt_col_name} {ASC_or_DESC}\n"
             ") WHERE ROWNUM = 1"
         )

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -1206,7 +1206,7 @@ def precision(self, _precision: Union[str, Dict[str, Union[str, int]]]) -> None:
             **(
                 {
                     'interval': existing_precision['interval'],
-                } if existing_precision else {}
+                } if (existing_precision or {}).get('interval') else {}
             )
         }
     )

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -580,6 +580,7 @@ def get_chunk_interval(
     -------
     The chunk interval (`timedelta` or `int`) to use with this pipe's `datetime` axis.
     """
+    from meerschaum.utils.dtypes import MRSM_PRECISION_UNITS_SCALARS, MRSM_PRECISION_UNITS_ALIASES
     default_chunk_minutes = get_config('pipes', 'parameters', 'verify', 'chunk_minutes')
     configured_chunk_minutes = self.parameters.get('verify', {}).get('chunk_minutes', None)
     chunk_minutes = (
@@ -598,7 +599,13 @@ def get_chunk_interval(
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime')
     if 'int' in dt_dtype.lower():
+        precision_unit = self.precision.get('unit', None)
+        true_unit = MRSM_PRECISION_UNITS_ALIASES.get(precision_unit, precision_unit)
+        scalar = MRSM_PRECISION_UNITS_SCALARS.get(true_unit, None)
+        if scalar is not None:
+            return int(chunk_minutes * 60 * scalar)
         return chunk_minutes
+
     return timedelta(minutes=chunk_minutes)
 
 

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -599,7 +599,7 @@ def get_chunk_interval(
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime')
     if 'int' in dt_dtype.lower():
-        if chunk_interval is not None:
+        if chunk_interval is not None or not self.parameters.get('precision', None):
             return chunk_minutes
         precision_unit = self.precision.get('unit', None)
         true_unit = MRSM_PRECISION_UNITS_ALIASES.get(precision_unit, precision_unit)

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -599,6 +599,8 @@ def get_chunk_interval(
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime')
     if 'int' in dt_dtype.lower():
+        if chunk_interval is not None:
+            return chunk_minutes
         precision_unit = self.precision.get('unit', None)
         true_unit = MRSM_PRECISION_UNITS_ALIASES.get(precision_unit, precision_unit)
         scalar = MRSM_PRECISION_UNITS_SCALARS.get(true_unit, None)

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -114,6 +114,7 @@ def get_backtrack_interval(
     -------
     The backtrack interval (`timedelta` or `int`) to use with this pipe's `datetime` axis.
     """
+    from meerschaum.utils.dtypes import MRSM_PRECISION_UNITS_SCALARS, MRSM_PRECISION_UNITS_ALIASES
     default_backtrack_minutes = get_config('pipes', 'parameters', 'fetch', 'backtrack_minutes')
     configured_backtrack_minutes = self.parameters.get('fetch', {}).get('backtrack_minutes', None)
     backtrack_minutes = (
@@ -122,16 +123,20 @@ def get_backtrack_interval(
         else default_backtrack_minutes
     ) if check_existing else 0
 
-    backtrack_interval = timedelta(minutes=backtrack_minutes)
     dt_col = self.columns.get('datetime', None)
     if dt_col is None:
-        return backtrack_interval
+        return timedelta(minutes=backtrack_minutes)
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime')
     if 'int' in dt_dtype.lower():
+        precision_unit = self.precision.get('unit', None)
+        true_unit = MRSM_PRECISION_UNITS_ALIASES.get(precision_unit, precision_unit)
+        scalar = MRSM_PRECISION_UNITS_SCALARS.get(true_unit, None)
+        if scalar is not None:
+            return int(backtrack_minutes * 60 * scalar)
         return backtrack_minutes
 
-    return backtrack_interval
+    return timedelta(minutes=backtrack_minutes)
 
 
 def _determine_begin(

--- a/meerschaum/core/Pipe/_fetch.py
+++ b/meerschaum/core/Pipe/_fetch.py
@@ -129,6 +129,8 @@ def get_backtrack_interval(
 
     dt_dtype = self.dtypes.get(dt_col, 'datetime')
     if 'int' in dt_dtype.lower():
+        if not self.parameters.get('precision', None):
+            return backtrack_minutes
         precision_unit = self.precision.get('unit', None)
         true_unit = MRSM_PRECISION_UNITS_ALIASES.get(precision_unit, precision_unit)
         scalar = MRSM_PRECISION_UNITS_SCALARS.get(true_unit, None)

--- a/meerschaum/utils/formatting/_shell.py
+++ b/meerschaum/utils/formatting/_shell.py
@@ -13,8 +13,15 @@ from meerschaum._internal.static import STATIC_CONFIG
 FLUSH_TOKEN: str = STATIC_CONFIG['jobs']['flush_token']
 
 
-def make_header(message: str, ruler: str = '─', left_pad: int = 2) -> str:
-    """Format a message string with a ruler.
+def make_header(
+    message: str,
+    ruler: str = '─',
+    left_pad: int = 2,
+    top: bool = False,
+    top_pad: int = 1,
+) -> str:
+    """
+    Format a message string with a ruler or box.
     Length of the ruler is the length of the longest word.
     
     Example:
@@ -34,7 +41,9 @@ def make_header(message: str, ruler: str = '─', left_pad: int = 2) -> str:
     left_buffer = left_pad * ' '
 
     return (
-        left_buffer
+        (('\n' * top_pad) if top else "")
+        + left_buffer
+        + (((ruler * max_length) + '\n') if top else "")
         + message.replace('\n', '\n' + left_buffer)
         + "\n"
         + left_buffer

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1616,9 +1616,9 @@ def get_modules_from_package(
                 activate_venv(module_name.split('.')[-1], debug=debug)
             m = lazy_import(module_name, debug=debug) if lazy else _import_module(module_name)
             modules.append(m)
-        except Exception as e:
-            if debug:
-                dprint(str(e))
+        except Exception:
+            import traceback
+            traceback.print_exc()
         finally:
             if modules_venvs:
                 deactivate_venv(module_name.split('.')[-1], debug=debug)

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -814,14 +814,10 @@ def dateadd_str(
             f"CAST({begin} AS {db_type})" if begin != 'now'
             else f"CAST(NOW() AT TIME ZONE 'utc' AS {db_type})"
         )
-        if dt_is_utc:
-            begin += " AT TIME ZONE 'UTC'"
         da = begin + (f" + INTERVAL '{number} {datepart}'" if number != 0 else '')
 
     elif flavor == 'duckdb':
         begin = f"CAST({begin} AS {db_type})" if begin != 'now' else 'NOW()'
-        if dt_is_utc:
-            begin += " AT TIME ZONE 'UTC'"
         da = begin + (f" + INTERVAL '{number} {datepart}'" if number != 0 else '')
 
     elif flavor in ('mssql',):

--- a/tests/test_pipe_data.py
+++ b/tests/test_pipe_data.py
@@ -87,3 +87,41 @@ def test_get_data_order(flavor: str):
     )
     assert len(df) == limit
     assert df['id'][0] == 3
+
+
+def test_int_pipe_chunk_interval():
+    """
+    Test that integer pipes with precision correctly scale chunk and backtrack intervals.
+    """
+    import meerschaum as mrsm
+    pipe = mrsm.Pipe(
+        'demo', 'chunksize', 'int',
+        instance='sql:memory',
+        parameters={
+            'columns': {'datetime': 'ts', 'id': 'id'},
+            'dtypes': {'ts': 'int'},
+            'precision': 'ms',
+            'fetch': {'backtrack_minutes': 1440},
+            'verify': {'chunk_minutes': 1440 * 30},
+        },
+    )
+    assert pipe.get_chunk_interval() == 1440 * 30 * 60 * 1000
+    assert pipe.get_backtrack_interval() == 1440 * 60 * 1000
+
+    pipe.precision = 's'
+    assert pipe.get_chunk_interval() == 1440 * 30 * 60
+    assert pipe.get_backtrack_interval() == 1440 * 60
+
+    simple_pipe = mrsm.Pipe(
+        'demo', 'chunksize', 'int_no_precision',
+        instance='sql:memory',
+        parameters={
+            'columns': {'datetime': 'id'},
+            'dtypes': {'id': 'int'},
+            'precision': None,
+            'fetch': {'backtrack_minutes': 100},
+            'verify': {'chunk_minutes': 10000},
+        },
+    )
+    assert simple_pipe.get_chunk_interval() == 10000
+    assert simple_pipe.get_backtrack_interval() == 100

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1442,3 +1442,33 @@ def test_mixed_datetime_dtypes_sql(flavor: str):
     df = downstream_pipe.get_data()
     double_df = double_downstream_pipe.get_data()
     assert df.to_dict() == double_df.to_dict()
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_parametrized_sync_time(flavor: str):
+    """
+    Test that get_sync_time respects params for multiplexed pipes.
+    """
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'sync_time', 'params', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe(
+        'test', 'sync_time', 'params',
+        instance=conn,
+        columns={'datetime': 'ts', 'id': 'id'},
+    )
+    ts1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts2 = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    docs = [
+        {'ts': ts1, 'id': 'a', 'val': 1},
+        {'ts': ts2, 'id': 'b', 'val': 2},
+    ]
+    success, msg = pipe.sync(docs, debug=debug)
+    assert success, msg
+
+    sync_time_a = pipe.get_sync_time(params={'id': 'a'}, debug=debug)
+    sync_time_b = pipe.get_sync_time(params={'id': 'b'}, debug=debug)
+
+    assert sync_time_a is not None
+    assert sync_time_b is not None
+    assert sync_time_a < sync_time_b

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1450,6 +1450,8 @@ def test_parametrized_sync_time(flavor: str):
     Test that get_sync_time respects params for multiplexed pipes.
     """
     conn = conns[flavor]
+    if conn.type != 'sql':
+        return
     pipe = mrsm.Pipe('test', 'sync_time', 'params', instance=conn)
     pipe.delete()
     pipe = mrsm.Pipe(


### PR DESCRIPTION
# v3.2.4

- **Improvde default chunksize for integer pipes.**  
  Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.

  ```python
  import meerschaum as mrsm
  pipe = mrsm.Pipe(
      'demo', 'chunksize', 'int',
      instance='sql:memory',
      parameters={
          "columns": {
              "datetime": "ts",
              "id": "id",
          },
          "dtypes": {
              "ts": "int",
          },
          "precision": "ms", # millisecond
          "fetch": {
              "backtrack_minutes": 1440,
          },
          "verify": {
              "chunk_minutes": 1440 * 30, # 30 days
          }
      },
  )

  print(f"{pipe.get_chunk_interval()=}")
  # pipe.get_chunk_interval()=2592000000
  print(f"{pipe.get_backtrack_interval()=}")
  # pipe.get_backtrack_interval()=86400000

  pipe.precision = 's'
  print(f"{pipe.get_chunk_interval()=}")
  # pipe.get_chunk_interval()=2592000
  print(f"{pipe.get_backtrack_interval()=}")
  # pipe.get_backtrack_interval()=86400

  simple_pipe = mrsm.Pipe(
      'demo', 'chunksize', 'int_no_precision',
      instance='sql:memory',
      parameters={
          'columns': {
              'datetime': 'id',
          },
          'dtypes': {
              'id': 'int',
          },
          "precision": None, # omitted precision defaults to literal chunksize value (previous behavior)
          "fetch": {
              "backtrack_minutes": 100,
          },
          'verify': {
              'chunk_minutes': 10000,
          },
      },
  )
  print(f"{simple_pipe.get_chunk_interval()=}")
  # simple_pipe.get_chunk_interval()=10000
  print(f"{simple_pipe.get_backtrack_interval()=}")
  # simple_pipe.get_backtrack_interval()=100
  ```

- **Add `flush pipes` and `flush indices`.**  
  For convenience, the action `flush` is equivalent to `drop + sync` without arguments and `clear + sync` with filters (`--begin`, `--end`, `--params`).

- **Fix parametrized sync times.**  
  Passing `params` to `get_sync_time()` correctly returns the appropriate sync time value for multiplexed pipes.
