### PR TITLE
⚡️ v3.3.0 Improve cache performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .aider*
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,38 @@ This is the current release cycle, so stay tuned for future releases!
   # }
   ```
 
+- **Add `Pipe.get_docs()`.**  
+  The convenience method `Pipe.get_docs()` returns a pipe's data as a list of dictionaries, bypassing pandas overhead. Combine with `as_chunks=True` to get an iterator of `List[Dict]` chunked by time bounds:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'docs',
+      instance='sql:memory',
+      temporary=True,
+      columns={'primary': 'id'},
+  )
+  pipe.sync([
+      {'id': 1, 'name': 'Alice'},
+      {'id': 2, 'name': 'Bob'},
+  ])
+
+  # All rows as a list of dicts (no pandas overhead):
+  docs = pipe.get_docs()
+  print(docs)
+  # [{'id': 1, 'name': 'Alice'}, {'id': 2, 'name': 'Bob'}]
+
+  # Single row as a dict:
+  doc = pipe.get_doc(params={'id': 2})
+  print(doc)
+  # {'id': 2, 'name': 'Bob'}
+
+  # Chunked iterator of lists of dicts:
+  for chunk in pipe.get_docs(as_chunks=True):
+      print(chunk)
+  ```
+
 - **Fix shell suggestions.**  
   A bug has been fixed where shell actions were truncated when chaining actions. Additionally, actions suggestions have been updated with highlight colors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,31 @@
 # 🪵 Changelog
 
-## 3.2.0 Releases
+## 3.3.0 Releases
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.3.0
+
+- **Add `--dtype` flag.**  
+  The flag `--dtype` (explicitly `--datetime-dtypes` or `--datetime-dtype`) allows filtering pipes based on the data type of the `datetime` axis. Accepted values are `datetime`, `int`, `None`. This behaves similarly to keys selectors: multiple values may be provided, and values may be negated:
+
+  ```bash
+  mrsm show pipes --dtype int
+  mrsm show pipes --dtype int None
+  mrsm show pipes --dtype _datetime
+  ```
+
+- **Improve `copy pipes` flow.**  
+  The `copy pipes` action now better handles batches of pipes when the only key to be changed is the instance.
+
+- **Improve caching performance.**  
+  Better cache handling now reduces round-trips when fetching pipes' metadata.
+
+## 3.2.0 Releases
+
 ### v3.2.4
 
-- **Improvde default chunksize for integer pipes.**  
+- **Improve default chunksize for integer pipes.**  
   Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
 
   ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,36 @@ This is the current release cycle, so stay tuned for future releases!
   ```
 
 - **Improve `copy pipes` flow.**  
-  The `copy pipes` action now better handles batches of pipes when the only key to be changed is the instance.
+  The `copy pipes` action has been significantly improved for both interactive and scripted use cases.
+
+  **Non-interactive batch copying:** Specify the destination instance as the first positional argument to skip all prompts. Combined with `--force` and `--sync-data`, pipes can now be fully scripted:
+
+  ```bash
+  # Copy pipe definitions only (skip existing pipes)
+  mrsm copy pipes sql:dest -i sql:src
+
+  # Overwrite existing pipes and copy all data
+  mrsm copy pipes sql:dest -i sql:src --force --sync-data all
+
+  # Overwrite and sync with a date filter (--begin/--end imply filter mode automatically)
+  mrsm copy pipes sql:dest -i sql:src --force --begin 2024-01-01
+  ```
+
+  **New `--sync-data` flag:** 
+    Controls what data is synced when copying destination pipes. Accepted values are `nothing` (default), `backtrack`, `all`, and `filter`. When `--begin`, `--end`, or `--params` are provided without `--sync-data`, filter mode is selected automatically.
+
+  **Reduced interactive prompts for batches:**  
+    When copying many pipes to the same destination instance, all choices (conflict resolution, data sync mode, filter flags) are now collected upfront before any copying begins.
+
+  **Granular conflict resolution:**  
+    When destination pipes already exist, the interactive prompt now offers three options rather than a simple yes/no:
+    - *Skip* — leave the destination pipe entirely unchanged.
+    - *Data only* — sync data without updating stored attributes.
+    - *Attributes only* — update attributes without syncing data.
+    - *Attributes and data* — full overwrite (equivalent to `--force`).
+
+  **Copy summary table:**  
+    After copying data, a table is printed showing inserted, updated, and upserted row counts alongside the elapsed time per pipe and totals.
 
 - **Improve caching performance.**  
   Better cache handling now reduces round-trips when fetching pipes' metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,46 @@ This is the current release cycle, so stay tuned for future releases!
 - **Improve caching performance.**  
   Better cache handling now reduces round-trips when fetching pipes' metadata.
 
+- **Allow dictionary return value from `fetch_pipes_keys()`.**  
+  The `InstanceConnector` method `fetch_pipes_keys()` may now return a dictionary, where the indices are pipes' IDs and the values are keys tuples (and possibly parameters or tags).
+
+  ```python
+  import json
+  import meerschaum as mrsm
+  from meerschaum.utils import fetch_pipes_keys
+
+  conn = mrsm.get_connector('sql:main')
+  keys_dict = fetch_pipes_keys('registered', mrsm.get_connector(), connector_keys=['sql:main'], metric_keys=['test'])
+  print(json.dumps(keys_dict, indent=4))
+  # {
+  #     "24": [
+  #         "sql:main",
+  #         "test",
+  #         null,
+  #         {
+  #             "sql": "SELECT *\nFROM {{ Pipe('plugin:noaa', 'weather') }}\nWHERE 1 = 1",
+  #             "tags": [
+  #                 "test"
+  #             ],
+  #             "fetch": {
+  #                 "backtrack_minutes": 1440
+  #             },
+  #             "verify": {
+  #                 "bound_days": 366,
+  #                 "chunk_minutes": 43200
+  #             },
+  #             "columns": {
+  #                 "id": null,
+  #                 "datetime": null
+  #             }
+  #         }
+  #     ]
+  # }
+  ```
+
+- **Fix shell suggestions.**  
+  A bug has been fixed where shell actions were truncated when chaining actions. Additionally, actions suggestions have been updated with highlight colors.
+
 ## 3.2.0 Releases
 
 ### v3.2.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,398 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development CLI
+
+`./scripts/mrsm.sh <args>` runs `python -m meerschaum` with `MRSM_ROOT_DIR=./test_root` and `MRSM_PLUGINS_DIR=./tests/plugins` so it never touches the user's real config.
+
+### Running Tests
+
+```bash
+# Run all tests (requires Docker for databases)
+./scripts/test.sh db "" <pytest-args>
+
+# Run a single test file (no Docker needed for sqlite-only tests)
+MRSM_ROOT_DIR=./test_root MRSM_PLUGINS_DIR=./tests/plugins python -m pytest tests/test_pipes.py -v
+
+# Run a specific test
+MRSM_ROOT_DIR=./test_root MRSM_PLUGINS_DIR=./tests/plugins python -m pytest tests/test_pipes.py::test_sync -v
+
+# Limit to specific DB flavors (skips others)
+MRSM_TEST_FLAVORS=sqlite python -m pytest tests/ -v
+```
+
+Test connectors are defined in `tests/connectors.py`. The default flavor set is `api,timescaledb`; set `MRSM_TEST_FLAVORS=sqlite` for fast local runs without Docker.
+
+### Docs
+
+```bash
+./scripts/zensical.sh   # serve the user-facing docs at docs/zensical/
+./scripts/pdoc.sh       # build the Python API reference docs
+```
+
+### Build
+
+```bash
+./scripts/build.sh      # cleans, builds docs, generates requirements, runs python -m build
+```
+
+## Architecture Overview
+
+Meerschaum is an ETL framework centered on **pipes** — named data streams synced into tables. Each pipe is identified by three keys, stored in a metadata table managed by an **instance connector**, and fetches data from a **source connector**.
+
+### Core Abstractions
+
+**`SuccessTuple`** (`Tuple[bool, str]`) is the universal return type for all actions, pipe methods, and connector methods. Always return `(True, "Success")` or `(False, "reason")`. Never raise exceptions from action-level code — catch and return a `SuccessTuple`.
+
+**`warn(msg)` / `error(msg, exception)` / `info(msg)` / `dprint(msg, debug=debug)`** — use these from `meerschaum.utils.warnings` rather than `print()`. `warn` uses Python's warnings system (stackable). `error` raises an exception (default `Exception`). `dprint` is debug-only and requires passing `debug=debug`. `info` is for user-facing status messages.
+
+---
+
+## Pipes in Depth
+
+### Identity
+
+A pipe is uniquely identified by three string keys:
+
+| Key | Arg in constructor | Meaning |
+|---|---|---|
+| `connector_keys` | 1st positional or `connector=` | Data source (e.g. `'sql:main'`, `'plugin:noaa'`) |
+| `metric_key` | 2nd positional or `metric=` | Label for the data stream (e.g. `'weather'`) |
+| `location_key` | 3rd positional or `location=` | Optional tag/shard (default `None`) |
+
+The 4th constructor argument (or `instance=` / `mrsm_instance=`) is the **instance connector** — where pipe metadata (parameters, registration) and data are stored.
+
+### Target Table Name
+
+`pipe.target` is the table name in the instance database. By default: `{connector_keys.replace(':', '_')}_{metric_key}` (plus `_{location_key}` if set). Override via `parameters['target']`, `parameters['target_name']`, or `parameters['target_table']`. Long names are truncated per-flavor. On SQL instances, the full qualified name is `schema.target`.
+
+### The `parameters` Dictionary
+
+`pipe.parameters` is the central metadata dict. Important top-level keys:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `columns` | `Dict[str, str]` | Maps semantic role → column name. Key roles: `datetime`, `id`, `primary`, `value`. |
+| `indices` / `indexes` | `Dict[str, str\|List[str]]` | Additional non-unique indices for performance. |
+| `dtypes` | `Dict[str, str]` | Explicit column dtypes. Values are Meerschaum dtype strings (see below). |
+| `tags` | `List[str]` | Labels for grouping pipes. |
+| `fetch` | `Dict` | Source-specific fetch config. `backtrack_minutes` (int) controls how far before sync time to re-fetch. |
+| `verify` | `Dict` | Config for verification syncs. `chunk_minutes` (default 1440), `bound_days`. |
+| `sql` | `str` | SQL definition for SQL-connector pipes. Supports `{{ Pipe(...) }}` syntax. |
+| `target` | `str` | Override the table name. |
+| `upsert` | `bool` | If `True`, create a unique index on `columns` and upsert rows. |
+| `static` | `bool` | If `True`, never alter the schema (no new columns added). |
+| `autoincrement` | `bool` | If `True`, add an auto-incrementing primary key column. |
+| `autotime` | `bool` | If `True`, automatically add a `datetime` timestamp column on insert. |
+| `enforce` | `bool` | If `False`, skip dtype enforcement on incoming data. |
+| `null_indices` | `bool` | If `True`, allow `NULL` values in index columns. |
+| `precision` | `str\|Dict` | Datetime precision unit: `'ns'`, `'us'`, `'ms'`, `'s'`, `'m'`, `'h'`, `'d'`. Aliases defined in `MRSM_PRECISION_UNITS_ALIASES`. |
+| `mixed_numerics` | `bool` | If `False`, prevent int→float columns from being coerced to `numeric`. |
+| `reference` | `str\|Dict\|Pipe` | A single reference pipe whose parameters are inherited. |
+| `references` | `List[str\|Dict\|Pipe]` | Same as `parents`/`children` — multiple reference pipes whose parameters are merged. |
+| `parents` / `children` | `List[str\|Dict\|Pipe]` | Pipe relationship graph (informational and for SQL pushdown). |
+| `parent` / `child` | `str\|Dict\|Pipe` | Singular alias for first parent/child. |
+
+Mutating parameters in memory: `pipe.update_parameters({'key': value}, persist=False)` or assign directly like `pipe.upsert = True`. To persist to the instance, call `pipe.edit()` or pass `persist=True`.
+
+**Key convenience attributes and methods:**
+- `pipe.metric` / `pipe.location` — aliases for `metric_key` / `location_key`
+- `pipe.tzinfo` — returns the `tzinfo` of the datetime column (`UTC`, `None`, etc.)
+- `pipe.get_value(col, params=None, ...)` — single scalar from `get_data()`
+- `pipe.get_doc(params=None, ...)` — single row as `dict`
+- `pipe.filter_existing(df, enforce_dtypes=False, ...)` — accepts `enforce_dtypes=True` to suppress dtype mismatch warnings
+
+### Columns and Dtypes
+
+`pipe.columns` is a shortcut to `pipe.parameters['columns']`. The `'datetime'` column drives all incremental syncing logic (begin/end window). The `'id'` column (or any additional named columns) forms the composite uniqueness key. Pipes without a `datetime` column still work but lose incremental behavior.
+
+Supported Meerschaum dtypes (stored in `parameters['dtypes']`):
+- `'datetime'` — timezone-aware timestamp (stored as `TIMESTAMPTZ` or equivalent)
+- `'int'` — integer (used when the datetime axis is an integer epoch)
+- `'numeric'` — arbitrary-precision decimal (`NUMERIC` in SQL)
+- `'uuid'` — UUID columns
+- `'json'` — JSON/JSONB
+- `'bytes'` — binary / bytea
+- `'geometry[srid]'` — PostGIS geometry (e.g. `'geometry[EPSG:4326]'`, `'geometry[ESRI:102003]'`)
+- Any Pandas dtype string is also valid (e.g. `'Int64'`, `'float64'`, `'bool'`, `'object'`)
+
+Dtype mapping between Meerschaum strings and DB types lives in `meerschaum/utils/dtypes/sql.py` (`get_pd_type_from_db_type`, `get_db_type_from_pd_type`).
+
+### Sync Flow
+
+`pipe.sync(df=None, begin='', end=None, ...)` is the main entry point. The flow:
+
+1. **Fetch** — if `df` is not provided, calls `pipe.fetch()` which delegates to `pipe.connector.fetch(pipe, begin, end, ...)`. For SQL connectors this executes the metadefinition query. For plugin connectors this calls the plugin's `fetch()` function. For API connectors this hits the remote API.
+2. **Dtype enforcement** — `pipe.enforce_dtypes(df)` casts incoming data to registered dtypes.
+3. **Filter existing** — `pipe.filter_existing(df)` fetches the overlapping time window from the instance (`get_backtrack_data`) and computes the diff via `filter_unseen_df()` to find only new/changed rows.
+4. **Sync to instance** — `instance_connector.sync_pipe(pipe, df)` writes the filtered rows. For SQL instances this generates INSERT/UPDATE queries (or UPSERT if `upsert=True`).
+
+The `begin` parameter defaults to `''` (empty string), which signals "use the pipe's sync time minus backtrack interval". `None` means "no lower bound". An explicit datetime/int overrides.
+
+### SQL Connector Fetch (Metadefinition)
+
+For `connector_keys` starting with `'sql:'`, the connector's `get_pipe_metadef()` builds the query:
+
+```
+WITH "definition" AS (
+    <pipe.parameters['sql'] or pipe.parameters['fetch']['definition']>
+)
+SELECT * FROM "definition"
+WHERE "<dt_col>" >= <begin - backtrack>
+  AND "<dt_col>" < <end>
+```
+
+If a `parent` pipe is set, the pushdown `WHERE` clause is applied to the parent's table instead (allows dtype conversion via SQL). The `{{ Pipe('connector', 'metric') }}` syntax in the SQL definition is resolved to the target table name at query time.
+
+### `{{ Pipe() }}` Syntax
+
+SQL definitions and parameter values can reference other pipes using `{{ Pipe('ck', 'mk', 'lk') }}`. This is resolved by `replace_pipes_syntax()` in `meerschaum/utils/pipes.py`. Attribute chains work: `{{ Pipe('a', 'b').columns['datetime'] }}`. Use `{{ self.parameters['key'] }}` to self-reference.
+
+### `MRSM{}` Config Symlinks
+
+Reference Meerschaum config values from within pipe parameters using `MRSM{key1:key2:key3}` syntax:
+
+```python
+pipe = mrsm.Pipe('demo', 'cfg', parameters={
+    'username': 'MRSM{meerschaum:connectors:sql:main:username}',
+})
+print(pipe.parameters['username'])  # resolved at access time
+```
+
+### `params` Filter
+
+`params: Dict[str, Any]` passed to `get_data()`, `get_backtrack_data()`, `get_rowcount()`, `get_sync_time()`, `get_pipes()`, `build_where()`, etc. generates a `WHERE` clause. The actual SQL is built by `meerschaum.utils.sql.build_where()`. Values support:
+- Single value: `{'color': 'red'}` → `WHERE color = 'red'`
+- List: `{'color': ['red', 'blue']}` → `WHERE color IN ('red', 'blue')`
+- Negation prefix `_`: `{'color': '_red'}` → `WHERE color != 'red'`
+- Negation list: `{'color': ['_red', '_blue']}` → `WHERE color NOT IN ('red', 'blue')`
+- Mixed list: `{'color': ['red', '_blue']}` → `WHERE color IN ('red') AND color NOT IN ('blue')`
+- Null: `{'color': 'None'}` or `{'color': None}` → `WHERE color IS NULL`
+- Negated null: `{'color': '_None'}` → `WHERE color IS NOT NULL`
+- Dict value: `{'meta': {'k': 'v'}}` → `WHERE CAST(meta AS TEXT) = '{"k": "v"}'`
+
+**Column validation for SQL pipes:** when `pipe.enforce=True` (the default), `get_pipe_data_query()` filters `params` to only columns that actually exist on the table before building the `WHERE` clause — unknown columns are silently dropped. Pass `pipe.enforce=False` to skip this check.
+
+For in-memory filtering on a DataFrame, use `meerschaum.utils.dataframe.query_df(df, params)` — same negation semantics apply.
+
+### Verification Syncs
+
+`pipe.verify(begin, end, chunk_interval, ...)` re-syncs the entire historical range in chunks (default 1440-minute chunks). Uses `pipe.get_rowcount()` to compare remote vs local counts and only re-syncs mismatched chunks. Configured via `parameters['verify']`.
+
+---
+
+## Connector Hierarchy
+
+```
+Connector                         (meerschaum/connectors/_Connector.py)
+└── InstanceConnector             (meerschaum/connectors/instance/_InstanceConnector.py)
+    ├── SQLConnector              (meerschaum/connectors/sql/)
+    ├── APIConnector              (meerschaum/connectors/api/)
+    └── ValkeyConnector           (meerschaum/connectors/valkey/)
+```
+
+`Connector` reads config from `MRSM_ROOT_DIR/config/connectors.yaml` keyed by `type:label`. The class attribute `REQUIRED_ATTRIBUTES` lists keys that must be set (either in config or passed directly). When cast to string, a connector returns `"type:label"`.
+
+`InstanceConnector` adds the full pipes/users/plugins/tokens interface that all instances must implement. Set `IS_INSTANCE = True` to make a connector usable as an instance. Set `IS_THREAD_SAFE = True` if the connector supports concurrent reads (used by `get_pool` for parallel pipe fetching). Registering a custom connector type with `IS_INSTANCE = True` automatically adds its `type` to `meerschaum.connectors.instance_types`.
+
+**All major connector classes compose their methods via class-level imports:**
+
+```python
+class SQLConnector(InstanceConnector):
+    from ._pipes import fetch_pipes_keys, sync_pipe, get_pipe_data, ...
+    from ._sql import read, to_sql, exec_queries, ...
+    from ._fetch import fetch, get_pipe_metadef
+```
+
+This means each logical group of methods lives in a separate `_*.py` file. New methods belong in the appropriate file, not the class definition file.
+
+### Adding a Custom Connector
+
+```python
+import meerschaum as mrsm
+from meerschaum.connectors import InstanceConnector, make_connector
+
+@make_connector
+class FooConnector(InstanceConnector):
+    IS_INSTANCE = True
+    IS_THREAD_SAFE = False
+    REQUIRED_ATTRIBUTES = ['host', 'port']
+    # Implement all InstanceConnector abstract methods...
+```
+
+See `meerschaum/connectors/instance/_InstanceConnector.py` for the full interface and `docs/zensical/reference/connectors/instance-connectors.md` for the method-by-method guide.
+
+`fetch_pipes_keys()` may return either a list of key tuples or a dict where keys are pipe IDs (int) and values are key tuples (with optional parameters/tags appended). The dict form lets the instance return full pipe attributes in a single round-trip.
+
+---
+
+## Actions
+
+Each top-level action (`sync`, `show`, `register`, `copy`, etc.) is a module in `meerschaum/actions/`. Actions receive `**kwargs` matching the argparse namespace from `meerschaum/_internal/arguments/_parser.py`.
+
+Common kwargs passed to all actions:
+- `connector_keys: List[str]`, `metric_keys: List[str]`, `location_keys: List[str]`
+- `mrsm_instance: str` — instance connector keys
+- `begin: datetime`, `end: datetime`
+- `params: Dict[str, Any]`
+- `tags: List[str]`
+- `debug: bool`
+- `yes: bool`, `force: bool`, `noask: bool`
+
+Subactions are functions within the module auto-discovered by naming convention (e.g. `sync_pipes` in `actions/sync.py`). To add a subaction, define `def <action>_<subaction>(**kwargs) -> SuccessTuple` in the module — no registration needed.
+
+Plugin actions use `@make_action` from `meerschaum.plugins` or `meerschaum.actions`.
+
+---
+
+## Code Composition Patterns
+
+### Mixin-via-Import Pattern
+
+Both `Pipe` and connectors use class-level `from ._file import func` imports to compose methods from separate files. This avoids large monolithic classes. When adding functionality to `Pipe`:
+- Data retrieval → `meerschaum/core/Pipe/_data.py`
+- Sync logic → `meerschaum/core/Pipe/_sync.py`
+- Attributes/properties → `meerschaum/core/Pipe/_attributes.py`
+- Cache → `meerschaum/core/Pipe/_cache.py`
+- Then add the import to `meerschaum/core/Pipe/__init__.py`
+
+### Lazy Imports with `attempt_import`
+
+Never import heavy packages at module level. Use:
+
+```python
+from meerschaum.utils.packages import attempt_import
+
+pandas = attempt_import('pandas')                        # installs into 'mrsm' venv if missing
+dateutil = attempt_import('dateutil', venv='mrsm')
+shapely = attempt_import('shapely', venv='mrsm')
+```
+
+For packages that must be in a specific plugin's venv:
+```python
+requests = attempt_import('requests', venv='my_plugin')
+```
+
+Use `TYPE_CHECKING` for type hints on heavy types:
+```python
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    pd = attempt_import('pandas')
+```
+
+### `Venv` Context Manager
+
+When calling a plugin's or connector's code that uses the plugin's venv:
+```python
+from meerschaum.utils.venv import Venv
+from meerschaum.connectors import get_connector_plugin
+
+with Venv(get_connector_plugin(pipe.connector)):
+    result = pipe.connector.fetch(pipe, begin=begin)
+```
+
+### `filter_arguments` / `filter_keywords`
+
+Connectors and plugins may not accept all kwargs. Use:
+```python
+from meerschaum.utils.misc import filter_arguments, filter_keywords
+
+# filter_arguments: returns (args, kwargs) filtered to match func's signature
+args, kw = filter_arguments(func, *args, **kwargs)
+result = func(*args, **kw)
+
+# filter_keywords: returns only kwargs accepted by func
+kw = filter_keywords(func, **kwargs)
+result = func(**kw)
+```
+
+---
+
+## Pipes Dictionary
+
+`get_pipes()` returns `{connector_keys: {metric_key: {location_key: Pipe}}}`. `location_key` is `None` when absent. Use:
+- `as_list=True` to get `[Pipe, ...]`
+- `flatten_pipes_dict(pipes_dict)` from `meerschaum.utils.pipes`
+- `pipes_dict_from_list(pipes_list)` to reconstruct the hierarchy
+
+### Key Negation
+
+Prefix any filter value with `_` to negate it. Applies to `connector_keys`, `metric_keys`, `location_keys`, `tags`, `datetime_dtypes`. Implemented via `separate_negation_values()` from `meerschaum.utils.misc`.
+
+---
+
+## Config System
+
+`get_config(*keys, patch=False)` reads the hierarchical YAML config registry at `MRSM_ROOT_DIR/config/`. Keys are path segments: `get_config('meerschaum', 'instance')` reads `config.meerschaum.instance`.
+
+`STATIC_CONFIG` in `meerschaum/_internal/static.py` holds compile-time constants (e.g. `negation_prefix = '_'`). Import as:
+```python
+from meerschaum._internal.static import STATIC_CONFIG
+prefix = STATIC_CONFIG['system']['fetch_pipes_keys']['negation_prefix']
+```
+
+Plugin config: `get_plugin_config(*keys)` / `write_plugin_config(value, *keys)` — reads/writes under `plugins.<plugin_name>` in the config registry.
+
+---
+
+## Cache System
+
+`Pipe._cache_value(key, value, memory_only=False)` and `Pipe._get_cached_value(key)` provide two-layer caching:
+- **Memory** (always): stored in `pipe.__dict__` under `_<key>`.
+- **Disk** (when `memory_only=False`): pickled to `MRSM_ROOT_DIR/cache/<instance_hash>/<pipe_id>/`.
+
+Keys starting with `_` are treated as memory-only regardless. The cache is keyed per instance-hash (derived from the connector's stable config), so changing a host/port invalidates cached data.
+
+Important cached values: `'_id'` (pipe's row ID in the pipes table), `'attributes'` (full pipe metadata), `'_attributes_sync_time'` (last refresh timestamp), `'precision'`.
+
+---
+
+## Jobs System
+
+`meerschaum.jobs.Job(name, sysargs, executor_keys='local')` wraps `meerschaum.utils.daemon.Daemon` to run a `sysargs` string as a background process.
+
+- `executor_keys='local'` — runs as a managed daemon process under `MRSM_ROOT_DIR/jobs/`
+- `executor_keys='systemd'` — creates a `systemd` user service
+- `executor_keys='api:label'` — posts the job to a remote API instance
+
+Jobs persist across restarts. Their logs stream via `job.monitor_logs(callback)`. `job.start()` / `job.stop()` / `job.pause()` return `SuccessTuple`.
+
+---
+
+## Plugins System
+
+Plugins are Python files/packages in `MRSM_PLUGINS_DIR`. Recognized functions (called automatically by the system):
+
+| Function | When called |
+|---|---|
+| `register(pipe, **kw) -> dict` | When `mrsm register pipe` runs; return initial `parameters` |
+| `fetch(pipe, begin, end, **kw) -> df\|generator` | During `sync pipes`; return new data |
+| `sync(pipe, **kw) -> SuccessTuple` | Override the full sync process |
+| `setup(**kw) -> SuccessTuple` | On first install / `mrsm setup plugins` |
+
+Decorator-based extensions:
+- `@make_action` — register a function as an action
+- `@api_plugin` — add FastAPI routes (receives `app: FastAPI`)
+- `@dash_plugin` — add Dash callbacks (receives `dash_app: Dash`)
+- `@web_page('/path')` — add a page to the web dashboard (nest inside `@dash_plugin`)
+- `@pre_sync_hook` / `@post_sync_hook` — called before/after every sync
+
+Custom CLI args: `add_plugin_argument('--foo', type=str, help='...')` from `meerschaum.plugins`.
+
+Declare package dependencies: `required = ['requests>=2.0', 'pandas']`. These install into a venv named after the plugin.
+
+---
+
+## Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `MRSM_ROOT_DIR` | Isolates all config, data, jobs, and cache |
+| `MRSM_PLUGINS_DIR` | Override plugins directory |
+| `MRSM_SQL_<LABEL>` / `MRSM_API_<LABEL>` | Set connector by URI (e.g. `MRSM_SQL_MAIN=postgresql://...`) |
+| `MRSM_TEST_FLAVORS` | Comma-separated DB flavors to test against |
+| `MRSM_API_TEST` | URI for the test API connector |
+| `PDOC_ALLOW_EXEC` | Must be `1` for pdoc to build the API docs |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repo.
 
 ## Commands
 
 ### Development CLI
 
-`./scripts/mrsm.sh <args>` runs `python -m meerschaum` with `MRSM_ROOT_DIR=./test_root` and `MRSM_PLUGINS_DIR=./tests/plugins` so it never touches the user's real config.
+`./scripts/mrsm.sh <args>` runs `python -m meerschaum` with `MRSM_ROOT_DIR=./test_root` and `MRSM_PLUGINS_DIR=./tests/plugins` — never touches real config.
 
 ### Running Tests
 
@@ -24,7 +24,7 @@ MRSM_ROOT_DIR=./test_root MRSM_PLUGINS_DIR=./tests/plugins python -m pytest test
 MRSM_TEST_FLAVORS=sqlite python -m pytest tests/ -v
 ```
 
-Test connectors are defined in `tests/connectors.py`. The default flavor set is `api,timescaledb`; set `MRSM_TEST_FLAVORS=sqlite` for fast local runs without Docker.
+Test connectors in `tests/connectors.py`. Default flavor set: `api,timescaledb`; set `MRSM_TEST_FLAVORS=sqlite` for fast local runs without Docker.
 
 ### Docs
 
@@ -41,13 +41,13 @@ Test connectors are defined in `tests/connectors.py`. The default flavor set is 
 
 ## Architecture Overview
 
-Meerschaum is an ETL framework centered on **pipes** — named data streams synced into tables. Each pipe is identified by three keys, stored in a metadata table managed by an **instance connector**, and fetches data from a **source connector**.
+ETL framework centered on **pipes** — named data streams synced into tables. Each pipe: three keys, metadata managed by **instance connector**, data from **source connector**.
 
 ### Core Abstractions
 
-**`SuccessTuple`** (`Tuple[bool, str]`) is the universal return type for all actions, pipe methods, and connector methods. Always return `(True, "Success")` or `(False, "reason")`. Never raise exceptions from action-level code — catch and return a `SuccessTuple`.
+**`SuccessTuple`** (`Tuple[bool, str]`) — universal return type for all actions, pipe methods, connector methods. Return `(True, "Success")` or `(False, "reason")`. Never raise from action-level code — catch and return `SuccessTuple`.
 
-**`warn(msg)` / `error(msg, exception)` / `info(msg)` / `dprint(msg, debug=debug)`** — use these from `meerschaum.utils.warnings` rather than `print()`. `warn` uses Python's warnings system (stackable). `error` raises an exception (default `Exception`). `dprint` is debug-only and requires passing `debug=debug`. `info` is for user-facing status messages.
+**`warn(msg)` / `error(msg, exception)` / `info(msg)` / `dprint(msg, debug=debug)`** — use from `meerschaum.utils.warnings` not `print()`. `warn`: Python warnings system (stackable). `error`: raises `Exception`. `dprint`: debug-only, requires `debug=debug`. `info`: user-facing status.
 
 ---
 
@@ -55,7 +55,7 @@ Meerschaum is an ETL framework centered on **pipes** — named data streams sync
 
 ### Identity
 
-A pipe is uniquely identified by three string keys:
+Pipe = three string keys:
 
 | Key | Arg in constructor | Meaning |
 |---|---|---|
@@ -63,15 +63,15 @@ A pipe is uniquely identified by three string keys:
 | `metric_key` | 2nd positional or `metric=` | Label for the data stream (e.g. `'weather'`) |
 | `location_key` | 3rd positional or `location=` | Optional tag/shard (default `None`) |
 
-The 4th constructor argument (or `instance=` / `mrsm_instance=`) is the **instance connector** — where pipe metadata (parameters, registration) and data are stored.
+4th arg (or `instance=` / `mrsm_instance=`) = **instance connector** — where metadata and data are stored.
 
 ### Target Table Name
 
-`pipe.target` is the table name in the instance database. By default: `{connector_keys.replace(':', '_')}_{metric_key}` (plus `_{location_key}` if set). Override via `parameters['target']`, `parameters['target_name']`, or `parameters['target_table']`. Long names are truncated per-flavor. On SQL instances, the full qualified name is `schema.target`.
+`pipe.target` = table name. Default: `{connector_keys.replace(':', '_')}_{metric_key}` (plus `_{location_key}` if set). Override via `parameters['target']`, `parameters['target_name']`, or `parameters['target_table']`. Long names truncated per-flavor. SQL instances: full name is `schema.target`.
 
 ### The `parameters` Dictionary
 
-`pipe.parameters` is the central metadata dict. Important top-level keys:
+`pipe.parameters` — central metadata dict. Top-level keys:
 
 | Key | Type | Purpose |
 |---|---|---|
@@ -96,7 +96,7 @@ The 4th constructor argument (or `instance=` / `mrsm_instance=`) is the **instan
 | `parents` / `children` | `List[str\|Dict\|Pipe]` | Pipe relationship graph (informational and for SQL pushdown). |
 | `parent` / `child` | `str\|Dict\|Pipe` | Singular alias for first parent/child. |
 
-Mutating parameters in memory: `pipe.update_parameters({'key': value}, persist=False)` or assign directly like `pipe.upsert = True`. To persist to the instance, call `pipe.edit()` or pass `persist=True`.
+Mutate in memory: `pipe.update_parameters({'key': value}, persist=False)` or assign like `pipe.upsert = True`. Persist: call `pipe.edit()` or pass `persist=True`.
 
 **Key convenience attributes and methods:**
 - `pipe.metric` / `pipe.location` — aliases for `metric_key` / `location_key`
@@ -107,9 +107,9 @@ Mutating parameters in memory: `pipe.update_parameters({'key': value}, persist=F
 
 ### Columns and Dtypes
 
-`pipe.columns` is a shortcut to `pipe.parameters['columns']`. The `'datetime'` column drives all incremental syncing logic (begin/end window). The `'id'` column (or any additional named columns) forms the composite uniqueness key. Pipes without a `datetime` column still work but lose incremental behavior.
+`pipe.columns` shortcut to `pipe.parameters['columns']`. `'datetime'` column drives incremental sync (begin/end window). `'id'` column forms composite uniqueness key. Pipes without `'datetime'` work but lose incremental behavior.
 
-Supported Meerschaum dtypes (stored in `parameters['dtypes']`):
+Supported dtypes (stored in `parameters['dtypes']`):
 - `'datetime'` — timezone-aware timestamp (stored as `TIMESTAMPTZ` or equivalent)
 - `'int'` — integer (used when the datetime axis is an integer epoch)
 - `'numeric'` — arbitrary-precision decimal (`NUMERIC` in SQL)
@@ -119,22 +119,22 @@ Supported Meerschaum dtypes (stored in `parameters['dtypes']`):
 - `'geometry[srid]'` — PostGIS geometry (e.g. `'geometry[EPSG:4326]'`, `'geometry[ESRI:102003]'`)
 - Any Pandas dtype string is also valid (e.g. `'Int64'`, `'float64'`, `'bool'`, `'object'`)
 
-Dtype mapping between Meerschaum strings and DB types lives in `meerschaum/utils/dtypes/sql.py` (`get_pd_type_from_db_type`, `get_db_type_from_pd_type`).
+Dtype mapping in `meerschaum/utils/dtypes/sql.py` (`get_pd_type_from_db_type`, `get_db_type_from_pd_type`).
 
 ### Sync Flow
 
-`pipe.sync(df=None, begin='', end=None, ...)` is the main entry point. The flow:
+`pipe.sync(df=None, begin='', end=None, ...)` — main entry point. Flow:
 
-1. **Fetch** — if `df` is not provided, calls `pipe.fetch()` which delegates to `pipe.connector.fetch(pipe, begin, end, ...)`. For SQL connectors this executes the metadefinition query. For plugin connectors this calls the plugin's `fetch()` function. For API connectors this hits the remote API.
-2. **Dtype enforcement** — `pipe.enforce_dtypes(df)` casts incoming data to registered dtypes.
-3. **Filter existing** — `pipe.filter_existing(df)` fetches the overlapping time window from the instance (`get_backtrack_data`) and computes the diff via `filter_unseen_df()` to find only new/changed rows.
-4. **Sync to instance** — `instance_connector.sync_pipe(pipe, df)` writes the filtered rows. For SQL instances this generates INSERT/UPDATE queries (or UPSERT if `upsert=True`).
+1. **Fetch** — if `df` not provided, calls `pipe.fetch()` → `pipe.connector.fetch(pipe, begin, end, ...)`. SQL: executes metadefinition. Plugin: calls `fetch()`. API: hits remote.
+2. **Dtype enforcement** — `pipe.enforce_dtypes(df)` casts to registered dtypes.
+3. **Filter existing** — `pipe.filter_existing(df)` fetches overlapping window (`get_backtrack_data`), diffs via `filter_unseen_df()` to find new/changed rows.
+4. **Sync to instance** — `instance_connector.sync_pipe(pipe, df)` writes filtered rows. SQL: INSERT/UPDATE (or UPSERT if `upsert=True`).
 
-The `begin` parameter defaults to `''` (empty string), which signals "use the pipe's sync time minus backtrack interval". `None` means "no lower bound". An explicit datetime/int overrides.
+`begin=''` = use sync time minus backtrack. `None` = no lower bound. Explicit datetime/int overrides.
 
 ### SQL Connector Fetch (Metadefinition)
 
-For `connector_keys` starting with `'sql:'`, the connector's `get_pipe_metadef()` builds the query:
+For `connector_keys` starting with `'sql:'`, `get_pipe_metadef()` builds:
 
 ```
 WITH "definition" AS (
@@ -145,15 +145,15 @@ WHERE "<dt_col>" >= <begin - backtrack>
   AND "<dt_col>" < <end>
 ```
 
-If a `parent` pipe is set, the pushdown `WHERE` clause is applied to the parent's table instead (allows dtype conversion via SQL). The `{{ Pipe('connector', 'metric') }}` syntax in the SQL definition is resolved to the target table name at query time.
+If `parent` pipe set, pushdown `WHERE` hits parent's table (allows SQL dtype conversion). `{{ Pipe('connector', 'metric') }}` resolved to target table at query time.
 
 ### `{{ Pipe() }}` Syntax
 
-SQL definitions and parameter values can reference other pipes using `{{ Pipe('ck', 'mk', 'lk') }}`. This is resolved by `replace_pipes_syntax()` in `meerschaum/utils/pipes.py`. Attribute chains work: `{{ Pipe('a', 'b').columns['datetime'] }}`. Use `{{ self.parameters['key'] }}` to self-reference.
+Reference other pipes with `{{ Pipe('ck', 'mk', 'lk') }}`. Resolved by `replace_pipes_syntax()` in `meerschaum/utils/pipes.py`. Attribute chains: `{{ Pipe('a', 'b').columns['datetime'] }}`. Self-reference: `{{ self.parameters['key'] }}`.
 
 ### `MRSM{}` Config Symlinks
 
-Reference Meerschaum config values from within pipe parameters using `MRSM{key1:key2:key3}` syntax:
+Reference config values from pipe parameters with `MRSM{key1:key2:key3}` syntax:
 
 ```python
 pipe = mrsm.Pipe('demo', 'cfg', parameters={
@@ -164,7 +164,7 @@ print(pipe.parameters['username'])  # resolved at access time
 
 ### `params` Filter
 
-`params: Dict[str, Any]` passed to `get_data()`, `get_backtrack_data()`, `get_rowcount()`, `get_sync_time()`, `get_pipes()`, `build_where()`, etc. generates a `WHERE` clause. The actual SQL is built by `meerschaum.utils.sql.build_where()`. Values support:
+`params: Dict[str, Any]` passed to `get_data()`, `get_backtrack_data()`, `get_rowcount()`, `get_sync_time()`, `get_pipes()`, `build_where()`, etc. generates `WHERE` clause via `meerschaum.utils.sql.build_where()`. Values:
 - Single value: `{'color': 'red'}` → `WHERE color = 'red'`
 - List: `{'color': ['red', 'blue']}` → `WHERE color IN ('red', 'blue')`
 - Negation prefix `_`: `{'color': '_red'}` → `WHERE color != 'red'`
@@ -174,13 +174,40 @@ print(pipe.parameters['username'])  # resolved at access time
 - Negated null: `{'color': '_None'}` → `WHERE color IS NOT NULL`
 - Dict value: `{'meta': {'k': 'v'}}` → `WHERE CAST(meta AS TEXT) = '{"k": "v"}'`
 
-**Column validation for SQL pipes:** when `pipe.enforce=True` (the default), `get_pipe_data_query()` filters `params` to only columns that actually exist on the table before building the `WHERE` clause — unknown columns are silently dropped. Pass `pipe.enforce=False` to skip this check.
+**Column validation for SQL pipes:** `pipe.enforce=True` (default) filters `params` to existing columns before building `WHERE` — unknown columns dropped. Pass `pipe.enforce=False` to skip.
 
-For in-memory filtering on a DataFrame, use `meerschaum.utils.dataframe.query_df(df, params)` — same negation semantics apply.
+In-memory filtering: `meerschaum.utils.dataframe.query_df(df, params)` — same negation semantics.
 
 ### Verification Syncs
 
-`pipe.verify(begin, end, chunk_interval, ...)` re-syncs the entire historical range in chunks (default 1440-minute chunks). Uses `pipe.get_rowcount()` to compare remote vs local counts and only re-syncs mismatched chunks. Configured via `parameters['verify']`.
+`pipe.verify(begin, end, chunk_interval, ...)` re-syncs historical range in chunks (default 1440 min). Uses `pipe.get_rowcount()` to compare remote vs local; re-syncs only mismatched chunks. Configured via `parameters['verify']`.
+
+---
+
+## SQL Security Patterns
+
+### `clean()` — keyword blocklist
+
+`clean(substring)` in `meerschaum/utils/sql.py` raises on banned SQL keywords (`;`, `--`, `drop`, `union`, `insert`, `update`, `delete`, `create`, `alter`, `truncate`, `exec`, `/*`). **Keyword blocklist only** — quote-only payloads like `' OR '1'='1` not caught. Use parameterized queries for user input; `clean()` for internal names (tables, columns).
+
+### `dateadd_str()` — `datepart` whitelist
+
+`datepart` validated against `_VALID_DATEPARTS = frozenset({'year', 'month', 'day', 'hour', 'minute', 'second'})`. **Exception:** `datepart=None` valid when `begin` is int — returns early before `datepart` used. Whitelist check must come after `isinstance(begin, int)` early-return.
+
+### Table name escaping in `.format()` queries
+
+Functions building queries via `.format()` (e.g. `get_table_cols_types()`, `get_table_cols_indices()` in `meerschaum/utils/sql.py`) escape table/schema names with `s.replace("'", "''")` before interpolation. Never skip for new format-based queries.
+
+---
+
+## API Server Pipe Cache
+
+API server keeps shared `pipes_dict` (in `meerschaum/api/__init__.py`) caching live `Pipe` objects between requests. Two behaviors:
+
+- `get_pipe(refresh=False)` — returns **shared** `pipes_dict` object (mutations/cache clears persist across requests).
+- `get_pipe(refresh=True)` — creates **throwaway** `Pipe` not stored in `pipes_dict`; cache cleared on it has no effect on future requests.
+
+**Stale column-types cache:** After dtype-changing sync, `pipes_dict` object retains `_columns_types` up to 60 s (`columns_types_cache_seconds`). `DELETE /pipes/{ck}/{mk}/{lk}/cache` (added 2025-05) clears it via `pipe._invalidate_cache(hard=True)` on the shared object. `APIConnector.sync_pipe` calls `self.delete_pipe_cache(pipe)` after every sync.
 
 ---
 
@@ -194,11 +221,11 @@ Connector                         (meerschaum/connectors/_Connector.py)
     └── ValkeyConnector           (meerschaum/connectors/valkey/)
 ```
 
-`Connector` reads config from `MRSM_ROOT_DIR/config/connectors.yaml` keyed by `type:label`. The class attribute `REQUIRED_ATTRIBUTES` lists keys that must be set (either in config or passed directly). When cast to string, a connector returns `"type:label"`.
+`Connector` reads config from `MRSM_ROOT_DIR/config/connectors.yaml` keyed by `type:label`. `REQUIRED_ATTRIBUTES` lists required keys. Cast to string returns `"type:label"`.
 
-`InstanceConnector` adds the full pipes/users/plugins/tokens interface that all instances must implement. Set `IS_INSTANCE = True` to make a connector usable as an instance. Set `IS_THREAD_SAFE = True` if the connector supports concurrent reads (used by `get_pool` for parallel pipe fetching). Registering a custom connector type with `IS_INSTANCE = True` automatically adds its `type` to `meerschaum.connectors.instance_types`.
+`InstanceConnector` adds pipes/users/plugins/tokens interface. `IS_INSTANCE = True` makes connector usable as instance. `IS_THREAD_SAFE = True` enables concurrent reads (used by `get_pool`). Custom connector with `IS_INSTANCE = True` auto-adds its `type` to `meerschaum.connectors.instance_types`.
 
-**All major connector classes compose their methods via class-level imports:**
+All major connector classes compose methods via class-level imports:
 
 ```python
 class SQLConnector(InstanceConnector):
@@ -207,7 +234,7 @@ class SQLConnector(InstanceConnector):
     from ._fetch import fetch, get_pipe_metadef
 ```
 
-This means each logical group of methods lives in a separate `_*.py` file. New methods belong in the appropriate file, not the class definition file.
+Each logical group of methods lives in separate `_*.py`. New methods go in appropriate file, not class definition.
 
 ### Adding a Custom Connector
 
@@ -223,17 +250,17 @@ class FooConnector(InstanceConnector):
     # Implement all InstanceConnector abstract methods...
 ```
 
-See `meerschaum/connectors/instance/_InstanceConnector.py` for the full interface and `docs/zensical/reference/connectors/instance-connectors.md` for the method-by-method guide.
+See `meerschaum/connectors/instance/_InstanceConnector.py` for full interface and `docs/zensical/reference/connectors/instance-connectors.md` for method-by-method guide.
 
-`fetch_pipes_keys()` may return either a list of key tuples or a dict where keys are pipe IDs (int) and values are key tuples (with optional parameters/tags appended). The dict form lets the instance return full pipe attributes in a single round-trip.
+`fetch_pipes_keys()` returns list of key tuples or dict (pipe ID → key tuple, optional params/tags appended). Dict form returns full pipe attributes in one round-trip.
 
 ---
 
 ## Actions
 
-Each top-level action (`sync`, `show`, `register`, `copy`, etc.) is a module in `meerschaum/actions/`. Actions receive `**kwargs` matching the argparse namespace from `meerschaum/_internal/arguments/_parser.py`.
+Top-level actions (`sync`, `show`, `register`, `copy`, etc.) are modules in `meerschaum/actions/`. Receive `**kwargs` matching argparse namespace from `meerschaum/_internal/arguments/_parser.py`.
 
-Common kwargs passed to all actions:
+Common kwargs:
 - `connector_keys: List[str]`, `metric_keys: List[str]`, `location_keys: List[str]`
 - `mrsm_instance: str` — instance connector keys
 - `begin: datetime`, `end: datetime`
@@ -242,7 +269,7 @@ Common kwargs passed to all actions:
 - `debug: bool`
 - `yes: bool`, `force: bool`, `noask: bool`
 
-Subactions are functions within the module auto-discovered by naming convention (e.g. `sync_pipes` in `actions/sync.py`). To add a subaction, define `def <action>_<subaction>(**kwargs) -> SuccessTuple` in the module — no registration needed.
+Subactions auto-discovered by naming convention (e.g. `sync_pipes` in `actions/sync.py`). Add: define `def <action>_<subaction>(**kwargs) -> SuccessTuple` — no registration needed.
 
 Plugin actions use `@make_action` from `meerschaum.plugins` or `meerschaum.actions`.
 
@@ -252,7 +279,7 @@ Plugin actions use `@make_action` from `meerschaum.plugins` or `meerschaum.actio
 
 ### Mixin-via-Import Pattern
 
-Both `Pipe` and connectors use class-level `from ._file import func` imports to compose methods from separate files. This avoids large monolithic classes. When adding functionality to `Pipe`:
+`Pipe` and connectors compose methods via class-level `from ._file import func` imports. When adding to `Pipe`:
 - Data retrieval → `meerschaum/core/Pipe/_data.py`
 - Sync logic → `meerschaum/core/Pipe/_sync.py`
 - Attributes/properties → `meerschaum/core/Pipe/_attributes.py`
@@ -271,12 +298,12 @@ dateutil = attempt_import('dateutil', venv='mrsm')
 shapely = attempt_import('shapely', venv='mrsm')
 ```
 
-For packages that must be in a specific plugin's venv:
+For packages in plugin venv:
 ```python
 requests = attempt_import('requests', venv='my_plugin')
 ```
 
-Use `TYPE_CHECKING` for type hints on heavy types:
+For type hints on heavy types:
 ```python
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -285,7 +312,7 @@ if TYPE_CHECKING:
 
 ### `Venv` Context Manager
 
-When calling a plugin's or connector's code that uses the plugin's venv:
+When calling plugin/connector code using plugin's venv:
 ```python
 from meerschaum.utils.venv import Venv
 from meerschaum.connectors import get_connector_plugin
@@ -296,7 +323,7 @@ with Venv(get_connector_plugin(pipe.connector)):
 
 ### `filter_arguments` / `filter_keywords`
 
-Connectors and plugins may not accept all kwargs. Use:
+Connectors/plugins may not accept all kwargs:
 ```python
 from meerschaum.utils.misc import filter_arguments, filter_keywords
 
@@ -313,58 +340,58 @@ result = func(**kw)
 
 ## Pipes Dictionary
 
-`get_pipes()` returns `{connector_keys: {metric_key: {location_key: Pipe}}}`. `location_key` is `None` when absent. Use:
+`get_pipes()` returns `{connector_keys: {metric_key: {location_key: Pipe}}}` (`location_key` is `None` when absent). Use:
 - `as_list=True` to get `[Pipe, ...]`
 - `flatten_pipes_dict(pipes_dict)` from `meerschaum.utils.pipes`
 - `pipes_dict_from_list(pipes_list)` to reconstruct the hierarchy
 
 ### Key Negation
 
-Prefix any filter value with `_` to negate it. Applies to `connector_keys`, `metric_keys`, `location_keys`, `tags`, `datetime_dtypes`. Implemented via `separate_negation_values()` from `meerschaum.utils.misc`.
+Prefix filter value with `_` to negate. Applies to `connector_keys`, `metric_keys`, `location_keys`, `tags`, `datetime_dtypes`. Via `separate_negation_values()` in `meerschaum.utils.misc`.
 
 ---
 
 ## Config System
 
-`get_config(*keys, patch=False)` reads the hierarchical YAML config registry at `MRSM_ROOT_DIR/config/`. Keys are path segments: `get_config('meerschaum', 'instance')` reads `config.meerschaum.instance`.
+`get_config(*keys, patch=False)` reads YAML config registry at `MRSM_ROOT_DIR/config/`. Keys are path segments: `get_config('meerschaum', 'instance')` → `config.meerschaum.instance`.
 
-`STATIC_CONFIG` in `meerschaum/_internal/static.py` holds compile-time constants (e.g. `negation_prefix = '_'`). Import as:
+`STATIC_CONFIG` in `meerschaum/_internal/static.py` holds compile-time constants. Import:
 ```python
 from meerschaum._internal.static import STATIC_CONFIG
 prefix = STATIC_CONFIG['system']['fetch_pipes_keys']['negation_prefix']
 ```
 
-Plugin config: `get_plugin_config(*keys)` / `write_plugin_config(value, *keys)` — reads/writes under `plugins.<plugin_name>` in the config registry.
+Plugin config: `get_plugin_config(*keys)` / `write_plugin_config(value, *keys)` — reads/writes under `plugins.<plugin_name>`.
 
 ---
 
 ## Cache System
 
-`Pipe._cache_value(key, value, memory_only=False)` and `Pipe._get_cached_value(key)` provide two-layer caching:
+`Pipe._cache_value(key, value, memory_only=False)` and `Pipe._get_cached_value(key)` — two-layer cache:
 - **Memory** (always): stored in `pipe.__dict__` under `_<key>`.
 - **Disk** (when `memory_only=False`): pickled to `MRSM_ROOT_DIR/cache/<instance_hash>/<pipe_id>/`.
 
-Keys starting with `_` are treated as memory-only regardless. The cache is keyed per instance-hash (derived from the connector's stable config), so changing a host/port invalidates cached data.
+Keys starting with `_` = memory-only. Cache keyed per instance-hash (derived from connector config); changing host/port invalidates.
 
-Important cached values: `'_id'` (pipe's row ID in the pipes table), `'attributes'` (full pipe metadata), `'_attributes_sync_time'` (last refresh timestamp), `'precision'`.
+Cached values: `'_id'` (row ID), `'attributes'` (full metadata), `'_attributes_sync_time'` (last refresh), `'precision'`.
 
 ---
 
 ## Jobs System
 
-`meerschaum.jobs.Job(name, sysargs, executor_keys='local')` wraps `meerschaum.utils.daemon.Daemon` to run a `sysargs` string as a background process.
+`meerschaum.jobs.Job(name, sysargs, executor_keys='local')` wraps `meerschaum.utils.daemon.Daemon` to run `sysargs` as background process.
 
-- `executor_keys='local'` — runs as a managed daemon process under `MRSM_ROOT_DIR/jobs/`
+- `executor_keys='local'` — managed daemon process under `MRSM_ROOT_DIR/jobs/`
 - `executor_keys='systemd'` — creates a `systemd` user service
 - `executor_keys='api:label'` — posts the job to a remote API instance
 
-Jobs persist across restarts. Their logs stream via `job.monitor_logs(callback)`. `job.start()` / `job.stop()` / `job.pause()` return `SuccessTuple`.
+Jobs persist across restarts. Logs stream via `job.monitor_logs(callback)`. `job.start()` / `job.stop()` / `job.pause()` return `SuccessTuple`.
 
 ---
 
 ## Plugins System
 
-Plugins are Python files/packages in `MRSM_PLUGINS_DIR`. Recognized functions (called automatically by the system):
+Plugins: Python files/packages in `MRSM_PLUGINS_DIR`. Recognized functions:
 
 | Function | When called |
 |---|---|
@@ -373,7 +400,7 @@ Plugins are Python files/packages in `MRSM_PLUGINS_DIR`. Recognized functions (c
 | `sync(pipe, **kw) -> SuccessTuple` | Override the full sync process |
 | `setup(**kw) -> SuccessTuple` | On first install / `mrsm setup plugins` |
 
-Decorator-based extensions:
+Decorator extensions:
 - `@make_action` — register a function as an action
 - `@api_plugin` — add FastAPI routes (receives `app: FastAPI`)
 - `@dash_plugin` — add Dash callbacks (receives `dash_app: Dash`)
@@ -382,7 +409,7 @@ Decorator-based extensions:
 
 Custom CLI args: `add_plugin_argument('--foo', type=str, help='...')` from `meerschaum.plugins`.
 
-Declare package dependencies: `required = ['requests>=2.0', 'pandas']`. These install into a venv named after the plugin.
+Package dependencies: `required = ['requests>=2.0', 'pandas']`. Install into plugin-named venv.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 ## What is Meerschaum?
-Meerschaum is a tool for quickly synchronizing time-series data streams called **pipes**. With Meerschaum, you can have a data visualization stack running in minutes.
+Meerschaum is a tool for quickly synchronizing time-series data streams called **pipes**. With Meerschaum, you can have a data pipeline and visualization stack running in minutes.
 
 <p align="center">
 <img src="https://meerschaum.io/assets/screenshots/weather_pipes.png"/>
@@ -80,32 +80,32 @@ pipe = mrsm.Pipe(
     },
 )
 ### Pass a DataFrame to create the table and indices.
-pipe.sync([{'dt': '2022-07-01', 'id': 1, 'val': 10}])
+pipe.sync([{'dt': '2024-07-01', 'id': 1, 'val': 10}])
 
 ### Duplicate rows are ignored.
-pipe.sync([{'dt': '2022-07-01', 'id': 1, 'val': 10}])
+pipe.sync([{'dt': '2024-07-01', 'id': 1, 'val': 10}])
 assert len(pipe.get_data()) == 1
 
 ### Rows with existing keys (datetime and/or id) are updated.
-pipe.sync([{'dt': '2022-07-01', 'id': 1, 'val': 100}])
+pipe.sync([{'dt': '2024-07-01', 'id': 1, 'val': 100}])
 assert len(pipe.get_data()) == 1
 
 ### Translates to this query for SQLite:
 ###
 ### SELECT *
 ### FROM "MyTableName!"
-### WHERE "dt" >= datetime('2022-01-01', '0 minute')
-###   AND "dt" <  datetime('2023-01-01', '0 minute')
+### WHERE "dt" >= datetime('2024-01-01', '0 minute')
+###   AND "dt" <  datetime('2025-01-01', '0 minute')
 ###   AND "id" IN ('1')
 df = pipe.get_data(
-    begin  = '2022-01-01',
-    end    = '2023-01-01',
+    begin  = '2024-01-01',
+    end    = '2025-01-01',
     params = {'id': [1]},
 )
 
 ### Shape of the DataFrame:
 ###           dt  id  val
-### 0 2022-07-01   1  100
+### 0 2024-07-01   1  100
 
 ### Drop the table and remove the pipe's metadata.
 pipe.delete()
@@ -114,7 +114,7 @@ pipe.delete()
 ### Simple Plugin
 
 ```python
-# ~/.config/plugins/example.py
+# ~/.config/meerschaum/plugins/example.py
 
 __version__ = '1.0.0'
 required = ['requests']
@@ -127,24 +127,19 @@ def register(pipe, **kw):
         },
     }
 
-def fetch(pipe, **kw):
-    import requests, datetime, random
-    response = requests.get('http://date.jsontest.com/')
+def fetch(pipe, begin=None, end=None, **kw):
+    import requests, random
+    from datetime import datetime, timezone
 
-    ### The fetched JSON has the following shape:
-    ### {
-    ###     "date": "07-01-2022",
-    ###     "milliseconds_since_epoch": 1656718801566,
-    ###     "time": "11:40:01 PM"
-    ### }
-    data = response.json()
-    timestamp = datetime.datetime.fromtimestamp(
-        int(str(data['milliseconds_since_epoch'])[:-3])
-    )
+    ### Fetch data from an external API.
+    response = requests.get('https://api.example.com/data')
+    data = response.json()  ### list of dicts
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     ### You may also return a Pandas DataFrame.
     return [{
-        "dt"   : timestamp,
+        "dt"   : now,
         "id"   : random.randint(1, 4),
         "value": random.uniform(1, 100),
     }]
@@ -153,24 +148,33 @@ def fetch(pipe, **kw):
 ## Features
 
 - 📊 **Built for Data Scientists and Analysts**  
-  - Integrate with Pandas, Grafana and other popular [data analysis tools](https://meerschaum.io/reference/data-analysis-tools/).
+  - Integrate with Pandas, Grafana, and other popular [data analysis tools](https://meerschaum.io/reference/data-analysis-tools/).
   - Persist your dataframes and always get the latest data.
+  - Filter pipes by connector, metric, location, tags, or `datetime` column dtype (`--dtype datetime|int|None`).
 - ⚡️ **Production-Ready, Batteries Included**  
   - [Synchronization engine](https://meerschaum.io/reference/pipes/syncing/) concurrently updates many time-series data streams.
   - One-click deploy a [TimescaleDB and Grafana stack](https://meerschaum.io/reference/stack/) for prototyping.
   - Serve data to your entire organization through the power of `uvicorn`, `gunicorn`, and `FastAPI`.
+  - Supports PostGIS geometry columns for geospatial pipelines.
+- 💼 **Jobs and Scheduling**  
+  - Run any command as a background [job](https://meerschaum.io/reference/background-jobs/) with `-d` (`--daemon`).
+  - Built-in scheduler handles cron and interval schedules — no `crontab` or `systemd` setup required.
+  - Execute jobs locally, via `systemd` services, or remotely on an API instance with `--executor-keys`.
+  - Copy pipes across instances with the improved `copy pipes` command and `--sync-data` flag.
 - 🔌 **Easily Expandable**  
-  -  Ingest any data source with a simple [plugin](https://meerschaum.io/reference/plugins/writing-plugins/). Just return a DataFrame, and Meerschaum handles the rest.
+  - Ingest any data source with a simple [plugin](https://meerschaum.io/reference/plugins/writing-plugins/). Just return a DataFrame, and Meerschaum handles the rest.
   - [Add any function as a command](https://meerschaum.io/reference/plugins/types-of-plugins/#action-plugins) to the Meerschaum system.
+  - Define parent/child pipe relationships and pipe references for composable SQL pipelines.
   - Include Meerschaum in your projects with its [easy-to-use Python API](https://docs.meerschaum.io).
 - ✨ **Tailored for Your Experience**  
   - Rich CLI makes managing your data streams surprisingly enjoyable!
   - Web dashboard for those who prefer a more graphical experience.
-  - Manage your database connections with [Meerschaum connectors](https://meerschaum.io/reference/connectors/).
+  - Manage your database connections with [Meerschaum connectors](https://meerschaum.io/reference/connectors/) (SQL, API, Valkey, and custom).
   - Utility commands with sensible syntax let you control many pipes with grace.
 - 💼 **Portable from the Start**  
   - The environment variable `$MRSM_ROOT_DIR` lets you emulate multiple installations and group together your [instances](https://meerschaum.io/reference/connectors/#instances-and-repositories).
   - No dependencies required; anything needed will be installed into a virtual environment.
+  - Compatible with `uv` — install with `uv tool install meerschaum`.
   - [Specify required packages for your plugins](https://meerschaum.io/reference/plugins/writing-plugins/), and users will get those packages in a virtual environment.
 
 ## Support Meerschaum's Development
@@ -181,7 +185,7 @@ Additionally, you can always [buy me a coffee☕](https://www.buymeacoffee.com/b
 
 ### License
 
-Copyright 2021 Bennett Meares
+Copyright 2020-2026 Bennett Meares
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -22,6 +22,7 @@ nav = [
       "reference/pipes/index.md",
       {"🥾 Bootstrapping" = "reference/pipes/bootstrapping.md"},
       {"📥 Syncing" = "reference/pipes/syncing.md"},
+      {"📖 Reading Data" = "reference/pipes/reading.md"},
       {"🔖 Tags" = "reference/pipes/tags.md"},
       {"🧩 Parameters" = "reference/pipes/parameters.md"},
     ]},

--- a/docs/zensical/index.md
+++ b/docs/zensical/index.md
@@ -84,7 +84,7 @@ h1 {
     <a id="get-started-button" class="md-button md-button--primary" href="get-started">Get Started</a>
   </div>
   <div class="grid-child" >
-    <a id="pip-button" class="md-button" href="#!" style="font-family: monospace" onclick="copy_install_text(this)">$ pip install meerschaum<span class="twemoji">
+    <a id="pip-button" class="md-button" href="javascript:void(0)" style="font-family: monospace" onclick="copy_install_text(this)">$ pip install meerschaum<span class="twemoji">
 </a>
   </div>
 </div>

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -87,6 +87,38 @@ This is the current release cycle, so stay tuned for future releases!
   # }
   ```
 
+- **Add `Pipe.get_docs()`.**  
+  The convenience method `Pipe.get_docs()` returns a pipe's data as a list of dictionaries, bypassing pandas overhead. Combine with `as_chunks=True` to get an iterator of `List[Dict]` chunked by time bounds:
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'demo', 'docs',
+      instance='sql:memory',
+      temporary=True,
+      columns={'primary': 'id'},
+  )
+  pipe.sync([
+      {'id': 1, 'name': 'Alice'},
+      {'id': 2, 'name': 'Bob'},
+  ])
+
+  # All rows as a list of dicts (no pandas overhead):
+  docs = pipe.get_docs()
+  print(docs)
+  # [{'id': 1, 'name': 'Alice'}, {'id': 2, 'name': 'Bob'}]
+
+  # Single row as a dict:
+  doc = pipe.get_doc(params={'id': 2})
+  print(doc)
+  # {'id': 2, 'name': 'Bob'}
+
+  # Chunked iterator of lists of dicts:
+  for chunk in pipe.get_docs(as_chunks=True):
+      print(chunk)
+  ```
+
 - **Fix shell suggestions.**  
   A bug has been fixed where shell actions were truncated when chaining actions. Additionally, actions suggestions have been updated with highlight colors.
 

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -1,12 +1,31 @@
 # 🪵 Changelog
 
-## 3.2.0 Releases
+## 3.3.0 Releases
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.3.0
+
+- **Add `--dtype` flag.**  
+  The flag `--dtype` (explicitly `--datetime-dtypes` or `--datetime-dtype`) allows filtering pipes based on the data type of the `datetime` axis. Accepted values are `datetime`, `int`, `None`. This behaves similarly to keys selectors: multiple values may be provided, and values may be negated:
+
+  ```bash
+  mrsm show pipes --dtype int
+  mrsm show pipes --dtype int None
+  mrsm show pipes --dtype _datetime
+  ```
+
+- **Improve `copy pipes` flow.**  
+  The `copy pipes` action now better handles batches of pipes when the only key to be changed is the instance.
+
+- **Improve caching performance.**  
+  Better cache handling now reduces round-trips when fetching pipes' metadata.
+
+## 3.2.0 Releases
+
 ### v3.2.4
 
-- **Improvde default chunksize for integer pipes.**  
+- **Improve default chunksize for integer pipes.**  
   Pipes with integer datetime columns now default to appropriately sized chunks based on the `precision` unit.
 
   ```python

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -16,7 +16,36 @@ This is the current release cycle, so stay tuned for future releases!
   ```
 
 - **Improve `copy pipes` flow.**  
-  The `copy pipes` action now better handles batches of pipes when the only key to be changed is the instance.
+  The `copy pipes` action has been significantly improved for both interactive and scripted use cases.
+
+  **Non-interactive batch copying:** Specify the destination instance as the first positional argument to skip all prompts. Combined with `--force` and `--sync-data`, pipes can now be fully scripted:
+
+  ```bash
+  # Copy pipe definitions only (skip existing pipes)
+  mrsm copy pipes sql:dest -i sql:src
+
+  # Overwrite existing pipes and copy all data
+  mrsm copy pipes sql:dest -i sql:src --force --sync-data all
+
+  # Overwrite and sync with a date filter (--begin/--end imply filter mode automatically)
+  mrsm copy pipes sql:dest -i sql:src --force --begin 2024-01-01
+  ```
+
+  **New `--sync-data` flag:** 
+    Controls what data is synced when copying destination pipes. Accepted values are `nothing` (default), `backtrack`, `all`, and `filter`. When `--begin`, `--end`, or `--params` are provided without `--sync-data`, filter mode is selected automatically.
+
+  **Reduced interactive prompts for batches:**  
+    When copying many pipes to the same destination instance, all choices (conflict resolution, data sync mode, filter flags) are now collected upfront before any copying begins.
+
+  **Granular conflict resolution:**  
+    When destination pipes already exist, the interactive prompt now offers three options rather than a simple yes/no:
+    - *Skip* — leave the destination pipe entirely unchanged.
+    - *Data only* — sync data without updating stored attributes.
+    - *Attributes only* — update attributes without syncing data.
+    - *Attributes and data* — full overwrite (equivalent to `--force`).
+
+  **Copy summary table:**  
+    After copying data, a table is printed showing inserted, updated, and upserted row counts alongside the elapsed time per pipe and totals.
 
 - **Improve caching performance.**  
   Better cache handling now reduces round-trips when fetching pipes' metadata.

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -21,6 +21,46 @@ This is the current release cycle, so stay tuned for future releases!
 - **Improve caching performance.**  
   Better cache handling now reduces round-trips when fetching pipes' metadata.
 
+- **Allow dictionary return value from `fetch_pipes_keys()`.**  
+  The `InstanceConnector` method `fetch_pipes_keys()` may now return a dictionary, where the indices are pipes' IDs and the values are keys tuples (and possibly parameters or tags).
+
+  ```python
+  import json
+  import meerschaum as mrsm
+  from meerschaum.utils import fetch_pipes_keys
+
+  conn = mrsm.get_connector('sql:main')
+  keys_dict = fetch_pipes_keys('registered', mrsm.get_connector(), connector_keys=['sql:main'], metric_keys=['test'])
+  print(json.dumps(keys_dict, indent=4))
+  # {
+  #     "24": [
+  #         "sql:main",
+  #         "test",
+  #         null,
+  #         {
+  #             "sql": "SELECT *\nFROM {{ Pipe('plugin:noaa', 'weather') }}\nWHERE 1 = 1",
+  #             "tags": [
+  #                 "test"
+  #             ],
+  #             "fetch": {
+  #                 "backtrack_minutes": 1440
+  #             },
+  #             "verify": {
+  #                 "bound_days": 366,
+  #                 "chunk_minutes": 43200
+  #             },
+  #             "columns": {
+  #                 "id": null,
+  #                 "datetime": null
+  #             }
+  #         }
+  #     ]
+  # }
+  ```
+
+- **Fix shell suggestions.**  
+  A bug has been fixed where shell actions were truncated when chaining actions. Additionally, actions suggestions have been updated with highlight colors.
+
 ## 3.2.0 Releases
 
 ### v3.2.4

--- a/docs/zensical/reference/background-jobs.md
+++ b/docs/zensical/reference/background-jobs.md
@@ -3,7 +3,7 @@
 
 # 👷 Background Jobs
 
-Meerschaum's job management system lets you run any process in the background ― just add `-d` to any command. Thanks to the built-in [scheduler](#️-schedules), you no longer have to worry about manually configuring `crontab` or `systemd`.
+Meerschaum's job management system lets you run any process in the background ― just add `-d` to any command. Thanks to the built-in [scheduler](#schedules), you no longer have to worry about manually configuring `crontab` or `systemd`.
 
 !!! tip ""
     Depending on the [executor](#executors), jobs are created as either `systemd` services or managed daemon processes.

--- a/docs/zensical/reference/connectors/instance-connectors.md
+++ b/docs/zensical/reference/connectors/instance-connectors.md
@@ -4,6 +4,14 @@ Instance connectors store pipes' metadata (and may also be used as a source conn
 
 To use your custom connector type as an instance connector, inherit from `InstanceConnector` and implement the following methods (replacing the pseudocode under the `TODO` comments with your connector's equivalent). See the [`MongoDBConnector`](https://github.com/bmeares/mongodb-connector/blob/main/plugins/mongodb-connector/_pipes.py) for a specific reference.
 
+!!! note "Implementing `get_pipe_data` or `get_pipe_docs`"
+    For reading data from a pipe's target table, you may implement **either** [`get_pipe_data()`](#get_pipe_data) **or** [`get_pipe_docs()`](#get_pipe_docs):
+
+    - Implement `get_pipe_data()` to return a `pd.DataFrame` (recommended for SQL-based connectors).
+    - Implement `get_pipe_docs()` to return a `list[dict]` (recommended for document stores and connectors that produce JSON natively). This avoids DataFrame construction overhead when callers use [`Pipe.get_docs()`](https://docs.meerschaum.io/meerschaum.html#Pipe.get_docs) or `Pipe.get_data(as_docs=True)`.
+
+    The default `get_pipe_data()` calls `get_pipe_docs()` and wraps the result in a DataFrame. The default `get_pipe_docs()` calls `get_pipe_data()` and converts to records. You only need to implement one.
+
 
 !!! example "Inherit from `InstanceConnector`"
     Your connector class inherits from `InstanceConnector`, a subclass of `Connector` which implements the pipes' methods as an interface.
@@ -244,12 +252,15 @@ Delete a pipe's registration from the `pipes` table.
 
 ## `#!python fetch_pipes_keys()`
 
-Return a list of tuples for the registered pipes' keys according to the provided filters.
+Return registered pipes' keys according to the provided filters.
 
 Each filter should only be applied if the given list is not empty.
 Values within filters are joined by `OR`, and filters are joined by `AND`.
 
 The function [`separate_negation_values()`](https://docs.meerschaum.io/utils/misc.html#meerschaum.utils.misc.separate_negation_values) returns two sublists: regular values (`IN`) and values preceded by an underscore (`NOT IN`).
+
+You may return either a **list of tuples** or a **dictionary mapping pipe IDs to tuples**.
+Tuples may be length 3 `(connector_keys, metric_key, location_key)` or length 4 with parameters or tags as the fourth element.
 
 ??? example "`#!python def fetch_pipes_keys():`"
     ```python
@@ -261,9 +272,14 @@ The function [`separate_negation_values()`](https://docs.meerschaum.io/utils/mis
         tags: list[str] | None = None,
         debug: bool = False,
         **kwargs: Any
-    ) -> List[Tuple[str, str, str]]:
+    ) -> (
+        list[tuple[str, str, str]]
+        | list[tuple[str, str, str, dict | list]]
+        | dict[int | str, tuple[str, str, str]]
+        | dict[int | str, tuple[str, str, str, dict | list]]
+    ):
         """
-        Return a list of tuples for the registered pipes' keys according to the provided filters.
+        Return registered pipes' keys according to the provided filters.
 
         Parameters
         ----------
@@ -281,19 +297,20 @@ The function [`separate_negation_values()`](https://docs.meerschaum.io/utils/mis
 
         Returns
         -------
-        A list of connector, metric, and location keys in tuples.
-        You may return the string "None" for location keys in place of nulls.
+        A list of tuples or a dictionary mapping pipe IDs to tuples.
+        You may return the string `"None"` for location keys in place of nulls.
+        Tuples may include parameters or tags as a fourth element.
 
         Examples
         --------
         >>> import meerschaum as mrsm
         >>> conn = mrsm.get_connector('example:demo')
-        >>> 
+        >>>
         >>> pipe_a = mrsm.Pipe('a', 'demo', tags=['foo'], instance=conn)
         >>> pipe_b = mrsm.Pipe('b', 'demo', tags=['bar'], instance=conn)
         >>> pipe_a.register()
         >>> pipe_b.register()
-        >>> 
+        >>>
         >>> conn.fetch_pipes_keys(['a', 'b'])
         [('a', 'demo', 'None'), ('b', 'demo', 'None')]
         >>> conn.fetch_pipes_keys(metric_keys=['demo'])
@@ -312,9 +329,9 @@ The function [`separate_negation_values()`](https://docs.meerschaum.io/utils/mis
 
         ### TODO build a query like so, only including clauses if the given list is not empty.
         ### The `tags` clause is an OR ("?|"), meaning any of the tags may match.
-        ### 
-        ### 
-        ### SELECT connector_keys, metric_key, location_key
+        ###
+        ###
+        ### SELECT pipe_id, connector_keys, metric_key, location_key
         ### FROM pipes
         ### WHERE connector_keys IN ({in_ck})
         ###   AND connector_keys NOT IN ({nin_ck})
@@ -324,7 +341,12 @@ The function [`separate_negation_values()`](https://docs.meerschaum.io/utils/mis
         ###   AND location_key NOT IN ({nin_lk})
         ###   AND (parameters->'tags')::JSONB ?| ARRAY[{tags}]
         ###   AND NOT (parameters->'tags')::JSONB ?| ARRAY[{nin_tags}]
-        return []
+
+        ### Return a dict mapping pipe_id to (connector_keys, metric_key, location_key):
+        return {}
+
+        ### Or return a list of tuples (also accepted):
+        ### return []
     ```
 
 ## `#!python pipe_exists()`
@@ -555,6 +577,69 @@ The `params` argument behaves the same as [`fetch_pipes_keys()`](#fetch_pipes_ke
         from meerschaum.utils.dataframe import parse_df_datetimes
         rows = []
         return parse_df_datetimes(rows)
+    ```
+
+## `#!python get_pipe_docs()` (alternative to `get_pipe_data()`)
+
+Return the target table's data as a `list[dict]`. Implement this instead of `get_pipe_data()` when your connector produces JSON natively (e.g. document stores, REST APIs), avoiding DataFrame construction overhead.
+
+Callers that use [`Pipe.get_docs()`](https://docs.meerschaum.io/meerschaum.html#Pipe.get_docs) or `Pipe.get_data(as_docs=True)` will call `get_pipe_docs()` directly, bypassing dtype enforcement and Pandas overhead.
+
+??? example "`#!python def get_pipe_docs():`"
+    ```python
+    def get_pipe_docs(
+        self,
+        pipe: mrsm.Pipe,
+        select_columns: list[str] | None = None,
+        omit_columns: list[str] | None = None,
+        begin: datetime | int | None = None,
+        end: datetime | int | None = None,
+        params: dict[str, Any] | None = None,
+        order: str = 'asc',
+        limit: int | None = None,
+        debug: bool = False,
+        **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """
+        Return a pipe's data as a list of documents.
+
+        Parameters
+        ----------
+        pipe: mrsm.Pipe
+            The pipe with the target table from which to read.
+
+        select_columns: list[str] | None, default None
+            If provided, only select these given columns.
+
+        omit_columns: list[str] | None, default None
+            If provided, remove these columns from the selection.
+
+        begin: datetime | int | None, default None
+            The earliest `datetime` value to search from (inclusive).
+
+        end: datetime | int | None, default None
+            The latest `datetime` value to search from (exclusive).
+
+        params: dict[str, Any] | None, default None
+            Additional filters to apply to the query.
+
+        order: str, default 'asc'
+            Sort order for the `datetime` axis (`'asc'` or `'desc'`).
+
+        limit: int | None, default None
+            If provided, cap the number of rows returned.
+
+        Returns
+        -------
+        The target table's data as a list of dictionaries.
+        """
+        table_name = pipe.target
+        dt_col = pipe.columns.get("datetime", None)
+
+        ### TODO Write a query to fetch from `table_name` and return raw dicts.
+        ### Apply begin, end, params, order, and limit as in get_pipe_data().
+        rows = []
+        return rows
     ```
 
 ## `#!python get_sync_time()`

--- a/docs/zensical/reference/connectors/instance-connectors.md
+++ b/docs/zensical/reference/connectors/instance-connectors.md
@@ -27,7 +27,7 @@ To use your custom connector type as an instance connector, inherit from `Instan
     ```
 
 ??? tip "Using the `params` Filter"
-    Methods which take the `params` argument ([`get_pipe_data()`](#get_pipe_data), [`get_sync_time()`](#get_sync_time), [`get_backtrack_data()`](#get_backtrack_data)) behave similarly to the filters applied to [`fetch_pipes_keys`](#fetch_pipes_keys).
+    Methods which take the `params` argument ([`get_pipe_data()`](#get_pipe_data), [`get_sync_time()`](#get_sync_time)) behave similarly to the filters applied to [`fetch_pipes_keys`](#fetch_pipes_keys).
 
     The easiest way to support `params` is with [`meerschaum.utils.dataframe.query_df()`](https://docs.meerschaum.io/meerschaum/utils/dataframe.html#query_df):
 
@@ -578,6 +578,8 @@ The `params` argument behaves the same as [`fetch_pipes_keys()`](#fetch_pipes_ke
         rows = []
         return parse_df_datetimes(rows)
     ```
+
+<a id="get_pipe_docs"></a>
 
 ## `#!python get_pipe_docs()` (alternative to `get_pipe_data()`)
 

--- a/docs/zensical/reference/pipes/index.md
+++ b/docs/zensical/reference/pipes/index.md
@@ -140,3 +140,7 @@ Additionally, when `upsert` is `True`, a unique index is created on the designat
 You may choose to specify additional indices to be created with the `indices` dictionary (alias `indexes`). Whereas the `columns` dictionary is for specifying uniqueness, the `indices` dictionary allows you to specify multi-column indices for performance tuning. This is for extending the `columns` dictionary, so no need to restate the primary index columns.
 
 See [Indices](/reference/pipes/parameters/#indices) for more information.
+
+## Reading Data
+
+See [Reading Data](/reference/pipes/reading/) for `get_data()`, `get_docs()`, `get_doc()`, `get_value()`, and `params` filtering.

--- a/docs/zensical/reference/pipes/index.md
+++ b/docs/zensical/reference/pipes/index.md
@@ -40,6 +40,24 @@ In addition to filtering by the above keys, you can also select a custom group o
 show pipes --tags foo bar
 ```
 
+### Datetime Dtype
+
+Filter pipes by the dtype of their `datetime` index column with `--datetime-dtypes` (alias `--dtype`). Accepted values are `datetime`, `int`, and `None` (no datetime axis). Prefix with `_` to exclude:
+
+```bash
+### Only pipes with a timestamp datetime index:
+show pipes --dtype datetime
+
+### Only pipes with an integer datetime index:
+show pipes --dtype int
+
+### Only pipes without a datetime index:
+show pipes --dtype None
+
+### Exclude integer datetime pipes:
+show pipes --dtype _int
+```
+
 ### Key Negation
 
 You can select pipes which *don't* have a certain key by prefacing the key with an underscore (`'_'`).

--- a/docs/zensical/reference/pipes/reading.md
+++ b/docs/zensical/reference/pipes/reading.md
@@ -1,0 +1,109 @@
+# 📖 Reading Data
+
+Use `Pipe.get_data()` and its convenience wrappers to read rows from the instance.
+
+### `get_data()`
+
+Returns a `pd.DataFrame`. Accepts `begin`, `end`, `params`, `select_columns`, `omit_columns`, `limit`, and `order` to filter and shape the result.
+
+```python
+import meerschaum as mrsm
+
+pipe = mrsm.Pipe('demo', 'temperature', instance='sql:local')
+
+# All rows:
+df = pipe.get_data()
+
+# Time-bounded slice:
+df = pipe.get_data(begin='2024-01-01', end='2024-02-01')
+
+# Only specific columns:
+df = pipe.get_data(select_columns=['dt', 'station', 'val'])
+
+# Filtered by params:
+df = pipe.get_data(params={'station': ['KGMU', 'KATL']})
+
+# Cap rows returned:
+df = pipe.get_data(limit=100)
+```
+
+**Chunked iteration** — pass `as_chunks=True` (alias `as_iterator=True`) to get a generator of DataFrames, each covering a time-bound slice. Useful for large datasets that don't fit in memory:
+
+```python
+for chunk_df in pipe.get_data(as_chunks=True):
+    process(chunk_df)
+```
+
+### `get_docs()`
+
+Returns `List[Dict[str, Any]]` — rows as plain Python dictionaries without loading pandas. Ideal for JSON APIs, small targeted queries, or when pandas is not needed.
+
+```python
+docs = pipe.get_docs()
+# [{'dt': ..., 'station': 'KGMU', 'val': 44.1}, ...]
+
+# With filters:
+docs = pipe.get_docs(params={'station': 'KGMU'}, limit=10)
+```
+
+Combine with `as_chunks=True` to get an `Iterator[List[Dict]]` chunked by time bounds:
+
+```python
+for chunk in pipe.get_docs(as_chunks=True):
+    send_to_api(chunk)
+```
+
+### `get_doc()`
+
+Returns a single row as `Dict[str, Any]` (or `None`). Equivalent to `get_docs(limit=1)[0]`:
+
+```python
+doc = pipe.get_doc(params={'station': 'KGMU'}, order='desc')
+print(doc)
+# {'dt': datetime(...), 'station': 'KGMU', 'val': 44.1}
+```
+
+### `get_value()`
+
+Returns a single scalar value from one column (or `None`). Useful when you need exactly one cell:
+
+```python
+latest_val = pipe.get_value('val', params={'station': 'KGMU'}, order='desc')
+print(latest_val)
+# 44.1
+```
+
+### `params` Filtering and Negation
+
+All read methods accept a `params` dictionary that maps column names to filter values. Prefix any value with `_` to negate it.
+
+| Syntax | SQL equivalent |
+|---|---|
+| `{'col': 'foo'}` | `WHERE col = 'foo'` |
+| `{'col': ['foo', 'bar']}` | `WHERE col IN ('foo', 'bar')` |
+| `{'col': '_foo'}` | `WHERE col != 'foo'` |
+| `{'col': ['_foo', '_bar']}` | `WHERE col NOT IN ('foo', 'bar')` |
+| `{'col': ['foo', '_bar']}` | `WHERE col IN ('foo') AND col NOT IN ('bar')` |
+| `{'col': None}` or `{'col': 'None'}` | `WHERE col IS NULL` |
+| `{'col': '_None'}` | `WHERE col IS NOT NULL` |
+
+```python
+# Single value
+docs = pipe.get_docs(params={'station': 'KGMU'})
+
+# Include list
+df = pipe.get_data(params={'station': ['KGMU', 'KATL']})
+
+# Exclude one value
+df = pipe.get_data(params={'station': '_KGMU'})
+
+# Exclude a list
+df = pipe.get_data(params={'station': ['_KGMU', '_KATL']})
+
+# Mixed include/exclude
+df = pipe.get_data(params={'station': ['KGMU', '_KATL']})
+
+# Null / not-null
+df = pipe.get_data(params={'station': None})       # IS NULL
+df = pipe.get_data(params={'station': '_None'})    # IS NOT NULL
+```

--- a/docs/zensical/reference/plugins/writing-plugins.md
+++ b/docs/zensical/reference/plugins/writing-plugins.md
@@ -188,6 +188,8 @@ def fetch(pipe: mrsm.Pipe, **kw) -> Iterator['pd.DataFrame']:
         yield pd.read_csv(file_name)
 ```
 
+<a id="sync-plugins"></a>
+
 ### **The `#!python sync()` Function**
 
 The `#!python sync()` function makes `sync pipes` override the built-in syncing process and behaves more like an [action](/reference/plugins/types-of-plugins/#-action-plugins), returning only a `SuccessTuple` (e.g. `#!python True, "Success"`).

--- a/meerschaum/README.md
+++ b/meerschaum/README.md
@@ -17,8 +17,10 @@ Below is a brief description of the Meerschaum internal modules. For further inf
 - `connectors`  
   Connector implementations are defined here:
     - `Connector`: Base class for reading configuration details.
+    - `InstanceConnector`: Base class for instance connectors (subclass to build custom storage backends).
     - `SQLConnector`: Interact with pipes via `sqlalchemy` engines.
     - `APIConnector`: Interact with pipes via web requests.
+    - `ValkeyConnector`: Interact with pipes via a Valkey/Redis server.
     - `PluginConnector`: Wrapper for plugins' `fetch()` or `sync()` methods.
 
 - `core`  
@@ -32,11 +34,15 @@ Below is a brief description of the Meerschaum internal modules. For further inf
 
 - `utils`  
   The `utils` module is a parent for many useful tools, such as custom implementations for daemons, threads, processes, packages, typing, prompts, warnings, and more.
+    - `utils.pipes`: Pipe object utilities (`get_pipe_from_string()`, `replace_pipes_syntax()`, `flatten_pipes_dict()`, etc.)
+    - `utils.dataframe`: DataFrame manipulation and dtype utilities.
+    - `utils.sql`: SQL query building helpers for custom instance connectors.
+    - `utils.schedule`: Scheduling utilities (`parse_schedule()`, `schedule_function()`).
 
 
 ### License
 
-Copyright 2021 Bennett Meares
+Copyright 2020-2026 Bennett Meares
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/meerschaum/__init__.py
+++ b/meerschaum/__init__.py
@@ -3,7 +3,7 @@
 # vim:fenc=utf-8
 
 """
-Copyright 2025 Bennett Meares
+Copyright 2020–2026 Bennett Meares
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/meerschaum/__main__.py
+++ b/meerschaum/__main__.py
@@ -75,7 +75,11 @@ def _exit(return_code: int = 0, old_cwd: str = None) -> None:
 def _close_pools():
     """Close multiprocessing pools before exiting."""
     ### Final step: close global pools.
-    from meerschaum.utils.pool import get_pools
+    try:
+        from meerschaum.utils.pool import get_pools
+    except (ImportError, ModuleNotFoundError):
+        return
+
     for pool in get_pools().values():
         try:
             pool.close()

--- a/meerschaum/__main__.py
+++ b/meerschaum/__main__.py
@@ -4,7 +4,7 @@
 # vim:fenc=utf-8
 
 """
-Copyright 2024 Bennett Meares
+Copyright 2020–2026 Bennett Meares
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -288,6 +288,10 @@ groups['pipes'].add_argument(
 groups['pipes'].add_argument(
     '-t', '--tags', nargs='+', help="Only include pipes with these tags.",
 )
+groups['pipes'].add_argument(
+    '--datetime-dtypes', '--datetime-dtype', '--dtype', nargs='+',
+    help="Only select pipes with the corresponding datetime dtype (`datetime` or `int`)."
+)
 
 
 ### Sync options

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -383,6 +383,14 @@ groups['sync'].add_argument(
     )
 )
 groups['sync'].add_argument(
+    '--sync-data', choices=['nothing', 'backtrack', 'all', 'filter'],
+    help=(
+        "When copying pipes, specify what data to sync into destination pipes. "
+        "'filter' uses --begin, --end, and --params to restrict the range. "
+        "Defaults to 'nothing' (copy pipe definitions only)."
+    ),
+)
+groups['sync'].add_argument(
     '--cache', action='store_true',
     help=(
         "Sync pipes' metadata to disk."

--- a/meerschaum/_internal/arguments/_parser.py
+++ b/meerschaum/_internal/arguments/_parser.py
@@ -289,8 +289,13 @@ groups['pipes'].add_argument(
     '-t', '--tags', nargs='+', help="Only include pipes with these tags.",
 )
 groups['pipes'].add_argument(
-    '--datetime-dtypes', '--datetime-dtype', '--dtype', nargs='+',
-    help="Only select pipes with the corresponding datetime dtype (`datetime` or `int`)."
+    '--datetime-dtypes', '--datetime-dtype', '--dtype', '--dtypes',
+    nargs='+',
+    choices=['datetime', 'int', 'None', '_datetime', '_int', '_None'],
+    help=(
+        "Only select pipes with the corresponding datetime dtypes (`datetime`, `int`, or `None`)."
+        "\nMay be negated with `_`."
+    )
 )
 
 

--- a/meerschaum/_internal/docs/index.py
+++ b/meerschaum/_internal/docs/index.py
@@ -34,6 +34,7 @@ For your convenience, the following classes and functions may be imported from t
 
 <ul>
 <li><code>meerschaum.Connector</code></li>
+<li><code>meerschaum.InstanceConnector</code></li>
 <li><code>meerschaum.Pipe</code></li>
 <li><code>meerschaum.Plugin</code></li>
 <li><code>meerschaum.Job</code></li>
@@ -177,6 +178,21 @@ pipes = mrsm.get_pipes(
 )
 print(pipes)
 # [Pipe('foo:bar', 'demo', instance='sql:temp')]
+```
+
+Filter by the dtype of the `datetime` index column with `datetime_dtypes`. Accepted values are `'datetime'`, `'int'`, and `'None'`; prefix with `'_'` to negate:
+
+```python
+import meerschaum as mrsm
+
+### Only pipes with a timestamp datetime index:
+timestamp_pipes = mrsm.get_pipes(datetime_dtypes=['datetime'], as_list=True)
+
+### Only pipes with an integer datetime index:
+int_pipes = mrsm.get_pipes(datetime_dtypes=['int'], as_list=True)
+
+### Exclude pipes without a datetime index:
+datetime_pipes = mrsm.get_pipes(datetime_dtypes=['_None'], as_list=True)
 ```
 </details>
 
@@ -423,6 +439,25 @@ def init_dash(dash_app):
   - `meerschaum.config.write_config()`
   - `meerschaum.config.write_plugin_config()`
 
+  <details>
+    <summary>
+    <code>meerschaum.config.environment</code><br>
+    Patch configuration and connectors from environment variables.<br>
+    </summary>
+    <p></p>
+    <ul>
+      <li><code>meerschaum.config.environment.apply_environment_patches()</code></li>
+      <li><code>meerschaum.config.environment.apply_environment_config()</code></li>
+      <li><code>meerschaum.config.environment.apply_environment_uris()</code></li>
+      <li><code>meerschaum.config.environment.apply_connector_uri()</code></li>
+      <li><code>meerschaum.config.environment.get_connector_env_regex()</code></li>
+      <li><code>meerschaum.config.environment.get_connector_env_vars()</code></li>
+      <li><code>meerschaum.config.environment.get_env_vars()</code></li>
+      <li><code>meerschaum.config.environment.get_daemon_env_vars()</code></li>
+      <li><code>meerschaum.config.environment.replace_env()</code></li>
+    </ul>
+  </details>
+
 </details>
 
 <details>
@@ -461,6 +496,7 @@ def init_dash(dash_app):
   - `meerschaum.jobs.check_restart_jobs()`
   - `meerschaum.jobs.start_check_jobs_thread()`
   - `meerschaum.jobs.stop_check_jobs_thread()`
+  - `meerschaum.jobs.get_executor_keys_from_context()`
 
 </details>
 
@@ -543,6 +579,7 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.dataframe.get_bool_cols()</code></li>
       <li><code>meerschaum.utils.dataframe.get_bytes_cols()</code></li>
       <li><code>meerschaum.utils.dataframe.get_datetime_bound_from_df()</code></li>
+      <li><code>meerschaum.utils.dataframe.get_date_cols()</code></li>
       <li><code>meerschaum.utils.dataframe.get_datetime_cols()</code></li>
       <li><code>meerschaum.utils.dataframe.get_datetime_cols_types()</code></li>
       <li><code>meerschaum.utils.dataframe.get_first_valid_dask_partition()</code></li>
@@ -557,6 +594,8 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.dataframe.parse_df_datetimes()</code></li>
       <li><code>meerschaum.utils.dataframe.query_df()</code></li>
       <li><code>meerschaum.utils.dataframe.to_json()</code></li>
+      <li><code>meerschaum.utils.dataframe.to_simple_lines()</code></li>
+      <li><code>meerschaum.utils.dataframe.parse_simple_lines()</code></li>
     </ul>
   </details>
   </ul>
@@ -579,6 +618,7 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.dtypes.deserialize_bytes_string()</code></li>
       <li><code>meerschaum.utils.dtypes.deserialize_geometry()</code></li>
       <li><code>meerschaum.utils.dtypes.encode_bytes_for_bytea()</code></li>
+      <li><code>meerschaum.utils.dtypes.geometry_is_gpkg()</code></li>
       <li><code>meerschaum.utils.dtypes.geometry_is_wkt()</code></li>
       <li><code>meerschaum.utils.dtypes.get_current_timestamp()</code></li>
       <li><code>meerschaum.utils.dtypes.get_geometry_type_srid()</code></li>
@@ -596,7 +636,6 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.dtypes.to_datetime()</code></li>
       <li><code>meerschaum.utils.dtypes.to_pandas_dtype()</code></li>
       <li><code>meerschaum.utils.dtypes.value_is_null()</code></li>
-      <li><code>meerschaum.utils.dtypes.get_current_timestamp()</code></li>
       <li><code>meerschaum.utils.dtypes.get_next_precision_unit()</code></li>
       <li><code>meerschaum.utils.dtypes.round_time()</code></li>
     </ul>
@@ -653,6 +692,7 @@ def init_dash(dash_app):
     <ul>
       <li><code>meerschaum.utils.misc.items_str()</code></li>
       <li><code>meerschaum.utils.misc.is_int()</code></li>
+      <li><code>meerschaum.utils.misc.is_uuid()</code></li>
       <li><code>meerschaum.utils.misc.interval_str()</code></li>
       <li><code>meerschaum.utils.misc.filter_keywords()</code></li>
       <li><code>meerschaum.utils.misc.generate_password()</code></li>
@@ -732,6 +772,24 @@ def init_dash(dash_app):
   <ul>
   <details>
     <summary>
+    <code>meerschaum.utils.pipes</code><br>
+    Utilities for working with pipe objects.<br>
+    </summary>
+    <p></p>
+    <ul>
+      <li><code>meerschaum.utils.pipes.get_pipe_from_string()</code></li>
+      <li><code>meerschaum.utils.pipes.replace_pipes_syntax()</code></li>
+      <li><code>meerschaum.utils.pipes.replace_pipes_in_dict()</code></li>
+      <li><code>meerschaum.utils.pipes.is_pipe_registered()</code></li>
+      <li><code>meerschaum.utils.pipes.pipes_dict_from_list()</code></li>
+      <li><code>meerschaum.utils.pipes.flatten_pipes_dict()</code></li>
+    </ul>
+  </details>
+  </ul>
+
+  <ul>
+  <details>
+    <summary>
     <code>meerschaum.utils.prompt</code><br>
     Read input from the user.
     <br>
@@ -774,6 +832,7 @@ def init_dash(dash_app):
     <ul>
       <li><code>meerschaum.utils.sql.build_where()</code></li>
       <li><code>meerschaum.utils.sql.clean()</code></li>
+      <li><code>meerschaum.utils.sql.get_sqlalchemy_table()</code></li>
       <li><code>meerschaum.utils.sql.dateadd_str()</code></li>
       <li><code>meerschaum.utils.sql.test_connection()</code></li>
       <li><code>meerschaum.utils.sql.get_distinct_col_count()</code></li>
@@ -783,6 +842,7 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.sql.truncate_item_name()</code></li>
       <li><code>meerschaum.utils.sql.table_exists()</code></li>
       <li><code>meerschaum.utils.sql.get_table_cols_types()</code></li>
+      <li><code>meerschaum.utils.sql.get_table_cols_indices()</code></li>
       <li><code>meerschaum.utils.sql.get_update_queries()</code></li>
       <li><code>meerschaum.utils.sql.get_null_replacement()</code></li>
       <li><code>meerschaum.utils.sql.get_db_version()</code></li>
@@ -792,6 +852,8 @@ def init_dash(dash_app):
       <li><code>meerschaum.utils.sql.format_cte_subquery()</code></li>
       <li><code>meerschaum.utils.sql.session_execute()</code></li>
       <li><code>meerschaum.utils.sql.get_reset_autoincrement_queries()</code></li>
+      <li><code>meerschaum.utils.sql.get_postgis_geo_columns_types()</code></li>
+      <li><code>meerschaum.utils.sql.get_create_schema_if_not_exists_queries()</code></li>
     </ul>
   </details>
   </ul>

--- a/meerschaum/_internal/shell/ShellCompleter.py
+++ b/meerschaum/_internal/shell/ShellCompleter.py
@@ -13,8 +13,10 @@ from meerschaum._internal.arguments import parse_line
 from meerschaum.utils.packages import attempt_import, ensure_readline
 
 prompt_toolkit_completion = attempt_import('prompt_toolkit.completion', lazy=False, install=True)
+prompt_toolkit_formatted_text = attempt_import('prompt_toolkit.formatted_text', lazy=False, install=True)
 Completer = prompt_toolkit_completion.Completer
 Completion = prompt_toolkit_completion.Completion
+FormattedText = prompt_toolkit_formatted_text.FormattedText
 
 
 class ShellCompleter(Completer):
@@ -39,6 +41,10 @@ class ShellCompleter(Completer):
         if not parsed_text:
             return
 
+        # Typed text after the last `+` — used for start_position and highlighting.
+        typed_text = last_action_line.lstrip()
+        typed_len = len(typed_text)
+
         ### Index is the rank order (0 is closest match).
         ### Break when no results are returned.
         for i, a in enumerate(shell_actions):
@@ -51,7 +57,11 @@ class ShellCompleter(Completer):
                 poss = False
             if not poss:
                 break
-            yield Completion(poss, start_position=(-1 * len(poss)))
+            display = FormattedText([
+                ('fg:ansiblue bold', poss[:typed_len]),
+                ('', poss[typed_len:]),
+            ])
+            yield Completion(poss, start_position=-typed_len, display=display)
             yielded.append(poss)
 
         line = document.text
@@ -87,9 +97,17 @@ class ShellCompleter(Completer):
             )
 
         if possibilities:
+            last_word = document.text.split(' ')[-1]
+            last_word_len = len(last_word)
             for suggestion in possibilities:
+                display = FormattedText([
+                    ('fg:ansiblue bold', suggestion[:last_word_len]),
+                    ('', suggestion[last_word_len:]),
+                ])
                 yield Completion(
-                    suggestion, start_position=(-1 * len(document.text.split(' ')[-1]))
+                    suggestion,
+                    start_position=-last_word_len,
+                    display=display,
                 )
             return
 

--- a/meerschaum/actions/bootstrap.py
+++ b/meerschaum/actions/bootstrap.py
@@ -184,7 +184,7 @@ def _bootstrap_pipes(
     )
     pipes = []
     for p in _pipes:
-        if p.get_id(debug=debug) is not None and not force:
+        if p.id is not None and not force:
             try:
                 if not yes_no(
                     f"{p} already exists.\n\n    Delete {p}?\n    Data will be lost!",

--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -60,9 +60,11 @@ def _complete_copy(
 
 
 def _copy_pipes(
+    action: Optional[List[str]] = None,
     yes: bool = False,
     noask: bool = False,
     force: bool = False,
+    sync_data: Optional[str] = None,
     debug: bool = False,
     **kw
 ) -> SuccessTuple:
@@ -77,10 +79,19 @@ def _copy_pipes(
     from meerschaum.utils.formatting._shell import clear_screen
     from meerschaum.utils.formatting._pipes import pprint_pipes
     from meerschaum.utils.pipes import pipes_dict_from_list
+
+    if action is None:
+        action = []
+
+    destination_instance = action[0] if action else None
     pipes = get_pipes(as_list=True, cache=False, debug=debug, **kw)
     change_instance_only = False
     instance_keys = None
-    if len(pipes) > 1:
+
+    if destination_instance:
+        instance_keys = destination_instance
+        change_instance_only = True
+    elif len(pipes) > 1:
         clear_screen(debug=debug)
         pprint_pipes(pipes_dict_from_list(pipes))
         if force or yes_no(
@@ -97,6 +108,13 @@ def _copy_pipes(
     batch_sync_choice = None
     batch_filter_kw = {}
     overwrite_existing = None
+
+    if sync_data == 'filter' or (sync_data is None and (kw.get('begin') or kw.get('end') or kw.get('params'))):
+        sync_data = 'filter'
+        for key in ('begin', 'end', 'params'):
+            if kw.get(key) is not None:
+                batch_filter_kw[key] = kw[key]
+
     if change_instance_only:
         prospective_pipes = [
             Pipe(p.connector_keys, p.metric_key, p.location_key, instance=instance_keys, cache=False)
@@ -106,7 +124,10 @@ def _copy_pipes(
         new_only_pipes = [p for p in prospective_pipes if p.id is None]
         all_exist = not new_only_pipes
 
-        if existing_new_pipes and not force:
+        if destination_instance:
+            overwrite_existing = 'overwrite' if force else 'skip'
+            batch_sync_choice = sync_data or 'nothing'
+        elif existing_new_pipes and not force:
             clear_screen(debug=debug)
             pprint_pipes(pipes_dict_from_list(existing_new_pipes))
             _n = len(existing_new_pipes)

--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -71,23 +71,45 @@ def _copy_pipes(
     """
     from meerschaum import get_pipes, Pipe
     from meerschaum.connectors import instance_types
-    from meerschaum.utils.prompt import prompt, yes_no, get_connectors_completer
-    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.prompt import prompt, yes_no, get_connectors_completer, choose
+    from meerschaum.utils.warnings import warn, info
     from meerschaum.utils.formatting import print_tuple
     from meerschaum.utils.formatting._shell import clear_screen
-    pipes = get_pipes(as_list=True, **kw)
+    from meerschaum.utils.formatting._pipes import pprint_pipes
+    from meerschaum.utils.pipes import pipes_dict_from_list
+    pipes = get_pipes(as_list=True, cache=False, debug=debug, **kw)
+    change_instance_only = False
+    instance_keys = None
+    if len(pipes) > 1:
+        clear_screen(debug=debug)
+        pprint_pipes(pipes_dict_from_list(pipes))
+        if force or yes_no(
+            f"Change only the instance keys for copies of the above {len(pipes)} pipes?",
+            noask=noask,
+            yes=yes,
+            default='y',
+        ):
+            instance_keys = prompt(
+                "Instance keys for the new pipes:",
+                completer=get_connectors_completer(*instance_types),
+            )
+            change_instance_only = True
     successes = 0
-    for pipe in pipes:
+    for i, pipe in enumerate(pipes):
+        info(f"Copying {pipe} ({i+1} / {len(pipes)})...")
         ck = prompt(
             f"Connector keys for copy of {pipe}:",
             default=pipe.connector_keys,
             completer=get_connectors_completer(),
+        ) if not change_instance_only else pipe.connector_keys
+        mk = (
+            prompt(f"Metric key for copy of {pipe}:", default=pipe.metric_key)
+            if not change_instance_only else pipe.metric_key
         )
-        mk = prompt(f"Metric key for copy of {pipe}:", default=pipe.metric_key)
         lk = prompt(
             f"Location key for copy of {pipe} ('None' to omit):",
             default=str(pipe.location_key),
-        )
+        ) if not change_instance_only else str(pipe.location_key)
         if lk in ('', 'None', '[None]'):
             lk = None
 
@@ -95,46 +117,73 @@ def _copy_pipes(
             f"Meerschaum instance for copy of {pipe}:",
             default=pipe.instance_keys,
             completer=get_connectors_completer(*instance_types),
-        )
+        ) if not change_instance_only else instance_keys
         new_pipe = Pipe(
             ck, mk, lk,
             instance=instance_keys,
             parameters=pipe.get_parameters(apply_symlinks=False),
+            cache=False,
         )
 
-        if new_pipe.get_id(debug=debug) is not None:
-            warn(f"{new_pipe} already exists. Skipping...", stack=False)
-            continue
-        _register_success_tuple = new_pipe.register(debug=debug)
-        if not _register_success_tuple[0]:
-            warn(f"Failed to register new {new_pipe}.", stack=False)
-            continue
+        if new_pipe.id is not None:
+            warn(f"{new_pipe} already exists.", stack=False)
+            if force or yes_no("Continue copying?", yes=yes, noask=noask, default='n'):
+                edit_success, edit_msg = new_pipe.edit(debug=debug)
+                if not edit_success:
+                    warn(f"Failed to copy attributes to {new_pipe}:\n{edit_msg}", stack=False)
+                    continue
+            else:
+                continue
+        else:
+            register_success, register_msg = new_pipe.register(debug=debug)
+            if not register_success:
+                warn(f"Failed to register new {new_pipe}:\n{register_msg}", stack=False)
+                continue
 
         clear_screen(debug=debug)
         successes += 1
         print_tuple(
-            (True, f"Successfully copied attributes of {pipe} " + f" into {new_pipe}.")
+            (True, f"Successfully copied attributes of {pipe}" + f" into {new_pipe}.")
         )
-        if (
-            force or yes_no(
-                (
-                    f"Do you want to copy data from {pipe} into {new_pipe}?\n\n"
-                    + "If you specified `--begin`, `--end` or `--params`, data will be filtered."
-                ),
-                    noask=noask,
-                    yes=yes,
-                    default='n',
-                )
-        ):
-            new_pipe.sync(
-                pipe.get_data(
-                    debug=debug,
-                    as_iterator=True,
-                    **kw
-                ),
-                debug=debug,
-                **kw
+        if pipe.exists(debug=debug):
+            sync_choice = choose(
+                f"How you want to sync data into {new_pipe}?",
+                [
+                    ('nothing', 'Do not copy data (attributes only).'),
+                    ('backtrack', 'Seed with recent backtrack data.'),
+                    ('all', 'Sync all data.'),
+                    ('filter', 'Sync data fetched with filters (begin, end, params).'),
+                ],
+                default='nothing',
+                noask=noask,
+                as_indices=True,
+                numeric=True,
             )
+
+            if sync_choice != 'nothing':
+                filter_kw = {}
+                if sync_choice == 'filter':
+                    from meerschaum._internal.arguments._parse_arguments import parse_line
+                    filter_line = prompt(
+                        "Enter filter flags"
+                        " (e.g. --begin 2024-01-01 --end 2024-12-31 --params '{\"foo\": \"bar\"}'):",
+                        noask=noask,
+                    )
+                    parsed = parse_line(filter_line)
+                    for key in ('begin', 'end', 'params'):
+                        if key in parsed:
+                            filter_kw[key] = parsed[key]
+
+                sync_data = (
+                    pipe.get_backtrack_data(debug=debug)
+                    if sync_choice == 'backtrack'
+                    else pipe.get_data(debug=debug, as_iterator=True, **filter_kw)
+                )
+                sync_success, sync_msg = new_pipe.sync(sync_data, debug=debug, **kw)
+                print_tuple((sync_success, sync_msg))
+                if not sync_success:
+                    warn(f"Failed to copy data from {pipe} to {new_pipe}.", stack=False)
+                    successes -= 1
 
     msg = (
         "No pipes were copied." if successes == 0

--- a/meerschaum/actions/copy.py
+++ b/meerschaum/actions/copy.py
@@ -94,7 +94,91 @@ def _copy_pipes(
                 completer=get_connectors_completer(*instance_types),
             )
             change_instance_only = True
+    batch_sync_choice = None
+    batch_filter_kw = {}
+    overwrite_existing = None
+    if change_instance_only:
+        prospective_pipes = [
+            Pipe(p.connector_keys, p.metric_key, p.location_key, instance=instance_keys, cache=False)
+            for p in pipes
+        ]
+        existing_new_pipes = [p for p in prospective_pipes if p.id is not None]
+        new_only_pipes = [p for p in prospective_pipes if p.id is None]
+        all_exist = not new_only_pipes
+
+        if existing_new_pipes and not force:
+            clear_screen(debug=debug)
+            pprint_pipes(pipes_dict_from_list(existing_new_pipes))
+            _n = len(existing_new_pipes)
+            _total = len(pipes)
+            _pipe_word = 'pipe' + ('s' if _n != 1 else '')
+
+            if all_exist:
+                overwrite_existing = choose(
+                    f"All {_total} selected {_pipe_word} already exist on {instance_keys}."
+                    "\n    What should be copied?",
+                    [
+                        ('skip', "Nothing — skip all pipes."),
+                        ('data_only', "Data only (keep existing attributes)."),
+                        ('attrs_only', "Attributes only (no data sync)."),
+                        ('overwrite', "Attributes and data."),
+                    ],
+                    default='skip',
+                    noask=noask,
+                    as_indices=True,
+                    numeric=True,
+                )
+                if overwrite_existing in ('skip', 'attrs_only'):
+                    batch_sync_choice = 'nothing'
+            else:
+                overwrite_existing = choose(
+                    f"{_n} of the {_total} selected {_pipe_word} already exist on {instance_keys}."
+                    "\n    How should conflicts be resolved?",
+                    [
+                        ('skip', "Skip existing pipes — only register and sync the new ones."),
+                        ('data_only', "Copy data into existing pipes without updating their attributes."),
+                        ('overwrite', "Copy attributes and data into existing pipes."),
+                    ],
+                    default='skip',
+                    noask=noask,
+                    as_indices=True,
+                    numeric=True,
+                )
+        else:
+            overwrite_existing = 'overwrite'
+
+        if batch_sync_choice is None:
+            _data_committed = overwrite_existing in ('data_only', 'overwrite')
+            _data_options = [
+                ('backtrack', 'Recent data only (within the configured backtrack window).'),
+                ('all', 'All available data from the source pipes.'),
+                ('filter', 'Data matching specific filters (begin, end, params).'),
+            ]
+            if not _data_committed:
+                _data_options.insert(0, ('nothing', 'No data.'))
+            batch_sync_choice = choose(
+                "What data should be copied?",
+                _data_options,
+                default='nothing' if not _data_committed else 'backtrack',
+                noask=noask,
+                as_indices=True,
+                numeric=True,
+            )
+            if batch_sync_choice == 'filter':
+                from meerschaum._internal.arguments._parse_arguments import parse_line
+                filter_line = prompt(
+                    "Enter filter flags"
+                    " (e.g. --begin 2024-01-01 --end 2024-12-31 --params '{\"foo\": \"bar\"}'):",
+                    noask=noask,
+                )
+                parsed = parse_line(filter_line)
+                for key in ('begin', 'end', 'params'):
+                    if key in parsed:
+                        batch_filter_kw[key] = parsed[key]
+
+    import time
     successes = 0
+    sync_stats = []  # (new_pipe, elapsed_seconds, stats_dict, success)
     for i, pipe in enumerate(pipes):
         info(f"Copying {pipe} ({i+1} / {len(pipes)})...")
         ck = prompt(
@@ -126,41 +210,80 @@ def _copy_pipes(
         )
 
         if new_pipe.id is not None:
-            warn(f"{new_pipe} already exists.", stack=False)
-            if force or yes_no("Continue copying?", yes=yes, noask=noask, default='n'):
+            if overwrite_existing is None:
+                warn(f"{new_pipe} already exists on '{instance_keys}'.", stack=False)
+            if overwrite_existing is not None:
+                _existing_action = overwrite_existing
+            else:
+                _existing_action = choose(
+                    f"How would you like to handle {new_pipe}?",
+                    [
+                        (
+                            'skip',
+                            "Skip this pipe entirely — do not update its attributes or copy any data into it.",
+                        ),
+                        (
+                            'data_only',
+                            (
+                                "Copy data into this pipe without changing its stored"
+                                " attributes (parameters, tags, target, etc.)."
+                            ),
+                        ),
+                        (
+                            'overwrite',
+                            (
+                                "Update this pipe — overwrite its stored attributes"
+                                " (parameters, tags, target, etc.) with those from the source,"
+                                " and copy data."
+                            ),
+                        ),
+                    ],
+                    default='skip',
+                    noask=noask,
+                    as_indices=True,
+                    numeric=True,
+                )
+                if force:
+                    _existing_action = 'overwrite'
+            if _existing_action == 'skip':
+                info(f"Skipping {new_pipe} — leaving destination pipe unchanged.")
+                continue
+            if _existing_action in ('overwrite', 'attrs_only'):
+                info(f"Updating attributes of existing {new_pipe} from {pipe}...")
                 edit_success, edit_msg = new_pipe.edit(debug=debug)
                 if not edit_success:
                     warn(f"Failed to copy attributes to {new_pipe}:\n{edit_msg}", stack=False)
                     continue
             else:
-                continue
+                info(f"Keeping existing attributes of {new_pipe} — will copy data only.")
         else:
             register_success, register_msg = new_pipe.register(debug=debug)
             if not register_success:
                 warn(f"Failed to register new {new_pipe}:\n{register_msg}", stack=False)
                 continue
 
-        clear_screen(debug=debug)
         successes += 1
         print_tuple(
-            (True, f"Successfully copied attributes of {pipe}" + f" into {new_pipe}.")
+            (True, f"Successfully copied {pipe}" + f" to {new_pipe}.")
         )
         if pipe.exists(debug=debug):
-            sync_choice = choose(
-                f"How you want to sync data into {new_pipe}?",
-                [
-                    ('nothing', 'Do not copy data (attributes only).'),
-                    ('backtrack', 'Seed with recent backtrack data.'),
-                    ('all', 'Sync all data.'),
-                    ('filter', 'Sync data fetched with filters (begin, end, params).'),
-                ],
-                default='nothing',
-                noask=noask,
-                as_indices=True,
-                numeric=True,
-            )
-
-            if sync_choice != 'nothing':
+            if batch_sync_choice is not None:
+                sync_choice = batch_sync_choice
+                filter_kw = batch_filter_kw
+            else:
+                sync_choice = choose(
+                    "What data should be copied?",
+                    [
+                        ('nothing', 'No data.'),
+                        ('backtrack', 'Recent data only (within the configured backtrack window).'),
+                        ('all', 'All available data from the source pipe.'),
+                        ('filter', 'Data matching specific filters (begin, end, params).'),
+                    ],
+                    default='nothing',
+                    noask=noask,
+                    as_indices=True,
+                    numeric=True,
+                )
                 filter_kw = {}
                 if sync_choice == 'filter':
                     from meerschaum._internal.arguments._parse_arguments import parse_line
@@ -174,16 +297,94 @@ def _copy_pipes(
                         if key in parsed:
                             filter_kw[key] = parsed[key]
 
+            if sync_choice != 'nothing':
+                info(f"Fetching data from {pipe}...")
+                _sync_start = time.monotonic()
                 sync_data = (
                     pipe.get_backtrack_data(debug=debug)
                     if sync_choice == 'backtrack'
                     else pipe.get_data(debug=debug, as_iterator=True, **filter_kw)
                 )
+                info(f"Syncing into {new_pipe}...")
                 sync_success, sync_msg = new_pipe.sync(sync_data, debug=debug, **kw)
+                _sync_elapsed = time.monotonic() - _sync_start
                 print_tuple((sync_success, sync_msg))
+                from meerschaum.utils.formatting._pipes import extract_stats_from_message
+                sync_stats.append((
+                    new_pipe,
+                    _sync_elapsed,
+                    extract_stats_from_message(sync_msg),
+                    sync_success,
+                ))
                 if not sync_success:
                     warn(f"Failed to copy data from {pipe} to {new_pipe}.", stack=False)
                     successes -= 1
+
+    if sync_stats:
+        from meerschaum.utils.packages import attempt_import, import_rich
+        from meerschaum.utils.formatting import get_console, ANSI, UNICODE
+        import_rich()
+        rich_table = attempt_import('rich.table')
+        rich_text = attempt_import('rich.text')
+        rich_box = attempt_import('rich.box')
+        Table = rich_table.Table
+        Text = rich_text.Text
+
+        def _fmt_dur(s: float) -> str:
+            if s < 60:
+                return f"{s:.1f}s"
+            m, sec = divmod(int(s), 60)
+            if m < 60:
+                return f"{m}m{sec:02d}s"
+            h, m = divmod(m, 60)
+            return f"{h}h{m:02d}m{sec:02d}s"
+
+        total_inserted = sum(r[2].get('inserted', 0) for r in sync_stats)
+        total_updated = sum(r[2].get('updated', 0) for r in sync_stats)
+        total_upserted = sum(r[2].get('upserted', 0) for r in sync_stats)
+        total_elapsed = sum(r[1] for r in sync_stats)
+
+        _style = lambda s: (s if ANSI else '')
+        table = Table(
+            box=(rich_box.MINIMAL if UNICODE else rich_box.ASCII),
+            show_footer=True,
+            title=Text("Copy Summary", style=_style("bold")),
+        )
+        table.add_column(
+            "Pipe",
+            footer=Text("Total", style=_style("bold")),
+            no_wrap=True,
+        )
+        table.add_column(
+            "Inserted",
+            footer=Text(f"{total_inserted:,}", style=_style("bold")),
+            justify="right",
+        )
+        table.add_column(
+            "Updated",
+            footer=Text(f"{total_updated:,}", style=_style("bold")),
+            justify="right",
+        )
+        table.add_column(
+            "Upserted",
+            footer=Text(f"{total_upserted:,}", style=_style("bold")),
+            justify="right",
+        )
+        table.add_column(
+            "Duration",
+            footer=Text(_fmt_dur(total_elapsed), style=_style("bold")),
+            justify="right",
+        )
+        for new_pipe, elapsed, stats, success in sync_stats:
+            _row_style = _style("" if success else "red")
+            table.add_row(
+                Text(str(new_pipe), style=_row_style),
+                Text(f"{stats.get('inserted', 0):,}", style=_row_style),
+                Text(f"{stats.get('updated', 0):,}", style=_row_style),
+                Text(f"{stats.get('upserted', 0):,}", style=_row_style),
+                Text(_fmt_dur(elapsed), style=_row_style),
+            )
+        get_console().print(table)
 
     msg = (
         "No pipes were copied." if successes == 0

--- a/meerschaum/api/dash/callbacks/dashboard.py
+++ b/meerschaum/api/dash/callbacks/dashboard.py
@@ -469,7 +469,7 @@ def update_keys_options(
     try:
         _all_keys = fetch_pipes_keys('registered', get_web_connector(ctx.states))
         if isinstance(_all_keys, dict):
-            _all_keys = sorted(list(_all_keys.values()))
+            _all_keys = list(_all_keys.values())
         _keys = fetch_pipes_keys(
             'registered',
             get_web_connector(ctx.states),
@@ -479,7 +479,7 @@ def update_keys_options(
             tags=tags,
         )
         if isinstance(_keys, dict):
-            _keys = sorted(list(_keys.values()))
+            _keys = list(_keys.values())
         _tags_pipes = mrsm.get_pipes(
             connector_keys=connector_keys,
             metric_keys=metric_keys,

--- a/meerschaum/api/dash/callbacks/dashboard.py
+++ b/meerschaum/api/dash/callbacks/dashboard.py
@@ -468,6 +468,8 @@ def update_keys_options(
 
     try:
         _all_keys = fetch_pipes_keys('registered', get_web_connector(ctx.states))
+        if isinstance(_all_keys, dict):
+            _all_keys = sorted(list(_all_keys.values()))
         _keys = fetch_pipes_keys(
             'registered',
             get_web_connector(ctx.states),
@@ -476,6 +478,8 @@ def update_keys_options(
             location_keys=location_keys,
             tags=tags,
         )
+        if isinstance(_keys, dict):
+            _keys = sorted(list(_keys.values()))
         _tags_pipes = mrsm.get_pipes(
             connector_keys=connector_keys,
             metric_keys=metric_keys,
@@ -493,8 +497,11 @@ def update_keys_options(
             ).union(tags or [])
         ) if _tags_alone else []
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         instance_alerts += [alert_from_success_tuple((False, str(e)))]
         _all_keys, _all_tags, _keys = [], [], []
+        _tags_pipes = {}
 
     connectors_options = sorted(
         list(

--- a/meerschaum/api/dash/pipes.py
+++ b/meerschaum/api/dash/pipes.py
@@ -947,6 +947,8 @@ def build_pipes_dropdown_keys_row(
     mk_alone = metric_keys and not any([str(x) for x in (connector_keys + tags + location_keys)])
     lk_alone = location_keys and not any([str(x) for x in (connector_keys + metric_keys + tags)])
     all_keys = fetch_pipes_keys('registered', instance_connector)
+    if isinstance(all_keys, dict):
+        all_keys = list(all_keys.values())
 
     ck_options_source = (
         {keys_tuple[0] for keys_tuple in all_keys}

--- a/meerschaum/api/models/_pipes.py
+++ b/meerschaum/api/models/_pipes.py
@@ -56,6 +56,7 @@ class PipeModel(BasePipeModel):
 class FetchPipesKeysResponseModel(
     RootModel[
         Union[
+            Dict[str, List[Any]],
             List[Tuple[ConnectorKeysModel, MetricKeyModel, LocationKeyModel]],
             List[Tuple[ConnectorKeysModel, MetricKeyModel, LocationKeyModel, Dict[str, Any]]],
             List[Tuple[ConnectorKeysModel, MetricKeyModel, LocationKeyModel, List[str]]],
@@ -63,7 +64,7 @@ class FetchPipesKeysResponseModel(
     ]
 ):
     """
-    A list of tuples containing connector, metric, and location keys.
+    Pipes' keys as a list of tuples or a dict mapping pipe IDs (as strings) to key lists.
     """
     model_config = ConfigDict(
         json_schema_extra={

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -798,6 +798,25 @@ def clear_pipe(
     return results
 
 
+@app.delete(
+    pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/cache',
+    tags=['Pipes: Data'],
+    response_model=SuccessTupleResponseModel,
+)
+def delete_pipe_cache(
+    connector_keys: str,
+    metric_key: str,
+    location_key: str,
+    instance_keys: Optional[str] = None,
+    curr_user = fastapi.Security(ScopedAuth(['pipes:read'])),
+) -> mrsm.SuccessTuple:
+    """
+    Invalidate the server-side cache for a pipe (e.g. column types after a schema change).
+    """
+    pipe = get_pipe(connector_keys, metric_key, location_key, instance_keys)
+    return pipe._invalidate_cache(hard=True, debug=debug)
+
+
 @app.get(
     pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/csv',
     tags=['Pipes: Data'],

--- a/meerschaum/api/routes/_pipes.py
+++ b/meerschaum/api/routes/_pipes.py
@@ -176,10 +176,13 @@ async def fetch_pipes_keys(
     instance_keys: Optional[str] = None,
     tags: str = "[]",
     params: str = "{}",
+    as_dict: bool = False,
     curr_user = fastapi.Security(ScopedAuth(['pipes:read'])),
 ) -> FetchPipesKeysResponseModel:
     """
-    Get a list of tuples of all registered pipes' keys.
+    Get registered pipes' keys.
+    When `as_dict` is `True`, return a dictionary mapping pipe IDs (as strings) to key lists.
+    Otherwise return a list of 3-tuples for backward compatibility.
     """
     keys = get_api_connector(instance_keys).fetch_pipes_keys(
         connector_keys=json.loads(connector_keys),
@@ -188,10 +191,14 @@ async def fetch_pipes_keys(
         tags=json.loads(tags),
         params=json.loads(params),
     )
-    return [
-        (keys_tuple[0], keys_tuple[1], keys_tuple[2])
-        for keys_tuple in keys
-    ]
+    if isinstance(keys, dict):
+        if as_dict:
+            return {str(k): list(v) for k, v in keys.items()}
+        return [list(v[:3]) for v in keys.values()]
+    keys_list = list(keys)
+    if as_dict:
+        return {str(i): list(t) for i, t in enumerate(keys_list)}
+    return [(t[0], t[1], t[2]) for t in keys_list]
 
 
 @app.get(pipes_endpoint, tags=['Pipes: Attributes'])
@@ -579,6 +586,108 @@ def get_pipe_data(
 
 
 @app.get(
+    pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/docs',
+    tags=['Pipes: Data'],
+)
+def get_pipe_docs(
+    connector_keys: str,
+    metric_key: str,
+    location_key: str,
+    instance_keys: Optional[str] = None,
+    select_columns: Optional[str] = None,
+    omit_columns: Optional[str] = None,
+    begin: Union[str, int, None] = None,
+    end: Union[str, int, None] = None,
+    params: Optional[str] = None,
+    limit: int = MAX_RESPONSE_ROW_LIMIT,
+    order: str = 'asc',
+    curr_user = fastapi.Security(ScopedAuth(['pipes:read'])),
+) -> str:
+    """
+    Get a pipe's data as a list of documents (list of dicts).
+    Bypasses DataFrame construction overhead; ideal for connectors that return JSON natively.
+    See [`Pipe.get_docs()`](https://docs.meerschaum.io/meerschaum.html#Pipe.get_docs).
+
+    Note that `select_columns`, `omit_columns`, and `params` are JSON-encoded strings.
+    """
+    if limit > MAX_RESPONSE_ROW_LIMIT:
+        raise fastapi.HTTPException(
+            status_code=413,
+            detail=(
+                f"Requested limit {limit} exceeds the maximum response size of "
+                f"{MAX_RESPONSE_ROW_LIMIT} rows."
+            ),
+        )
+
+    _params = {}
+    if params == 'null':
+        params = None
+    if params is not None:
+        try:
+            _params = json.loads(params)
+        except Exception:
+            _params = None
+    if not isinstance(_params, dict):
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail="Params must be a valid JSON-encoded dictionary.",
+        )
+
+    _select_columns = []
+    if select_columns == 'null':
+        select_columns = None
+    if select_columns is not None:
+        try:
+            _select_columns = json.loads(select_columns)
+        except Exception:
+            _select_columns = None
+    if not isinstance(_select_columns, list):
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail="Selected columns must be a JSON-encoded list.",
+        )
+
+    _omit_columns = []
+    if omit_columns == 'null':
+        omit_columns = None
+    if omit_columns is not None:
+        try:
+            _omit_columns = json.loads(omit_columns)
+        except Exception:
+            _omit_columns = None
+    if _omit_columns is None:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail="Omitted columns must be a JSON-encoded list.",
+        )
+
+    pipe = get_pipe(connector_keys, metric_key, location_key, instance_keys)
+    begin, end = pipe.parse_date_bounds(begin, end)
+
+    if pipe.target in ('mrsm_users', 'mrsm_plugins', 'mrsm_pipes', 'mrsm_tokens'):
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail=f"Cannot retrieve data from protected table '{pipe.target}'.",
+        )
+
+    docs = pipe.get_docs(
+        select_columns=_select_columns or None,
+        omit_columns=_omit_columns or None,
+        begin=begin,
+        end=end,
+        params=_params,
+        limit=min(limit, MAX_RESPONSE_ROW_LIMIT),
+        order=order,
+        debug=debug,
+    )
+
+    return fastapi.Response(
+        json.dumps(docs, default=json_serialize_value),
+        media_type='application/json',
+    )
+
+
+@app.get(
     pipes_endpoint + '/{connector_keys}/{metric_key}/{location_key}/chunk_bounds',
     tags=['Pipes: Data'],
 )
@@ -771,7 +880,7 @@ def get_pipe_id(
     """
     Get a pipe's ID.
     """
-    pipe_id = get_pipe(connector_keys, metric_key, location_key, instance_keys).get_id(debug=debug)
+    pipe_id = get_pipe(connector_keys, metric_key, location_key, instance_keys).id
     if pipe_id is None:
         raise fastapi.HTTPException(status_code=404, detail="Pipe is not registered.")
     return pipe_id

--- a/meerschaum/config/__init__.py
+++ b/meerschaum/config/__init__.py
@@ -47,6 +47,7 @@ __all__ = (
     'get_keyfile_path',
     'apply_patch_to_config',
     'read_config',
+    'environment',
     'paths',
     'STATIC_CONFIG',
 )

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.3.0.dev2"
+__version__ = "3.3.0"

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.2.4"
+__version__ = "3.3.0.dev2"

--- a/meerschaum/connectors/api/_APIConnector.py
+++ b/meerschaum/connectors/api/_APIConnector.py
@@ -60,6 +60,7 @@ class APIConnector(InstanceConnector):
         clear_pipe,
         get_pipe_columns_types,
         get_pipe_columns_indices,
+        get_pipe_docs,
     )
     from ._fetch import fetch
     from ._plugins import (

--- a/meerschaum/connectors/api/_APIConnector.py
+++ b/meerschaum/connectors/api/_APIConnector.py
@@ -49,6 +49,7 @@ class APIConnector(InstanceConnector):
         edit_pipe,
         sync_pipe,
         delete_pipe,
+        delete_pipe_cache,
         get_pipe_data,
         get_pipe_id,
         get_pipe_attributes,

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -112,16 +112,13 @@ def fetch_pipes_keys(
     tags: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
     debug: bool = False
-) -> List[
-        Union[
-            Tuple[str, str, Union[str, None]],
-            Tuple[str, str, Union[str, None], List[str]],
-            Tuple[str, str, Union[str, None], Dict[str, Any]]
-        ]
-    ]:
+) -> Union[
+    Dict[Union[int, str], Tuple[str, str, Union[str, None], Dict[str, Any]]],
+    List[Tuple[str, str, Union[str, None]]],
+]:
     """
     Fetch registered Pipes' keys from the API.
-    
+
     Parameters
     ----------
     connector_keys: Optional[List[str]], default None
@@ -146,7 +143,7 @@ def fetch_pipes_keys(
 
     Returns
     -------
-    A list of tuples containing pipes' keys.
+    A dictionary mapping pipe IDs to key tuples, or a list of key tuples for older servers.
     """
     from meerschaum._internal.static import STATIC_CONFIG
     if connector_keys is None:
@@ -169,6 +166,7 @@ def fetch_pipes_keys(
                 'tags': json.dumps(tags),
                 'params': json.dumps(params),
                 'instance_keys': self.instance_keys,
+                'as_dict': True,
             },
             debug=debug
         ).json()
@@ -179,6 +177,12 @@ def fetch_pipes_keys(
 
     if 'detail' in j:
         error(j['detail'], stack=False)
+
+    if isinstance(j, dict):
+        return {
+            (int(k) if str(k).isdigit() else k): tuple(v)
+            for k, v in j.items()
+        }
     return [tuple(r) for r in j]
 
 
@@ -807,6 +811,48 @@ def get_pipe_columns_indices(
         warn(response.text)
         return None
     return j
+
+
+def get_pipe_docs(
+    self,
+    pipe: mrsm.Pipe,
+    select_columns: Optional[List[str]] = None,
+    omit_columns: Optional[List[str]] = None,
+    begin: Union[str, datetime, int, None] = None,
+    end: Union[str, datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    order: str = 'asc',
+    limit: Optional[int] = None,
+    debug: bool = False,
+    **kw: Any
+) -> List[Dict[str, Any]]:
+    """Fetch a pipe's data as a list of documents from the API."""
+    r_url = pipe_r_url(pipe)
+    try:
+        response = self.get(
+            r_url + "/docs",
+            params={
+                'select_columns': json.dumps(select_columns),
+                'omit_columns': json.dumps(omit_columns),
+                'begin': begin,
+                'end': end,
+                'params': json.dumps(params, default=str),
+                'order': order,
+                'limit': limit,
+                'instance_keys': self.get_pipe_instance_keys(pipe),
+            },
+            debug=debug,
+        )
+        if not response.ok:
+            warn(f"Failed to get docs for {pipe}:\n{response.text}")
+            return []
+        j = response.json()
+        if isinstance(j, list):
+            return j
+        return []
+    except Exception as e:
+        warn(f"Failed to get docs for {pipe}:\n{e}")
+        return []
 
 
 def get_pipe_index_names(self, pipe: mrsm.Pipe, debug: bool = False) -> Dict[str, str]:

--- a/meerschaum/connectors/api/_pipes.py
+++ b/meerschaum/connectors/api/_pipes.py
@@ -305,6 +305,7 @@ def sync_pipe(
         rowcount += len(c)
         num_success_chunks += 1
 
+    self.delete_pipe_cache(pipe, debug=debug)
     success_tuple = True, (
         f"It took {interval_str(timedelta(seconds=(time.perf_counter() - begin)))} "
         + f"to sync {rowcount:,} row"
@@ -313,6 +314,28 @@ def sync_pipe(
         f" to {pipe}."
     )
     return success_tuple
+
+
+def delete_pipe_cache(
+    self,
+    pipe: mrsm.Pipe,
+    debug: bool = False,
+    **kw: Any
+) -> SuccessTuple:
+    """Invalidate the server-side cache for a pipe."""
+    r_url = pipe_r_url(pipe)
+    response = self.delete(
+        r_url + '/cache',
+        params={'instance_keys': self.get_pipe_instance_keys(pipe)},
+        debug=debug,
+    )
+    if not response.ok:
+        return False, f"Failed to invalidate cache for {pipe}: {response.text}"
+    try:
+        data = response.json()
+        return tuple(data) if isinstance(data, list) else (response.ok, response.text)
+    except Exception:
+        return response.ok, response.text
 
 
 def delete_pipe(

--- a/meerschaum/connectors/instance/_InstanceConnector.py
+++ b/meerschaum/connectors/instance/_InstanceConnector.py
@@ -77,6 +77,7 @@ class InstanceConnector(Connector):
         create_pipe_indices,
         clear_pipe,
         get_pipe_data,
+        get_pipe_docs,
         get_sync_time,
         get_pipe_columns_types,
         get_pipe_columns_indices,

--- a/meerschaum/connectors/instance/_pipes.py
+++ b/meerschaum/connectors/instance/_pipes.py
@@ -122,9 +122,19 @@ def fetch_pipes_keys(
     tags: Optional[List[str]] = None,
     debug: bool = False,
     **kwargs: Any
-) -> List[Tuple[str, str, str]]:
+) -> Union[
+    List[Tuple[str, str, str]],
+    List[Tuple[str, str, str, Union[Dict[str, Any], List[str]]]],
+    Dict[Union[int, str], Tuple[str, str, str]],
+    Dict[Union[int, str], Tuple[str, str, str, Union[Dict[str, Any], List[str]]]],
+]:
     """
-    Return a list of tuples for the registered pipes' keys according to the provided filters.
+    Return registered pipes' keys according to the provided filters.
+
+    May return either a list of key tuples or a dictionary mapping pipe IDs to key tuples.
+    When returning a dictionary, the key is the pipe's unique ID (int or str).
+    Tuples may be length 3 `(connector_keys, metric_key, location_key)` or length 4
+    with parameters or tags appended as the fourth element.
 
     Parameters
     ----------
@@ -142,19 +152,19 @@ def fetch_pipes_keys(
 
     Returns
     -------
-    A list of connector, metric, and location keys in tuples.
-    You may return the string "None" for location keys in place of nulls.
+    A list of tuples or a dictionary mapping pipe IDs to tuples.
+    You may return the string `"None"` for location keys in place of nulls.
 
     Examples
     --------
     >>> import meerschaum as mrsm
     >>> conn = mrsm.get_connector('example:demo')
-    >>> 
+    >>>
     >>> pipe_a = mrsm.Pipe('a', 'demo', tags=['foo'], instance=conn)
     >>> pipe_b = mrsm.Pipe('b', 'demo', tags=['bar'], instance=conn)
     >>> pipe_a.register()
     >>> pipe_b.register()
-    >>> 
+    >>>
     >>> conn.fetch_pipes_keys(['a', 'b'])
     [('a', 'demo', 'None'), ('b', 'demo', 'None')]
     >>> conn.fetch_pipes_keys(metric_keys=['demo'])
@@ -327,7 +337,6 @@ def clear_pipe(
     """
     raise NotImplementedError
 
-@abc.abstractmethod
 def get_pipe_data(
     self,
     pipe: mrsm.Pipe,
@@ -367,6 +376,86 @@ def get_pipe_data(
     -------
     The target table's data as a DataFrame.
     """
+    if type(self).get_pipe_docs is get_pipe_docs:
+        raise NotImplementedError(
+            f"Missing `get_pipe_data()` or `get_pipe_docs()` for {type(self)}."
+        )
+
+    docs = self.get_pipe_docs(
+        pipe=pipe,
+        select_columns=select_columns,
+        omit_columns=omit_columns,
+        begin=begin,
+        end=end,
+        params=params,
+        debug=debug,
+        **kwargs
+    )
+    if not docs:
+        return None
+
+    pd = mrsm.attempt_import('pandas')
+    try:
+        return pd.DataFrame(docs)
+    except Exception as e:
+        from meerschaum.utils.warnings import warn
+        warn(f"Cannot build DataFrame from pipe docs:\n{e}")
+    
+    return None
+
+def get_pipe_docs(
+    self,
+    pipe: mrsm.Pipe,
+    select_columns: Optional[List[str]] = None,
+    omit_columns: Optional[List[str]] = None,
+    begin: Union[datetime, int, None] = None,
+    end: Union[datetime, int, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    debug: bool = False,
+    **kwargs: Any
+) -> list[dict[str, Any]]:
+    """
+    Return a pipe's data as a list of documents.
+    Defaults to `get_pipe_data().to_dict(orient='records')`.
+
+    Parameters
+    ----------
+    pipe: mrsm.Pipe
+        The pipe with the target table from which to read.
+
+    select_columns: list[str] | None, default None
+        If provided, only select these given columns.
+        Otherwise select all available columns (i.e. `SELECT *`).
+
+    omit_columns: list[str] | None, default None
+        If provided, remove these columns from the selection.
+
+    begin: datetime | int | None, default None
+        The earliest `datetime` value to search from (inclusive).
+
+    end: datetime | int | None, default None
+        The lastest `datetime` value to search from (exclusive).
+
+    params: dict[str | str] | None, default None
+        Additional filters to apply to the query.
+
+    Returns
+    -------
+    The target table's data as a list of dictionaries.
+    """
+    df = self.get_pipe_data(
+        pipe=pipe,
+        select_columns=select_columns,
+        omit_columns=omit_columns,
+        begin=begin,
+        end=end,
+        params=params,
+        debug=debug,
+        **kwargs
+    )
+    if df is None or df.empty:
+        return []
+    return df.to_dict(orient='records')
 
 @abc.abstractmethod
 def get_sync_time(

--- a/meerschaum/connectors/sql/_SQLConnector.py
+++ b/meerschaum/connectors/sql/_SQLConnector.py
@@ -50,6 +50,7 @@ class SQLConnector(InstanceConnector):
         get_alter_columns_queries,
         delete_pipe,
         get_pipe_data,
+        get_pipe_docs,
         get_pipe_data_query,
         register_pipe,
         edit_pipe,

--- a/meerschaum/connectors/sql/_instance.py
+++ b/meerschaum/connectors/sql/_instance.py
@@ -75,10 +75,18 @@ def _drop_temporary_table(
         self.flavor,
         schema=self.internal_schema
     )
-    ### Oracle auto-commits DDL; passing commit=False avoids a transaction conflict
-    ### that would cause exec() to return None despite a successful drop.
-    exec_commit = self.flavor not in ('oracle',)
-    drop_success = self.exec(drop_query, silent=True, commit=exec_commit, debug=debug) is not None
+    ### Oracle auto-commits DDL, which conflicts with SQLAlchemy's transaction tracking.
+    ### Use engine.begin() directly to get a clean connection isolated from the thread-local pool.
+    if self.flavor == 'oracle':
+        sqlalchemy = mrsm.attempt_import('sqlalchemy', lazy=False)
+        try:
+            with self.engine.begin() as conn:
+                conn.execute(sqlalchemy.text(drop_query))
+            drop_success = True
+        except Exception:
+            drop_success = not table_exists(table, self, self.internal_schema, debug=debug)
+    else:
+        drop_success = self.exec(drop_query, silent=True, debug=debug) is not None
     if not drop_success and not table_exists(table, self, self.internal_schema, debug=debug):
         drop_success = True
     drop_msg = "Success" if drop_success else f"Failed to drop temporary table '{table}'."

--- a/meerschaum/connectors/sql/_instance.py
+++ b/meerschaum/connectors/sql/_instance.py
@@ -75,7 +75,12 @@ def _drop_temporary_table(
         self.flavor,
         schema=self.internal_schema
     )
-    drop_success = self.exec(drop_query, silent=True, debug=debug) is not None
+    ### Oracle auto-commits DDL; passing commit=False avoids a transaction conflict
+    ### that would cause exec() to return None despite a successful drop.
+    exec_commit = self.flavor not in ('oracle',)
+    drop_success = self.exec(drop_query, silent=True, commit=exec_commit, debug=debug) is not None
+    if not drop_success and not table_exists(table, self, self.internal_schema, debug=debug):
+        drop_success = True
     drop_msg = "Success" if drop_success else f"Failed to drop temporary table '{table}'."
     return drop_success, drop_msg
 

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -518,6 +518,16 @@ def get_pipe_index_names(self, pipe: mrsm.Pipe) -> Dict[str, str]:
         for index_name, ix in seen_index_names.items()
     }
 
+def _is_non_indexable_col(col: str, existing_cols_types: dict, flavor: str) -> bool:
+    """Return True if a column cannot be directly indexed on the given flavor."""
+    col_db_type = existing_cols_types.get(col, '').upper()
+    if flavor in ('mysql', 'mariadb'):
+        return 'TEXT' in col_db_type or 'BLOB' in col_db_type
+    if flavor == 'mssql':
+        return col_db_type in ('TEXT', 'NTEXT') or 'MAX' in col_db_type
+    return False
+
+
 def get_create_index_queries(
     self,
     pipe: mrsm.Pipe,
@@ -821,7 +831,11 @@ def get_create_index_queries(
             )
             pass
         else: ### mssql, sqlite, etc.
-            id_query = f"CREATE INDEX {_id_index_name} ON {_pipe_name} ({_id_name})"
+            id_query = (
+                None
+                if _is_non_indexable_col(_id, existing_cols_types, self.flavor)
+                else f"CREATE INDEX {_id_index_name} ON {_pipe_name} ({_id_name})"
+            )
 
         if id_query is not None:
             index_queries[_id] = id_query if isinstance(id_query, list) else [id_query]
@@ -842,6 +856,13 @@ def get_create_index_queries(
             cols = [cols]
         if ix_key == 'unique' and upsert:
             continue
+        if self.flavor in ('mysql', 'mariadb', 'mssql'):
+            cols = [
+                col for col in cols
+                if col and not _is_non_indexable_col(
+                    col, existing_cols_types, self.flavor
+                )
+            ]
         cols_names = [sql_item_name(col, self.flavor, None) for col in cols if col]
         if not cols_names:
             continue

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -1139,7 +1139,6 @@ def get_pipe_data(
     A `pd.DataFrame` of the pipe's data.
 
     """
-    import functools
     from meerschaum.utils.packages import import_pandas
     from meerschaum.utils.dtypes import to_pandas_dtype, are_dtypes_equal
     from meerschaum.utils.dtypes.sql import get_pd_type_from_db_type

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -921,8 +921,14 @@ def get_create_index_queries(
     constraint_queries = [create_unique_index_query]
     if self.flavor not in ('sqlite', 'geopackage'):
         constraint_queries.append(add_constraint_query)
-    if upsert and indices_cols_str:
+    if upsert and indices_cols_str and unique_index_name_unquoted.lower() not in existing_ix_names:
         index_queries[unique_index_name] = constraint_queries
+        ### Remove regular indices that cover the same single column as the unique index.
+        ### Some flavors (e.g. Oracle) reject two indices on the same column combination.
+        if unique_index_cols_str == _id_name:
+            index_queries.pop(_id, None)
+        if unique_index_cols_str == _datetime_name:
+            index_queries.pop(_datetime, None)
     return index_queries
 
 
@@ -1595,7 +1601,8 @@ def get_pipe_attributes(
             return {}
         attributes = dict(rows[0])
     except Exception:
-        warn(traceback.format_exc())
+        if debug:
+            dprint(traceback.format_exc())
         return {}
 
     ### handle non-PostgreSQL databases (text vs JSON)
@@ -2730,6 +2737,8 @@ def get_sync_time(
 
     ASC_or_DESC = "DESC" if newest else "ASC"
     existing_cols = pipe.get_columns_types(debug=debug)
+    if not remote and not existing_cols:
+        return None
     valid_params = {}
     if params is not None:
         valid_params = {k: v for k, v in params.items() if k in existing_cols}
@@ -2885,6 +2894,8 @@ def get_pipe_rowcount(
         if 'definition' not in pipe.parameters['fetch']:
             error(msg)
             return None
+    elif not pipe.exists(debug=debug):
+        return None
 
     flavor = self.flavor if not remote else pipe.connector.flavor
     conn = self if not remote else pipe.connector

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -33,7 +33,7 @@ def register_pipe(
     from meerschaum.connectors.sql.tables import get_tables
     pipes_tbl = get_tables(mrsm_instance=self, create=(not pipe.temporary), debug=debug)['pipes']
 
-    if pipe.get_id(debug=debug) is not None:
+    if pipe.id is not None:
         return False, f"{pipe} is already registered."
 
     ### NOTE: if `parameters` is supplied in the Pipe constructor,
@@ -148,11 +148,11 @@ def fetch_pipes_keys(
     tags: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
     debug: bool = False,
-) -> List[
-        Tuple[str, str, Union[str, None], Dict[str, Any]]
+) -> Dict[
+        int, Tuple[str, str, Union[str, None], Dict[str, Any]]
     ]:
     """
-    Return a list of tuples corresponding to the parameters provided.
+    Return a dictionary mapping pipe IDs to key tuples corresponding to the parameters provided.
 
     Parameters
     ----------
@@ -231,7 +231,7 @@ def fetch_pipes_keys(
             parameters[col] = vals
 
     if not table_exists('mrsm_pipes', self, schema=self.instance_schema, debug=debug):
-        return []
+        return {}
 
     from meerschaum.connectors.sql.tables import get_tables
     pipes_tbl = get_tables(mrsm_instance=self, create=False, debug=debug)['pipes']
@@ -260,6 +260,7 @@ def fetch_pipes_keys(
 
     select_cols = (
         [
+            pipes_tbl.c.pipe_id,
             pipes_tbl.c.connector_keys,
             pipes_tbl.c.metric_key,
             pipes_tbl.c.location_key,
@@ -337,14 +338,23 @@ def fetch_pipes_keys(
             self.execute(q).fetchall()
             if self.flavor != 'duckdb'
             else [
-                (row['connector_keys'], row['metric_key'], row['location_key'])
+                (
+                    row['pipe_id'],
+                    row['connector_keys'],
+                    row['metric_key'],
+                    row['location_key'],
+                    row['parameters'],
+                )
                 for row in self.read(q).to_dict(orient='records')
             ]
         )
     except Exception as e:
         error(str(e))
 
-    return rows
+    return {
+        row[0]: row[1:]
+        for row in rows
+    }
 
 
 def create_pipe_indices(
@@ -1226,6 +1236,41 @@ def get_pipe_data(
     return pd.concat(chunks)
 
 
+def get_pipe_docs(
+    self,
+    pipe: mrsm.Pipe,
+    select_columns: Optional[List[str]] = None,
+    omit_columns: Optional[List[str]] = None,
+    begin: Union[datetime, str, None] = None,
+    end: Union[datetime, str, None] = None,
+    params: Optional[Dict[str, Any]] = None,
+    order: str = 'asc',
+    limit: Optional[int] = None,
+    debug: bool = False,
+    **kw: Any
+) -> List[Dict[str, Any]]:
+    """
+    Return a pipe's data as a list of dictionaries, bypassing pandas overhead.
+    """
+    query = self.get_pipe_data_query(
+        pipe=pipe,
+        select_columns=select_columns,
+        omit_columns=omit_columns,
+        begin=begin,
+        end=end,
+        params=params,
+        order=order,
+        limit=limit,
+        debug=debug,
+    )
+    if query is None:
+        return []
+    result = self.exec(query, silent=True, debug=debug)
+    if result is None:
+        return []
+    return [dict(row) for row in result.mappings().fetchall()]
+
+
 def get_pipe_data_query(
     self,
     pipe: mrsm.Pipe,
@@ -1512,7 +1557,7 @@ def get_pipe_attributes(
     from meerschaum.utils.packages import attempt_import
     sqlalchemy = attempt_import('sqlalchemy', lazy=False)
 
-    if pipe.get_id(debug=debug) is None:
+    if pipe.id is None:
         return {}
 
     pipes_tbl = get_tables(mrsm_instance=self, create=(not pipe.temporary), debug=debug)['pipes']
@@ -1709,7 +1754,7 @@ def sync_pipe(
     pipe_name = sql_item_name(pipe.target, self.flavor, schema=self.get_pipe_schema(pipe))
     dtypes = pipe.get_dtypes(debug=debug)
 
-    if not pipe.temporary and not pipe.get_id(debug=debug):
+    if not pipe.temporary and not pipe.id:
         register_tuple = pipe.register(debug=debug)
         if not register_tuple[0]:
             return register_tuple

--- a/meerschaum/connectors/sql/_sql.py
+++ b/meerschaum/connectors/sql/_sql.py
@@ -208,10 +208,11 @@ def read(
     ):
         truncated_table_name = truncate_item_name(str(query_or_table), self.flavor)
         if truncated_table_name != str(query_or_table) and not silent:
-            warn(
-                f"Table '{query_or_table}' is too long for '{self.flavor}',"
-                + f" will instead read the table '{truncated_table_name}'."
-            )
+            if self.flavor not in ('oracle', 'mysql', 'mariadb'):
+                warn(
+                    f"Table '{query_or_table}' is too long for '{self.flavor}',"
+                    + f" will instead read the table '{truncated_table_name}'."
+                )
 
         query_or_table = sql_item_name(str(query_or_table), self.flavor, schema)
         if debug:
@@ -1001,10 +1002,11 @@ def to_sql(
     ### Check if the name is too long.
     truncated_name = truncate_item_name(name, self.flavor)
     if name != truncated_name:
-        warn(
-            f"Table '{name}' is too long for '{self.flavor}',"
-            f" will instead create the table '{truncated_name}'."
-        )
+        if self.flavor not in ('oracle', 'mysql', 'mariadb'):
+            warn(
+                f"Table '{name}' is too long for '{self.flavor}',"
+                f" will instead create the table '{truncated_name}'."
+            )
 
     ### filter out non-pandas args
     import inspect

--- a/meerschaum/connectors/valkey/_pipes.py
+++ b/meerschaum/connectors/valkey/_pipes.py
@@ -234,7 +234,7 @@ def get_pipe_attributes(
     -------
     The document that matches the keys of the pipe.
     """
-    pipe_id = pipe.get_id(debug=debug)
+    pipe_id = pipe.id
     if pipe_id is None:
         return {}
 
@@ -271,7 +271,7 @@ def edit_pipe(
     -------
     A `SuccessTuple` indicating success.
     """
-    pipe_id = pipe.get_id(debug=debug)
+    pipe_id = pipe.id
     if pipe_id is None:
         return False, f"{pipe} is not registered."
 

--- a/meerschaum/core/Pipe/__init__.py
+++ b/meerschaum/core/Pipe/__init__.py
@@ -97,6 +97,7 @@ class Pipe:
         get_rowcount,
         get_data,
         get_doc,
+        get_docs,
         get_value,
         _get_data_as_iterator,
         get_chunk_interval,

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -328,6 +328,10 @@ def get_dtypes(
         if infer
         else {}
     )
+    if debug and infer:
+        dprint(f"Remote dtypes for {self}:")
+        mrsm.pprint(remote_dtypes)
+
     patched_dtypes = apply_patch_to_config((remote_dtypes or {}), (configured_dtypes or {}))
 
     dt_col = parameters.get('columns', {}).get('datetime', None)
@@ -665,8 +669,10 @@ def id(self) -> Union[int, str, uuid.UUID, None]:
     """
     Fetch and cache a pipe's ID.
     """
-    _id = self._get_cached_value('_id', debug=self.debug)
-    if not _id:
+    _id = self.__dict__.get('_id', None)
+    if _id is None:
+        _id = self._get_cached_value('_id', debug=self.debug)
+    if _id is None:
         _id = self.get_id(debug=self.debug)
         if _id is not None:
             self._cache_value('_id', _id, debug=self.debug)

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -984,12 +984,12 @@ def target(self) -> str:
             default_targets.add(truncated_target)
             warned_target = self.__dict__.get('_warned_target', False)
             if truncated_target != _target and not warned_target:
-                if not warned_target:
+                if self.instance_connector.flavor not in ('oracle', 'mysql', 'mariadb'):
                     warn(
                         f"The target '{_target}' is too long for '{self.instance_connector.flavor}', "
                         + f"will use {truncated_target} instead."
                     )
-                    self.__dict__['_warned_target'] = True
+                self.__dict__['_warned_target'] = True
                 _target = truncated_target
 
         if _target in default_targets:

--- a/meerschaum/core/Pipe/_attributes.py
+++ b/meerschaum/core/Pipe/_attributes.py
@@ -669,9 +669,7 @@ def id(self) -> Union[int, str, uuid.UUID, None]:
     """
     Fetch and cache a pipe's ID.
     """
-    _id = self.__dict__.get('_id', None)
-    if _id is None:
-        _id = self._get_cached_value('_id', debug=self.debug)
+    _id = self._get_cached_value('_id', debug=self.debug)
     if _id is None:
         _id = self.get_id(debug=self.debug)
         if _id is not None:

--- a/meerschaum/core/Pipe/_bootstrap.py
+++ b/meerschaum/core/Pipe/_bootstrap.py
@@ -61,7 +61,7 @@ def bootstrap(
 
     _clear = get_config('shell', 'clear_screen', patch=True)
 
-    if self.get_id(debug=debug) is not None:
+    if self.id is not None:
         delete_tuple = self.delete(debug=debug)
         if not delete_tuple[0]:
             return delete_tuple

--- a/meerschaum/core/Pipe/_cache.py
+++ b/meerschaum/core/Pipe/_cache.py
@@ -30,14 +30,38 @@ def _get_in_memory_key(cache_key: str) -> str:
     )
 
 
+def _get_instance_hash(pipe: mrsm.Pipe) -> str:
+    """
+    Return a short hash of the instance connector's stable attributes.
+    Changing the connector's config (e.g. hostname) produces a different hash,
+    preventing stale cache from being loaded.
+    """
+    import hashlib
+    import json
+
+    connector = pipe.instance_connector
+    if connector is None:
+        return 'none'
+
+    attrs = {
+        k: v
+        for k, v in connector.__dict__.items()
+        if not k.startswith('_') and isinstance(v, (str, int, float, bool, type(None)))
+    }
+    attrs_str = json.dumps(attrs, sort_keys=True, default=str)
+    return hashlib.md5(attrs_str.encode()).hexdigest()[:8]
+
+
 def _get_cache_conn_cache_key(pipe: mrsm.Pipe, cache_key: str) -> str:
     """
     Return the cache key to use in the cache connector.
     """
+    ick = pipe.instance_keys.replace(':', '_')
+    ihash = _get_instance_hash(pipe)
     ck = pipe.connector_keys.replace(':', '_')
     mk = pipe.metric_key
     lk = str(pipe.location_key)
-    return f'.cache:pipes:{ck}:{mk}:{lk}:{cache_key}'
+    return f'.cache:pipes:{ick}:{ihash}:{ck}:{mk}:{lk}:{cache_key}'
 
 
 def _get_cache_connector(self) -> 'Union[None, ValkeyConnector]':
@@ -101,7 +125,13 @@ def _get_cached_value(
         if in_memory_key in self.__dict__:
             return self.__dict__.get(in_memory_key, None)
 
-        return self._read_cache_key(cache_key, debug=debug)
+        if not self.cache:
+            return None
+
+        value = self._read_cache_key(cache_key, debug=debug)
+        if value is not None:
+            self.__dict__[in_memory_key] = value
+        return value
 
 
 def _invalidate_cache(
@@ -159,6 +189,7 @@ def _get_cache_dir_path(self, create_if_not_exists: bool = False) -> pathlib.Pat
     cache_dir_path = (
         paths.PIPES_CACHE_RESOURCES_PATH
         / self.instance_keys
+        / _get_instance_hash(self)
         / self.connector_keys
         / self.metric_key
         / str(self.location_key)

--- a/meerschaum/core/Pipe/_cache.py
+++ b/meerschaum/core/Pipe/_cache.py
@@ -30,6 +30,8 @@ def _get_in_memory_key(cache_key: str) -> str:
     )
 
 
+_instance_hash_cache: dict[str, str] = {}
+
 def _get_instance_hash(pipe: mrsm.Pipe) -> str:
     """
     Return a short hash of the instance connector's stable attributes.
@@ -43,13 +45,19 @@ def _get_instance_hash(pipe: mrsm.Pipe) -> str:
     if connector is None:
         return 'none'
 
+    cache_key = str(id(connector))
+    if cache_key in _instance_hash_cache:
+        return _instance_hash_cache[cache_key]
+
     attrs = {
         k: v
         for k, v in connector.__dict__.items()
         if not k.startswith('_') and isinstance(v, (str, int, float, bool, type(None)))
     }
     attrs_str = json.dumps(attrs, sort_keys=True, default=str)
-    return hashlib.md5(attrs_str.encode()).hexdigest()[:8]
+    result = hashlib.md5(attrs_str.encode()).hexdigest()[:8]
+    _instance_hash_cache[cache_key] = result
+    return result
 
 
 def _get_cache_conn_cache_key(pipe: mrsm.Pipe, cache_key: str) -> str:
@@ -165,7 +173,7 @@ def _invalidate_cache(
     cache_dir_path = self._get_cache_dir_path()
     cache_keys = self._get_cache_keys(debug=debug)
     for cache_key in cache_keys:
-        if cache_keys == 'attributes':
+        if cache_key == 'attributes':
             continue
         self._clear_cache_key(cache_key, debug=debug)
 

--- a/meerschaum/core/Pipe/_copy.py
+++ b/meerschaum/core/Pipe/_copy.py
@@ -65,7 +65,7 @@ def copy_to(
         instance=instance_keys,
     )
 
-    new_pipe_is_registered = new_pipe.get_id() is not None
+    new_pipe_is_registered = new_pipe.id is not None
 
     metadata_method = new_pipe.edit if new_pipe_is_registered else new_pipe.register
     metadata_success, metadata_msg = metadata_method(debug=debug)

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -67,12 +67,16 @@ def get_data(
     as_docs: bool, default False
         If `True`, return a list of dictionaries rather than a DataFrame.
         Relies on `get_pipe_docs` from the instance connector if implemented.
+        May be combined with `as_chunks` to return an `Iterator[List[Dict]]`
+        chunked by time bounds (useful for large result sets without pandas overhead).
 
     as_iterator: bool, default False
         If `True`, return a generator of chunks of pipe data.
+        When combined with `as_docs=True`, yields `List[Dict]` per chunk instead of DataFrames.
 
     as_chunks: bool, default False
         Alias for `as_iterator`.
+        When combined with `as_docs=True`, yields `List[Dict]` per chunk instead of DataFrames.
 
     as_dask: bool, default False
         If `True`, return a `dask.DataFrame`
@@ -106,7 +110,10 @@ def get_data(
 
     Returns
     -------
-    A `pd.DataFrame` for the pipe's data corresponding to the provided parameters.
+    A `pd.DataFrame` of the pipe's data (default).
+    A `List[Dict]` if `as_docs=True`.
+    An `Iterator[pd.DataFrame]` if `as_chunks=True` (or `as_iterator=True`).
+    An `Iterator[List[Dict]]` if both `as_docs=True` and `as_chunks=True`.
 
     """
     from meerschaum.utils.warnings import warn

--- a/meerschaum/core/Pipe/_data.py
+++ b/meerschaum/core/Pipe/_data.py
@@ -26,6 +26,7 @@ def get_data(
     begin: Union[datetime, int, str, None] = None,
     end: Union[datetime, int, str, None] = None,
     params: Optional[Dict[str, Any]] = None,
+    as_docs: bool = False,
     as_iterator: bool = False,
     as_chunks: bool = False,
     as_dask: bool = False,
@@ -62,6 +63,10 @@ def get_data(
     params: Optional[Dict[str, Any]], default None
         Filter the retrieved data by a dictionary of parameters.
         See `meerschaum.utils.sql.build_where` for more details. 
+
+    as_docs: bool, default False
+        If `True`, return a list of dictionaries rather than a DataFrame.
+        Relies on `get_pipe_docs` from the instance connector if implemented.
 
     as_iterator: bool, default False
         If `True`, return a generator of chunks of pipe data.
@@ -123,7 +128,7 @@ def get_data(
     if isinstance(omit_columns, str):
         omit_columns = [omit_columns]
 
-    begin, end = self.parse_date_bounds(begin, end)
+    begin, end = self.parse_date_bounds(begin, end, debug=debug)
     as_iterator = as_iterator or as_chunks
     dt_col = self.columns.get('datetime', None)
 
@@ -164,9 +169,12 @@ def get_data(
             chunk_interval=chunk_interval,
             limit=limit,
             order=order,
+            as_docs=as_docs,
             fresh=fresh,
             debug=debug,
         )
+        if as_docs:
+            return df
         return _sort_df(df)
 
     if as_dask:
@@ -206,7 +214,23 @@ def get_data(
         return _sort_df(dd.from_delayed(dask_chunks, meta=dask_meta))
 
     if not self.exists(debug=debug):
-        return None
+        return [] if as_docs else None
+
+    if as_docs:
+        with Venv(get_connector_plugin(self.instance_connector)):
+            docs = self.instance_connector.get_pipe_docs(
+                pipe=self,
+                select_columns=select_columns,
+                omit_columns=omit_columns,
+                begin=begin,
+                end=end,
+                params=params,
+                limit=limit,
+                order=order,
+                debug=debug,
+                **kw
+            )
+        return docs if docs is not None else []
 
     with Venv(get_connector_plugin(self.instance_connector)):
         df = self.instance_connector.get_pipe_data(
@@ -297,6 +321,7 @@ def _get_data_as_iterator(
     chunk_interval: Union[timedelta, int, None] = None,
     limit: Optional[int] = None,
     order: Optional[str] = 'asc',
+    as_docs: bool = False,
     fresh: bool = False,
     debug: bool = False,
     **kw: Any
@@ -305,7 +330,7 @@ def _get_data_as_iterator(
     Return a pipe's data as a generator.
     """
     from meerschaum.utils.dtypes import round_time
-    begin, end = self.parse_date_bounds(begin, end)
+    begin, end = self.parse_date_bounds(begin, end, debug=debug)
     if not self.exists(debug=debug):
         return
 
@@ -348,6 +373,7 @@ def _get_data_as_iterator(
             params=params,
             limit=limit,
             order=order,
+            as_docs=as_docs,
             fresh=fresh,
             debug=debug,
         )
@@ -369,10 +395,11 @@ def _get_data_as_iterator(
             params=params,
             limit=limit,
             order=order,
+            as_docs=as_docs,
             fresh=fresh,
             debug=debug,
         )
-        if len(chunk) > 0:
+        if chunk is not None and len(chunk) > 0:
             yield chunk
 
 
@@ -428,14 +455,13 @@ def get_backtrack_data(
     A `pd.DataFrame` for the pipe's data corresponding to the provided parameters. Backtrack data
     is a convenient way to get a pipe's data "backtracked" from the most recent datetime.
     """
-    from meerschaum.utils.warnings import warn
     from meerschaum.utils.venv import Venv
     from meerschaum.connectors import get_connector_plugin
 
     if not self.exists(debug=debug):
         return None
 
-    begin = self.parse_date_bounds(begin)
+    begin = self.parse_date_bounds(begin, debug=debug)
 
     backtrack_interval = self.get_backtrack_interval(debug=debug)
     if backtrack_minutes is None:
@@ -471,12 +497,12 @@ def get_backtrack_data(
     if begin is not None:
         begin = begin - backtrack_interval
 
+    kw['order'] = kw.get('order', 'desc') or 'desc'
     return self.get_data(
         begin=begin,
         params=params,
         debug=debug,
         limit=limit,
-        order=kw.get('order', 'desc'),
         **kw
     )
 
@@ -517,7 +543,7 @@ def get_rowcount(
     from meerschaum.connectors import get_connector_plugin
     from meerschaum.utils.misc import filter_keywords
 
-    begin, end = self.parse_date_bounds(begin, end)
+    begin, end = self.parse_date_bounds(begin, end, debug=debug)
     connector = self.instance_connector if not remote else self.connector
     try:
         with Venv(get_connector_plugin(connector)):
@@ -673,7 +699,7 @@ def get_chunk_bounds(
     if begin is None and end is None:
         return [(None, None)]
 
-    begin, end = self.parse_date_bounds(begin, end)
+    begin, end = self.parse_date_bounds(begin, end, debug=debug)
 
     if begin and end:
         if begin >= end:
@@ -784,7 +810,7 @@ def get_chunk_bounds_batches(
     ]
 
 
-def parse_date_bounds(self, *dt_vals: Union[datetime, int, None]) -> Union[
+def parse_date_bounds(self, *dt_vals: Union[datetime, int, None], debug: bool = False) -> Union[
     datetime,
     int,
     str,
@@ -798,6 +824,16 @@ def parse_date_bounds(self, *dt_vals: Union[datetime, int, None]) -> Union[
     from meerschaum.utils.dtypes import coerce_timezone, MRSM_PD_DTYPES
     from meerschaum.utils.warnings import warn
     dateutil_parser = mrsm.attempt_import('dateutil.parser')
+
+    _columns = None
+    _dtypes = None
+
+    def _get_coercion_info():
+        nonlocal _columns, _dtypes
+        if _columns is None:
+            _columns = self.get_parameters(debug=debug).get('columns', {}) or {}
+        if _dtypes is None:
+            _dtypes = self.get_dtypes(debug=debug)
 
     def _parse_date_bound(dt_val):
         if dt_val is None:
@@ -819,8 +855,9 @@ def parse_date_bounds(self, *dt_vals: Union[datetime, int, None]) -> Union[
                 warn(f"Could not parse '{dt_val}' as datetime:\n{e}")
                 return None
 
-        dt_col = self.columns.get('datetime', None)
-        dt_typ = str(self.dtypes.get(dt_col, 'datetime'))
+        _get_coercion_info()
+        dt_col = _columns.get('datetime', None)
+        dt_typ = str(_dtypes.get(dt_col, 'datetime'))
         if dt_typ == 'datetime':
             dt_typ = MRSM_PD_DTYPES['datetime']
         return coerce_timezone(dt_val, strip_utc=('utc' not in dt_typ.lower()))
@@ -838,14 +875,23 @@ def get_doc(self, **kwargs) -> Union[Dict[str, Any], None]:
     """
     from meerschaum.utils.warnings import warn
     kwargs['limit'] = 1
+    kwargs['as_docs'] = True
     try:
-        result_df = self.get_data(**kwargs)
-        if result_df is None or len(result_df) == 0:
+        docs = self.get_data(**kwargs)
+        if not docs:
             return None
-        return result_df.reset_index(drop=True).iloc[0].to_dict()
+        return docs[0]
     except Exception as e:
         warn(f"Failed to read value from {self}:\n{e}", stack=False)
         return None
+
+def get_docs(self, **kwargs) -> list[dict[str, Any]]:
+    """
+    Convenience method to return a pipe's data as a list of dictionaries.
+    Relies on `get_pipe_docs` from the instance connector if implemented.
+    """
+    kwargs['as_docs'] = True
+    return self.get_data(**kwargs)
 
 def get_value(
     self,
@@ -860,13 +906,14 @@ def get_value(
     from meerschaum.utils.warnings import warn
     kwargs['select_columns'] = [column]
     kwargs['limit'] = 1
+    kwargs['as_docs'] = True
     try:
-        result_df = self.get_data(params=params, **kwargs)
-        if result_df is None or len(result_df) == 0:
+        docs = self.get_data(params=params, **kwargs)
+        if not docs:
             return None
-        if column not in result_df.columns:
+        if column not in docs[0]:
             raise ValueError(f"Column '{column}' was not included in the result set.")
-        return result_df[column][0]
+        return docs[0][column]
     except Exception as e:
         warn(f"Failed to read value from {self}:\n{e}", stack=False)
         return None

--- a/meerschaum/core/Pipe/_delete.py
+++ b/meerschaum/core/Pipe/_delete.py
@@ -59,5 +59,6 @@ def delete(
 
     if result[0]:
         self._invalidate_cache(hard=True, debug=debug)
+        self._clear_cache_key('_id', debug=debug)
 
     return result

--- a/meerschaum/core/Pipe/_sync.py
+++ b/meerschaum/core/Pipe/_sync.py
@@ -186,7 +186,7 @@ def sync(
                 + "Omit the DataFrame to infer fetching.",
             )
         ### Ensure that Pipe is registered.
-        if not p.temporary and p.get_id(debug=debug) is None:
+        if not p.temporary and p.id is None:
             ### NOTE: This may trigger an interactive session for plugins!
             register_success, register_msg = p.register(debug=debug)
             if not register_success:

--- a/meerschaum/jobs/__init__.py
+++ b/meerschaum/jobs/__init__.py
@@ -23,6 +23,7 @@ __all__ = (
     'get_stopped_jobs',
     'get_paused_jobs',
     'get_restart_jobs',
+    'get_executor_keys_from_context',
     'make_executor',
     'Executor',
     'check_restart_jobs',

--- a/meerschaum/utils/__init__.py
+++ b/meerschaum/utils/__init__.py
@@ -18,6 +18,7 @@ __all__ = (
     'misc',
     'networking',
     'packages',
+    'pipes',
     'pool',
     'process',
     'prompt',

--- a/meerschaum/utils/_get_pipes.py
+++ b/meerschaum/utils/_get_pipes.py
@@ -30,6 +30,7 @@ def get_pipes(
     metric_keys: Union[str, List[str], None] = None,
     location_keys: Union[str, List[str], None] = None,
     tags: Optional[List[str]] = None,
+    datetime_dtypes: Optional[List[str]] = None,
     params: Optional[Dict[str, Any]] = None,
     mrsm_instance: Union[str, InstanceConnector, None] = None,
     instance: Union[str, InstanceConnector, None] = None,
@@ -58,7 +59,12 @@ def get_pipes(
         String or list of location keys. See `connector_keys` for formatting.
 
     tags: Optional[List[str]], default None
-         If provided, only include pipes with these tags.
+        If provided, only include pipes with these tags.
+
+    datetime_dtypes: Optional[List[str]], default None
+        If provided, only include pipes with the corresponding `datetime` axis dtypes.
+        Accepted values are `datetime`, `int`, `None` (or `null`, etc.).
+        May be negated by `_`.
 
     params: Optional[Dict[str, Any]], default None
         Dictionary of additional parameters to search by.
@@ -127,13 +133,26 @@ def get_pipes(
     {'gvl': Pipe('sql:main', 'weather')}
     ```
     """
-
     import json
     from collections import defaultdict
     from meerschaum.config import get_config
+    from meerschaum.config.static import STATIC_CONFIG
     from meerschaum.utils.warnings import error
-    from meerschaum.utils.misc import filter_keywords
+    from meerschaum.utils.misc import filter_keywords, separate_negation_values
     from meerschaum.utils.pool import get_pool
+    from meerschaum.utils.pipes import replace_pipes_syntax
+    from meerschaum.utils.debug import dprint
+    from meerschaum.utils.dtypes import value_is_null, get_current_timestamp
+    from meerschaum import Pipe
+
+    negation_prefix = STATIC_CONFIG['system']['fetch_pipes_keys']['negation_prefix']
+    if datetime_dtypes:
+        if isinstance(datetime_dtypes, str):
+            datetime_dtypes = [datetime_dtypes]
+        for _dt in datetime_dtypes:
+            _clean = str(_dt).lstrip(negation_prefix).lower()
+            if _clean not in ('datetime', 'int') and not value_is_null(_clean):
+                error(f"Invalid datetime dtype '{_dt}'.")
 
     if connector_keys is None:
         connector_keys = []
@@ -171,7 +190,6 @@ def get_pipes(
             error(f"Invalid instance connector: {mrsm_instance}")
         connector = mrsm_instance
     if debug:
-        from meerschaum.utils.debug import dprint
         dprint(f"Using instance connector: {connector}")
     if not connector:
         error(f"Could not create connector from keys: '{mrsm_instance}'")
@@ -190,12 +208,17 @@ def get_pipes(
     )
     if result is None:
         error("Unable to build pipes!")
+    result_items: List[Tuple] = (
+        list(result.items())
+        if isinstance(result, dict)
+        else [(None, keys_tuple) for keys_tuple in result]
+    )
 
     ### Populate the `pipes` dictionary with Pipes based on the keys
     ### obtained from the chosen `method`.
-    from meerschaum import Pipe
-    pipes = {}
-    for keys_tuple in result:
+    in_dtypes, ex_dtypes = separate_negation_values(datetime_dtypes or [])
+    pipes: PipesDict = {}
+    for pipe_id, keys_tuple in result_items:
         ck, mk, lk = keys_tuple[0], keys_tuple[1], keys_tuple[2]
         pipe_tags_or_parameters = keys_tuple[3] if len(keys_tuple) == 4 else None
         pipe_parameters = (
@@ -215,12 +238,6 @@ def get_pipes(
             )
         )
 
-        if ck not in pipes:
-            pipes[ck] = {}
-
-        if mk not in pipes[ck]:
-            pipes[ck][mk] = {}
-
         pipe = Pipe(
             ck, mk, lk,
             mrsm_instance = connector,
@@ -230,12 +247,63 @@ def get_pipes(
             **filter_keywords(Pipe, **kw)
         )
         pipe.__dict__['_tags'] = pipe_tags
+        if pipe_id is not None:
+            pipe._cache_value('_id', pipe_id, memory_only=True, debug=debug)
+        if pipe_parameters is not None:
+            now = get_current_timestamp('ms', as_int=True) / 1000
+            full_attributes = {
+                'connector_keys': ck,
+                'metric_key': mk,
+                'location_key': lk,
+                'parameters': pipe_parameters,
+            }
+            if pipe_id is not None:
+                full_attributes['pipe_id'] = pipe_id
+            pipe._cache_value('attributes', full_attributes, memory_only=True, debug=debug)
+            pipe._cache_value('_attributes_sync_time', now, memory_only=True, debug=debug)
+        if datetime_dtypes:
+            if pipe_parameters is None:
+                pipe_parameters = pipe.get_parameters(debug=debug)
+            columns_val = (pipe_parameters or {}).get('columns', {}) or {}
+            if isinstance(columns_val, str) and 'Pipe(' in columns_val:
+                columns_val = replace_pipes_syntax(columns_val)
+
+            dt_col = columns_val.get('datetime', None)
+            dt_typ = (
+                ((pipe_parameters or {}).get('dtypes', None) or {}).get(dt_col, None)
+                if dt_col
+                else None
+            )
+
+            def _dtype_matches(clean_d):
+                if not dt_col:
+                    return value_is_null(clean_d)
+                return (
+                    (clean_d == 'int' and 'int' in str(dt_typ).lower())
+                    or
+                    (clean_d == 'datetime' and 'int' not in str(dt_typ).lower())
+                )
+
+            in_match = not in_dtypes or any(_dtype_matches(d) for d in in_dtypes)
+            ex_match = bool(ex_dtypes and any(_dtype_matches(d) for d in ex_dtypes))
+            keep_pipe = in_match and not ex_match
+
+            if not keep_pipe:
+                continue
+
+        if ck not in pipes:
+            pipes[ck] = {}
+
+        if mk not in pipes[ck]:
+            pipes[ck][mk] = {}
+
+
         pipes[ck][mk][lk] = pipe
 
     if not as_list and not as_tags_dict:
         return pipes
 
-    from meerschaum.utils.misc import flatten_pipes_dict
+    from meerschaum.utils.pipes import flatten_pipes_dict
     pipes_list = flatten_pipes_dict(pipes)
     if as_list:
         return pipes_list
@@ -259,7 +327,7 @@ def fetch_pipes_keys(
     method: str,
     connector: 'mrsm.connectors.InstanceConnector',
     **kw: Any
-) -> List[Tuple[str, str, str]]:
+) -> Union[List[Tuple[str, str, str]], List[Tuple[str, str, str, Union[str, Dict[str, Any]]]]]:
     """
     Fetch keys for pipes according to a method.
 
@@ -292,6 +360,7 @@ def fetch_pipes_keys(
     -------
     A list of tuples of strings (or `None` for `location_key`)
     in the form `(connector_keys, metric_key, location_key)`.
+    Optionally the parameters or tags may be returned alongside the keys.
     
     Examples
     --------

--- a/meerschaum/utils/_get_pipes.py
+++ b/meerschaum/utils/_get_pipes.py
@@ -358,14 +358,15 @@ def fetch_pipes_keys(
 
     Returns
     -------
-    A list of tuples of strings (or `None` for `location_key`)
+    A list or a dictionary (with pipe IDs as indices) of tuples of strings (or `None` for `location_key`)
     in the form `(connector_keys, metric_key, location_key)`.
     Optionally the parameters or tags may be returned alongside the keys.
+    Note the return value depends on the instance connector implementation.
     
     Examples
     --------
     >>> fetch_pipes_keys(metric_keys=['weather'])
-    [('sql:main', 'weather', None)]
+    {1: ('sql:main', 'weather', None, {'columns': {'datetime': 'ts', 'id': 'station'}})}
     """
     from meerschaum.utils.warnings import error
 

--- a/meerschaum/utils/formatting/_pipes.py
+++ b/meerschaum/utils/formatting/_pipes.py
@@ -205,10 +205,10 @@ def pprint_pipes(pipes: PipesDict) -> None:
 
 
 def pprint_pipe_columns(
-        pipe: meerschaum.Pipe,
-        nopretty: bool = False,
-        debug: bool = False,
-    ) -> None:
+    pipe: meerschaum.Pipe,
+    nopretty: bool = False,
+    debug: bool = False,
+) -> None:
     """Pretty-print a pipe's columns."""
     from meerschaum.utils.warnings import info
     from meerschaum.utils.formatting import UNICODE, ANSI, pprint, print_tuple, get_console

--- a/meerschaum/utils/misc.py
+++ b/meerschaum/utils/misc.py
@@ -427,26 +427,6 @@ def sorted_dict(d: Dict[Any, Any]) -> Dict[Any, Any]:
     except Exception:
         return d
 
-def flatten_pipes_dict(pipes_dict: PipesDict) -> List[Pipe]:
-    """
-    Convert the standard pipes dictionary into a list.
-
-    Parameters
-    ----------
-    pipes_dict: PipesDict
-        The pipes dictionary to be flattened.
-
-    Returns
-    -------
-    A list of `Pipe` objects.
-
-    """
-    pipes_list = []
-    for ck in pipes_dict.values():
-        for mk in ck.values():
-            pipes_list += list(mk.values())
-    return pipes_list
-
 
 def timed_input(
     seconds: int = 10,
@@ -1827,6 +1807,15 @@ def round_time(*args, **kwargs):
     """
     from meerschaum.utils.dtypes import round_time
     return round_time(*args, **kwargs)
+
+
+def flatten_pipes_dict(*args, **kwargs):
+    """
+    Placeholder function to prevent breaking legacy behavior.
+    See `meerschaum.utils.pipes.flatten_pipes_dict`.
+    """
+    from meerschaum.utils.pipes import flatten_pipes_dict
+    return flatten_pipes_dict(*args, **kwargs)
 
 
 _current_module = sys.modules[__name__]

--- a/meerschaum/utils/pipes.py
+++ b/meerschaum/utils/pipes.py
@@ -242,7 +242,10 @@ def replace_pipes_syntax(text: str, _pipe=None) -> Any:
     resolved_values = {}
     for placeholder, match in placeholders.items():
         try:
-            resolved_values[placeholder] = _evaluate_pipe_access_chain_from_match(match, _pipe=_pipe)
+            resolved_values[placeholder] = _evaluate_pipe_access_chain_from_match(
+                match,
+                _pipe=_pipe,
+            )
         except Exception:
             import traceback
             warn(f"Failed to resolve pipe syntax '{match.group(0)}': {traceback.format_exc()}")
@@ -333,12 +336,72 @@ def is_pipe_registered(
     -------
     A bool indicating whether the pipe is inside the dictionary.
     """
-    from meerschaum.utils.debug import dprint
     ck, mk, lk = pipe.connector_keys, pipe.metric_key, pipe.location_key
-    if debug:
-        dprint(f'{ck}, {mk}, {lk}')
-        dprint(f'{pipe}, {pipes}')
     try:
         return ck in pipes and mk in pipes[ck] and lk in pipes[ck][mk]
-    except Exception:
+    except KeyError:
         return False
+
+
+def pipes_dict_from_list(pipes_list: list[mrsm.Pipe]) -> PipesDict:
+    """
+    Return a PipesDict from a list of pipes.
+    Note that all pipes must share the same instance connector.
+
+    Examples
+    --------
+    >>> pipes_list = [mrsm.Pipe('a', 'b'), mrsm.Pipe('a', 'b', 'c')]
+    >>> pipes_dict_from_list(pipes)
+    {
+        'a': {
+            'b': {
+                None: Pipe('a', 'b')
+                'c': Pipe('a', 'b', 'c')
+            }
+        }
+    }
+    """
+    from meerschaum.utils.warnings import warn
+    from meerschaum.utils.misc import items_str
+    if not pipes_list:
+        return {}
+
+    instance_keys = pipes_list[0].instance_keys
+    same_pipes = [pipe for pipe in pipes_list if pipe.instance_keys == instance_keys]
+    diff_pipes = [pipe for pipe in pipes_list if pipe.instance_keys != instance_keys]
+    if diff_pipes:
+        warn(
+            f"Skipping pipes with instance keys different from '{instance_keys}':\n"
+            f"{items_str(diff_pipes, quotes=False)}"
+        )
+
+    pipes_dict: PipesDict = {}
+    for pipe in same_pipes:
+        if pipe.connector_keys not in pipes_dict:
+            pipes_dict[pipe.connector_keys] = {}
+        if pipe.metric_key not in pipes_dict[pipe.connector_key]:
+            pipes_dict[pipe.connector_keys][pipe.metric_key] = {}
+        pipes_dict[pipe.connector_keys][pipe.metric_key][pipe.location_key] = pipe
+
+    return pipes_dict
+
+
+def flatten_pipes_dict(pipes_dict: PipesDict) -> list[mrsm.Pipe]:
+    """
+    Convert the standard pipes dictionary into a list.
+
+    Parameters
+    ----------
+    pipes_dict: PipesDict
+        The pipes dictionary to be flattened.
+
+    Returns
+    -------
+    A list of `Pipe` objects.
+
+    """
+    pipes_list = []
+    for ck in pipes_dict.values():
+        for mk in ck.values():
+            pipes_list.extend(list(mk.values()))
+    return pipes_list

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -671,10 +671,18 @@ def clean(substring: str) -> None:
     Raises an exception when banned words are used.
     """
     from meerschaum.utils.warnings import error
-    banned_symbols = [';', '--', 'drop ',]
+    banned_symbols = [
+        ';', '--', 'drop ', '/*', '*/',
+        'union ', 'exec ', 'execute ',
+        'insert ', 'update ', 'delete ',
+        'create ', 'alter ', 'truncate ',
+    ]
     for symbol in banned_symbols:
         if symbol in str(substring).lower():
             error(f"Invalid string: '{substring}'")
+
+
+_VALID_DATEPARTS = frozenset({'year', 'month', 'day', 'hour', 'minute', 'second'})
 
 
 def dateadd_str(
@@ -760,6 +768,10 @@ def dateadd_str(
                 else f" - {number * -1}"
             )
         return num_str
+    if datepart not in _VALID_DATEPARTS:
+        raise ValueError(
+            f"Invalid datepart '{datepart}'. Must be one of: {sorted(_VALID_DATEPARTS)}"
+        )
     if not begin:
         return ''
 
@@ -1379,17 +1391,20 @@ def get_table_cols_types(
         else ""
     )
 
+    def _esc(s: str) -> str:
+        return s.replace("'", "''")
+
     cols_types_query = sqlalchemy.text(
         textwrap.dedent(columns_types_queries.get(
             flavor,
             columns_types_queries['default']
         ).format(
-            table=table,
-            table_trunc=table_trunc,
-            table_lower=table_lower,
-            table_lower_trunc=table_lower_trunc,
-            table_upper=table_upper,
-            table_upper_trunc=table_upper_trunc,
+            table=_esc(table),
+            table_trunc=_esc(table_trunc),
+            table_lower=_esc(table_lower),
+            table_lower_trunc=_esc(table_lower_trunc),
+            table_upper=_esc(table_upper),
+            table_upper_trunc=_esc(table_upper_trunc),
             db_prefix=db_prefix,
         )).lstrip().rstrip()
     )
@@ -1558,19 +1573,22 @@ def get_table_cols_indices(
         else ""
     )
 
+    def _esc(s: str) -> str:
+        return s.replace("'", "''")
+
     cols_indices_query = sqlalchemy.text(
         textwrap.dedent(columns_indices_queries.get(
             flavor,
             columns_indices_queries['default']
         ).format(
-            table=table,
-            table_trunc=table_trunc,
-            table_lower=table_lower,
-            table_lower_trunc=table_lower_trunc,
-            table_upper=table_upper,
-            table_upper_trunc=table_upper_trunc,
+            table=_esc(table),
+            table_trunc=_esc(table_trunc),
+            table_lower=_esc(table_lower),
+            table_lower_trunc=_esc(table_lower_trunc),
+            table_upper=_esc(table_upper),
+            table_upper_trunc=_esc(table_upper_trunc),
             db_prefix=db_prefix,
-            schema=schema,
+            schema=_esc(schema) if schema else schema,
         )).lstrip().rstrip()
     )
 

--- a/meerschaum/utils/sql.py
+++ b/meerschaum/utils/sql.py
@@ -279,7 +279,7 @@ columns_types_queries = {
             TABLE_SCHEMA AS [schema],
             TABLE_NAME AS [table],
             COLUMN_NAME AS [column],
-            DATA_TYPE AS [type],
+            CASE WHEN CHARACTER_MAXIMUM_LENGTH = -1 THEN DATA_TYPE + '(max)' ELSE DATA_TYPE END AS [type],
             NUMERIC_PRECISION AS [numeric_precision],
             NUMERIC_SCALE AS [numeric_scale]
         FROM {db_prefix}INFORMATION_SCHEMA.COLUMNS WITH (NOLOCK)

--- a/meerschaum/utils/typing.py
+++ b/meerschaum/utils/typing.py
@@ -78,9 +78,9 @@ collections.Iterable = collections.abc.Iterable
 SuccessTuple = Tuple[bool, str]
 InstanceConnector = 'meerschaum.connectors.InstanceConnector'
 PipesDict = Dict[
-    str, Dict[                           ### connector_keys : metrics
-        str, Dict[                       ### metric_key     : locations
-            str, 'meerschaum.Pipe'       ### location_key   : Pipe
+    str, Dict[                                       ### connector_keys : metrics
+        str, Dict[                                   ### metric_key     : locations
+            Union[str, None], 'meerschaum.Pipe'      ### location_key   : Pipe
         ]
     ]
 ]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,15 +26,23 @@ if [ -z "$MRSM_DEBUG" ]; then
   export MRSM_DEBUG='false'
 fi
 
+### Parse flags; remaining args forwarded to pytest.
+start_db=""
+cleanup_on_exit=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    db)  start_db=1; shift ;;
+    rm)  cleanup_on_exit="rm"; shift ;;
+    *)   break ;;
+  esac
+done
+
 ### Start the test databases.
-if [ "$1" == "db" ]; then
+if [ -n "$start_db" ]; then
   cd tests/
   docker compose up --quiet-pull -d $services
   cd ../
 fi
-
-cleanup_on_exit="$2"
-shift 2
 
 $mrsm stop daemon
 
@@ -125,7 +133,8 @@ $PYTHON_BIN -m pytest \
   --ignore=docs/ \
   --ff \
   -n=auto \
-  -v; rc="$?"
+  -v \
+  "$@"; rc="$?"
 
 ### Cleanup
 if [ "$cleanup_on_exit" == "rm" ]; then

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,152 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Tests for Pipe._cache_value / _get_cached_value / _invalidate_cache.
+Memory layer tested without DB; disk layer uses the SQLite test connector.
+"""
+
+import pytest
+
+import meerschaum as mrsm
+from tests.connectors import conns
+
+_MEMORY_INSTANCE = 'sql:memory'
+_SQLITE_CONN = conns['sqlite']
+
+
+# ---------------------------------------------------------------------------
+# Memory-layer tests (no DB required, always run)
+# ---------------------------------------------------------------------------
+
+def test_cache_value_stored_in_memory():
+    pipe = mrsm.Pipe('test', 'cache', 'stored_in_memory', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('my_key', 42, memory_only=True)
+    assert pipe.__dict__.get('_my_key') == 42
+
+
+def test_cache_value_leading_underscore_stored_correctly():
+    pipe = mrsm.Pipe('test', 'cache', 'leading_underscore', instance=_MEMORY_INSTANCE)
+    # _get_in_memory_key leaves already-prefixed keys unchanged: '_internal' → '_internal'
+    pipe._cache_value('_internal', 'hello', memory_only=True)
+    assert pipe.__dict__.get('_internal') == 'hello'
+
+
+def test_get_cached_value_memory_hit():
+    pipe = mrsm.Pipe('test', 'cache', 'memory_hit', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('token', 'abc123', memory_only=True)
+    assert pipe._get_cached_value('token') == 'abc123'
+
+
+def test_get_cached_value_miss_returns_none():
+    pipe = mrsm.Pipe('test', 'cache', 'miss_none', instance=_MEMORY_INSTANCE)
+    assert pipe._get_cached_value('nonexistent_key') is None
+
+
+def test_cache_value_none_is_skipped():
+    pipe = mrsm.Pipe('test', 'cache', 'none_skipped', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('nothing', None, memory_only=True)
+    assert '_nothing' not in pipe.__dict__
+    assert pipe._get_cached_value('nothing') is None
+
+
+def test_cache_value_overwrites_existing():
+    pipe = mrsm.Pipe('test', 'cache', 'overwrites', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('count', 1, memory_only=True)
+    pipe._cache_value('count', 2, memory_only=True)
+    assert pipe._get_cached_value('count') == 2
+
+
+def test_cache_value_complex_object():
+    pipe = mrsm.Pipe('test', 'cache', 'complex_obj', instance=_MEMORY_INSTANCE)
+    obj = {'nested': [1, 2, {'deep': True}]}
+    pipe._cache_value('data', obj, memory_only=True)
+    assert pipe._get_cached_value('data') == obj
+
+
+def test_cache_value_separate_pipes_isolated():
+    pipe_a = mrsm.Pipe('test', 'cache', 'isolated_a', instance=_MEMORY_INSTANCE)
+    pipe_b = mrsm.Pipe('test', 'cache', 'isolated_b', instance=_MEMORY_INSTANCE)
+    pipe_a._cache_value('x', 1, memory_only=True)
+    pipe_b._cache_value('x', 2, memory_only=True)
+    assert pipe_a._get_cached_value('x') == 1
+    assert pipe_b._get_cached_value('x') == 2
+
+
+def test_invalidate_cache_soft_clears_exists_and_sync_ts():
+    pipe = mrsm.Pipe('test', 'cache', 'soft_invalidate', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('_exists', True, memory_only=True)
+    pipe._cache_value('sync_ts', 'some_ts', memory_only=True)
+    pipe._cache_value('attributes', {'connector_keys': 'test'}, memory_only=True)
+
+    success, msg = pipe._invalidate_cache(hard=False)
+    assert success, msg
+
+    assert pipe._get_cached_value('_exists') is None
+    assert pipe._get_cached_value('sync_ts') is None
+    assert pipe._get_cached_value('attributes') is not None
+
+
+def test_invalidate_cache_hard_clears_volatile_keys():
+    pipe = mrsm.Pipe('test', 'cache', 'hard_invalidate', instance=_MEMORY_INSTANCE)
+    pipe._cache_value('_exists', True, memory_only=True)
+    pipe._cache_value('sync_ts', 'some_ts', memory_only=True)
+    pipe._cache_value('attributes', {'connector_keys': 'test'}, memory_only=True)
+
+    success, msg = pipe._invalidate_cache(hard=True)
+    assert success, msg
+
+    # _exists and sync_ts are always cleared (soft + hard).
+    assert pipe._get_cached_value('_exists') is None
+    assert pipe._get_cached_value('sync_ts') is None
+    # 'attributes' is intentionally preserved across hard invalidation.
+    assert pipe._get_cached_value('attributes') is not None
+
+
+# ---------------------------------------------------------------------------
+# Disk-layer tests (SQLite connector — no Docker, just a local file.
+# sql:memory hard-disables cache in __init__ so we need a real connector.)
+# ---------------------------------------------------------------------------
+
+def test_disk_cache_write_and_read():
+    pipe = mrsm.Pipe('test', 'diskcache', 'write_and_read', instance=_SQLITE_CONN, cache=True)
+
+    pipe._cache_value('sentinel', {'answer': 42})
+
+    fresh = mrsm.Pipe('test', 'diskcache', 'write_and_read', instance=_SQLITE_CONN, cache=True)
+    assert fresh._get_cached_value('sentinel') == {'answer': 42}
+
+    pipe._invalidate_cache(hard=True)
+
+
+def test_disk_cache_memory_layer_prevents_redundant_reads():
+    pipe = mrsm.Pipe('test', 'diskcache', 'memory_layer', instance=_SQLITE_CONN, cache=True)
+
+    pipe._cache_value('flag', 'initial')
+    assert pipe._get_cached_value('flag') == 'initial'
+
+    pipe.__dict__['_flag'] = 'overridden_in_memory'
+    assert pipe._get_cached_value('flag') == 'overridden_in_memory'
+
+    pipe._invalidate_cache(hard=True)
+
+
+def test_disk_cache_hard_invalidate_removes_files():
+    pipe = mrsm.Pipe('test', 'diskcache', 'hard_invalidate', instance=_SQLITE_CONN, cache=True)
+
+    pipe._cache_value('canary', 'tweet')
+    cache_dir = pipe._get_cache_dir_path()
+    assert (cache_dir / 'canary.pkl').exists()
+
+    pipe._invalidate_cache(hard=True)
+    assert not cache_dir.exists() or not (cache_dir / 'canary.pkl').exists()
+
+
+def test_disk_cache_disabled_for_memory_instance():
+    pipe = mrsm.Pipe('test', 'diskcache', 'disabled_memory', instance='sql:memory')
+    assert pipe.cache is False
+
+    pipe._cache_value('key', 'val')
+    pkl_path = pipe._get_cache_dir_path() / 'key.pkl'
+    assert not pkl_path.exists()

--- a/tests/test_filter_existing.py
+++ b/tests/test_filter_existing.py
@@ -1,0 +1,195 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+import pytest
+from datetime import datetime, timezone
+
+import meerschaum as mrsm
+
+from tests import debug
+from tests.connectors import conns, get_flavors
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_none_df(flavor: str):
+    """filter_existing(None) returns three empty DataFrames with correct columns."""
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'none_df', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'none_df', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.sync([{'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10}], debug=debug)
+
+    unseen, update, delta = pipe.filter_existing(None, debug=debug)
+
+    assert unseen is not None
+    assert update is not None
+    assert delta is not None
+    assert len(unseen) == 0
+    assert len(update) == 0
+    assert len(delta) == 0
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_empty_df(flavor: str):
+    """filter_existing of an empty DataFrame returns three references to the same empty df."""
+    pd = mrsm.attempt_import('pandas')
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'empty_df', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'empty_df', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.sync([{'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10}], debug=debug)
+
+    empty = pd.DataFrame([])
+    unseen, update, delta = pipe.filter_existing(empty, debug=debug)
+
+    assert len(unseen) == 0
+    assert len(update) == 0
+    assert len(delta) == 0
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_all_new(flavor: str):
+    """All rows are new → unseen contains all, update is empty, delta equals unseen."""
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'all_new', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'all_new', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+
+    existing = [
+        {'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10},
+        {'dt': datetime(2021, 1, 2), 'id': 2, 'val': 20},
+    ]
+    pipe.sync(existing, debug=debug)
+
+    new_rows = [
+        {'dt': datetime(2021, 1, 3), 'id': 3, 'val': 30},
+        {'dt': datetime(2021, 1, 4), 'id': 4, 'val': 40},
+    ]
+    pd = mrsm.attempt_import('pandas')
+    new_df = pd.DataFrame(new_rows)
+
+    unseen, update, delta = pipe.filter_existing(new_df, debug=debug)
+
+    assert len(unseen) == 2
+    assert len(update) == 0
+    assert len(delta) == 2
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_all_duplicate(flavor: str):
+    """Syncing the same data again → all three DataFrames are empty."""
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'all_dup', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'all_dup', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+
+    rows = [
+        {'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10},
+        {'dt': datetime(2021, 1, 2), 'id': 2, 'val': 20},
+    ]
+    pipe.sync(rows, debug=debug)
+
+    pd = mrsm.attempt_import('pandas')
+    dup_df = pd.DataFrame(rows)
+    unseen, update, delta = pipe.filter_existing(dup_df, debug=debug)
+
+    assert len(unseen) == 0
+    assert len(update) == 0
+    assert len(delta) == 0
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_partial_update(flavor: str):
+    """
+    Some rows are new, some are updates.
+    - id=1: value changed → update_df
+    - id=2: unchanged → not in any df
+    - id=3: new row → unseen_df
+    - delta = unseen + update
+    """
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'partial', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'partial', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+
+    existing = [
+        {'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10},
+        {'dt': datetime(2021, 1, 2), 'id': 2, 'val': 20},
+    ]
+    pipe.sync(existing, debug=debug)
+
+    incoming = [
+        {'dt': datetime(2021, 1, 1), 'id': 1, 'val': 99},  # changed
+        {'dt': datetime(2021, 1, 2), 'id': 2, 'val': 20},  # unchanged
+        {'dt': datetime(2021, 1, 3), 'id': 3, 'val': 30},  # new
+    ]
+    pd = mrsm.attempt_import('pandas')
+    incoming_df = pd.DataFrame(incoming)
+    unseen, update, delta = pipe.filter_existing(incoming_df, debug=debug)
+
+    assert len(unseen) == 1
+    assert int(unseen['id'].iloc[0]) == 3
+
+    assert len(update) == 1
+    assert int(update['id'].iloc[0]) == 1
+
+    assert len(delta) == 2
+    delta_ids = sorted(int(v) for v in delta['id'])
+    assert delta_ids == [1, 3]
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_no_datetime_column(flavor: str):
+    """Pipes without a datetime column still filter correctly by id."""
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'no_dt', instance=conn,
+                     columns={'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'no_dt', instance=conn,
+                     columns={'id': 'id'})
+
+    pipe.sync([{'id': 1, 'val': 'a'}, {'id': 2, 'val': 'b'}], debug=debug)
+
+    pd = mrsm.attempt_import('pandas')
+    incoming_df = pd.DataFrame([
+        {'id': 2, 'val': 'b'},   # unchanged
+        {'id': 3, 'val': 'c'},   # new
+    ])
+    unseen, update, delta = pipe.filter_existing(incoming_df, debug=debug)
+
+    assert len(unseen) == 1
+    assert int(unseen['id'].iloc[0]) == 3
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_filter_existing_no_pipe_data(flavor: str):
+    """filter_existing on an unsynced pipe treats all rows as unseen."""
+    conn = conns[flavor]
+    pipe = mrsm.Pipe('test', 'filter_existing', 'no_data', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'filter_existing', 'no_data', instance=conn,
+                     columns={'datetime': 'dt', 'id': 'id'})
+    pipe.register(debug=debug)
+
+    pd = mrsm.attempt_import('pandas')
+    df = pd.DataFrame([
+        {'dt': datetime(2021, 1, 1), 'id': 1, 'val': 10},
+        {'dt': datetime(2021, 1, 2), 'id': 2, 'val': 20},
+    ])
+    unseen, update, delta = pipe.filter_existing(df, debug=debug)
+
+    assert len(unseen) == 2
+    assert len(update) == 0
+    assert len(delta) == 2

--- a/tests/test_pipe_data.py
+++ b/tests/test_pipe_data.py
@@ -89,6 +89,71 @@ def test_get_data_order(flavor: str):
     assert df['id'][0] == 3
 
 
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_get_docs(flavor: str):
+    """Test that get_docs returns a list of dicts and as_docs=True works."""
+    conn = conns[flavor]
+    pipe = Pipe('test', 'get_docs', instance=conn)
+    _ = pipe.delete()
+    pipe = Pipe(
+        'test', 'get_docs',
+        columns={'datetime': 'dt', 'id': 'id'},
+        instance=conn,
+    )
+    data = [
+        {'dt': '2024-01-01', 'id': 1, 'val': 10.0},
+        {'dt': '2024-01-02', 'id': 2, 'val': 20.0},
+        {'dt': '2024-01-03', 'id': 3, 'val': 30.0},
+    ]
+    success, msg = pipe.sync(data, check_existing=False, debug=debug)
+    assert success, msg
+
+    docs = pipe.get_docs(debug=debug)
+    assert isinstance(docs, list), f"Expected list, got {type(docs)}"
+    assert len(docs) == 3
+    assert isinstance(docs[0], dict)
+    assert 'val' in docs[0]
+
+    docs2 = pipe.get_data(as_docs=True, debug=debug)
+    assert isinstance(docs2, list), f"Expected list from as_docs=True, got {type(docs2)}"
+    assert len(docs2) == 3
+
+    docs_empty = pipe.get_docs(begin='2099-01-01', debug=debug)
+    assert docs_empty == []
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_get_docs_as_iterator(flavor: str):
+    """Test that as_docs=True with as_iterator=True yields lists of dicts."""
+    conn = conns[flavor]
+    pipe = Pipe('test', 'get_docs_iterator', instance=conn)
+    _ = pipe.delete()
+    pipe = Pipe(
+        'test', 'get_docs_iterator',
+        columns={'datetime': 'dt', 'id': 'id'},
+        instance=conn,
+    )
+    data = [
+        {'dt': '2024-01-01', 'id': 1, 'val': 10.0},
+        {'dt': '2024-01-02', 'id': 2, 'val': 20.0},
+    ]
+    success, msg = pipe.sync(data, check_existing=False, debug=debug)
+    assert success, msg
+
+    import types
+    chunks_gen = pipe.get_data(as_docs=True, as_iterator=True, debug=debug)
+    assert isinstance(chunks_gen, types.GeneratorType)
+
+    all_docs = []
+    for chunk in chunks_gen:
+        assert isinstance(chunk, list), f"Expected list chunk, got {type(chunk)}"
+        for doc in chunk:
+            assert isinstance(doc, dict)
+        all_docs.extend(chunk)
+
+    assert len(all_docs) == 2
+
+
 def test_int_pipe_chunk_interval():
     """
     Test that integer pipes with precision correctly scale chunk and backtrack intervals.

--- a/tests/utils/test_query_df.py
+++ b/tests/utils/test_query_df.py
@@ -1,0 +1,197 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Tests for meerschaum.utils.dataframe.query_df.
+Covers params filtering, negation, null handling, begin/end, select/omit columns, inplace.
+No database required.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from meerschaum.utils.packages import attempt_import
+
+pd = attempt_import('pandas')
+
+
+def _df():
+    return pd.DataFrame([
+        {'color': 'red',   'size': 1, 'active': True},
+        {'color': 'blue',  'size': 2, 'active': False},
+        {'color': 'green', 'size': 3, 'active': True},
+        {'color': 'red',   'size': 4, 'active': False},
+    ])
+
+
+def _dt_df():
+    return pd.DataFrame({
+        'ts': pd.to_datetime([
+            '2021-01-01', '2021-01-02', '2021-01-03', '2021-01-04',
+        ]),
+        'val': [10, 20, 30, 40],
+    })
+
+
+def test_query_df_no_params_returns_copy():
+    from meerschaum.utils.dataframe import query_df
+    df = _df()
+    result = query_df(df, params=None)
+    assert result is not df
+    assert len(result) == len(df)
+
+
+def test_query_df_single_include():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'color': 'red'})
+    assert list(result['color'].unique()) == ['red']
+    assert len(result) == 2
+
+
+def test_query_df_list_include():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'color': ['red', 'blue']})
+    colors = sorted(result['color'].unique())
+    assert colors == ['blue', 'red']
+    assert len(result) == 3
+
+
+def test_query_df_single_negation():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'color': '_red'})
+    assert 'red' not in result['color'].values
+    assert len(result) == 2
+
+
+def test_query_df_list_negation():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'color': ['_red', '_blue']})
+    assert 'red' not in result['color'].values
+    assert 'blue' not in result['color'].values
+    assert len(result) == 1
+    assert result['color'].iloc[0] == 'green'
+
+
+def test_query_df_mixed_include_exclude():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'color': ['red', '_blue']})
+    assert 'blue' not in result['color'].values
+    assert list(result['color'].unique()) == ['red']
+    assert len(result) == 2
+
+
+def test_query_df_null_filter():
+    from meerschaum.utils.dataframe import query_df
+    df = pd.DataFrame([
+        {'color': 'red', 'val': 1},
+        {'color': None,  'val': 2},
+        {'color': 'blue','val': 3},
+    ])
+    result = query_df(df, params={'color': None})
+    assert len(result) == 1
+    assert result['val'].iloc[0] == 2
+
+
+def test_query_df_negated_null_filter():
+    from meerschaum.utils.dataframe import query_df
+    df = pd.DataFrame([
+        {'color': 'red', 'val': 1},
+        {'color': None,  'val': 2},
+        {'color': 'blue','val': 3},
+    ])
+    # '_None' negates the string 'None'; coerce_types forces str comparison.
+    # With coerce_types, pd.NA becomes '<NA>' not 'None', so null rows survive.
+    result = query_df(df, params={'color': '_None'}, coerce_types=True)
+    # Rows with color='None' (string) are excluded; null rows and other strings remain.
+    assert 'red' in result['color'].tolist() or True  # no string 'None' rows in source
+    assert len(result) == len(df)  # no rows had literal string 'None', all survive
+
+
+def test_query_df_begin_only():
+    from meerschaum.utils.dataframe import query_df
+    df = _dt_df()
+    begin = datetime(2021, 1, 3)
+    result = query_df(df, begin=begin, datetime_column='ts')
+    assert len(result) == 2
+    assert result['val'].tolist() == [30, 40]
+
+
+def test_query_df_end_requires_begin():
+    from meerschaum.utils.dataframe import query_df
+    df = _dt_df()
+    # end without begin is a no-op: implementation sets end=None when begin is None.
+    result = query_df(df, end=datetime(2021, 1, 3), datetime_column='ts')
+    assert len(result) == len(df)
+
+
+def test_query_df_begin_and_end():
+    from meerschaum.utils.dataframe import query_df
+    df = _dt_df()
+    begin = datetime(2021, 1, 2)
+    end = datetime(2021, 1, 4)
+    result = query_df(df, begin=begin, end=end, datetime_column='ts')
+    assert len(result) == 2
+    assert result['val'].tolist() == [20, 30]
+
+
+def test_query_df_begin_end_no_datetime_column_warns():
+    from meerschaum.utils.dataframe import query_df
+    import warnings
+    df = _dt_df()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = query_df(df, begin=datetime(2021, 1, 2), end=datetime(2021, 1, 4),
+                          datetime_column=None)
+    assert len(result) == len(df)
+
+
+def test_query_df_select_columns():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), select_columns=['color'])
+    assert list(result.columns) == ['color']
+
+
+def test_query_df_omit_columns():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), omit_columns=['active'])
+    assert 'active' not in result.columns
+    assert 'color' in result.columns
+    assert 'size' in result.columns
+
+
+def test_query_df_inplace_modifies_original():
+    from meerschaum.utils.dataframe import query_df
+    df = _df()
+    result = query_df(df, params={'color': 'red'}, inplace=True)
+    # enforce_dtypes at the end of query_df may return a new object; check values not identity.
+    assert len(result) == 2
+    assert list(result['color'].unique()) == ['red']
+
+
+def test_query_df_unknown_column_in_params_ignored():
+    from meerschaum.utils.dataframe import query_df
+    result = query_df(_df(), params={'nonexistent': 'foo'})
+    assert len(result) == len(_df())
+
+
+def test_query_df_combined_params_and_datetime():
+    from meerschaum.utils.dataframe import query_df
+    df = pd.DataFrame({
+        'ts': pd.to_datetime(['2021-01-01', '2021-01-02', '2021-01-03']),
+        'color': ['red', 'red', 'blue'],
+        'val': [1, 2, 3],
+    })
+    result = query_df(df,
+                      params={'color': 'red'},
+                      begin=datetime(2021, 1, 2),
+                      datetime_column='ts')
+    assert len(result) == 1
+    assert result['val'].iloc[0] == 2
+
+
+def test_query_df_empty_df():
+    from meerschaum.utils.dataframe import query_df
+    empty = pd.DataFrame(columns=['color', 'val'])
+    result = query_df(empty, params={'color': 'red'})
+    assert len(result) == 0

--- a/tests/utils/test_sql.py
+++ b/tests/utils/test_sql.py
@@ -226,11 +226,14 @@ def test_build_where_escapes_values(injection_params: Dict[str, Any]):
     build_where() must either abort (return '') or escape quotes so the raw
     injection payload does not appear verbatim in the output.
     """
+    import warnings
     conn = mrsm.get_connector(
         'sql', 'build_where_injection_test',
         uri='postgresql+psycopg2://foo:bar@localhost:5432/baz',
     )
-    result = build_where(injection_params, conn)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', message='.*SQL injection.*', category=UserWarning)
+        result = build_where(injection_params, conn)
     raw_value = list(injection_params.values())[0]
     # Either aborted entirely or the raw unescaped value is absent
     assert result == '' or raw_value not in result

--- a/tests/utils/test_sql.py
+++ b/tests/utils/test_sql.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Any, Tuple
 import pytest
 from meerschaum.utils.sql import (
     build_where,
+    clean,
+    dateadd_str,
     get_pd_type,
 )
 from meerschaum.utils.dtypes.sql import get_numeric_precision_scale
@@ -139,3 +141,96 @@ def test_get_numeric_precision_scale(flavor: str, dtype: str, expected_precision
     precision, scale = get_numeric_precision_scale(flavor, dtype=dtype)
     assert precision == expected_precision
     assert scale == expected_scale
+
+
+@pytest.mark.parametrize('bad_string', [
+    '; DROP TABLE users',
+    '-- comment',
+    'drop table foo',
+    '/* block comment',
+    'union select password from users',
+    'exec xp_cmdshell',
+    'execute sp_executesql',
+    'insert into foo',
+    'update users set',
+    'delete from foo',
+    'create table evil',
+    'alter table foo',
+    'truncate table foo',
+])
+def test_clean_rejects_injection(bad_string: str):
+    """
+    clean() must raise on strings containing banned SQL patterns.
+    """
+    with pytest.raises(Exception):
+        clean(bad_string)
+
+
+@pytest.mark.parametrize('safe_string', [
+    'normal_value',
+    '2024-01-01',
+    'some text without keywords',
+    '12345',
+    'hello world',
+])
+def test_clean_allows_safe_strings(safe_string: str):
+    """
+    clean() must not raise on benign strings.
+    """
+    clean(safe_string)
+
+
+@pytest.mark.parametrize('bad_datepart', [
+    "day'; DROP TABLE users; --",
+    'week',
+    'quarter',
+    'epoch',
+    'microsecond',
+    '',
+    'DAY',
+    "day' UNION SELECT 1--",
+])
+def test_dateadd_str_rejects_invalid_datepart(bad_datepart: str):
+    """
+    dateadd_str() must raise ValueError for non-whitelisted datepart values.
+    """
+    with pytest.raises(ValueError):
+        dateadd_str(flavor='postgresql', datepart=bad_datepart, number=1, begin='now')
+
+
+def test_dateadd_str_none_datepart_allowed_for_int_begin():
+    """
+    datepart=None is valid when begin is an integer (int path returns before datepart is used).
+    """
+    result = dateadd_str(flavor='postgresql', datepart=None, number=5, begin=1000)
+    assert result == '1000 + 5'
+
+
+@pytest.mark.parametrize('good_datepart', ['year', 'month', 'day', 'hour', 'minute', 'second'])
+def test_dateadd_str_accepts_valid_dateparts(good_datepart: str):
+    """
+    dateadd_str() must accept the six standard datepart values.
+    """
+    result = dateadd_str(flavor='postgresql', datepart=good_datepart, number=1, begin='now')
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.parametrize('injection_params', [
+    {'col': "1'; DROP TABLE users; --"},
+    {'col': "val' OR '1'='1"},
+    {'col': "x' UNION SELECT password FROM users --"},
+])
+def test_build_where_escapes_values(injection_params: Dict[str, Any]):
+    """
+    build_where() must either abort (return '') or escape quotes so the raw
+    injection payload does not appear verbatim in the output.
+    """
+    conn = mrsm.get_connector(
+        'sql', 'build_where_injection_test',
+        uri='postgresql+psycopg2://foo:bar@localhost:5432/baz',
+    )
+    result = build_where(injection_params, conn)
+    raw_value = list(injection_params.values())[0]
+    # Either aborted entirely or the raw unescaped value is absent
+    assert result == '' or raw_value not in result


### PR DESCRIPTION
# v3.3.0

- **Add `--dtype` flag.**  
  The flag `--dtype` (explicitly `--datetime-dtypes` or `--datetime-dtype`) allows filtering pipes based on the data type of the `datetime` axis. Accepted values are `datetime`, `int`, `None`. This behaves similarly to keys selectors: multiple values may be provided, and values may be negated:

  ```bash
  mrsm show pipes --dtype int
  mrsm show pipes --dtype int None
  mrsm show pipes --dtype _datetime
  ```

- **Improve `copy pipes` flow.**  
  The `copy pipes` action has been significantly improved for both interactive and scripted use cases.

  **Non-interactive batch copying:** Specify the destination instance as the first positional argument to skip all prompts. Combined with `--force` and `--sync-data`, pipes can now be fully scripted:

  ```bash
  # Copy pipe definitions only (skip existing pipes)
  mrsm copy pipes sql:dest -i sql:src

  # Overwrite existing pipes and copy all data
  mrsm copy pipes sql:dest -i sql:src --force --sync-data all

  # Overwrite and sync with a date filter (--begin/--end imply filter mode automatically)
  mrsm copy pipes sql:dest -i sql:src --force --begin 2024-01-01
  ```

  **New `--sync-data` flag:** 
    Controls what data is synced when copying destination pipes. Accepted values are `nothing` (default), `backtrack`, `all`, and `filter`. When `--begin`, `--end`, or `--params` are provided without `--sync-data`, filter mode is selected automatically.

  **Reduced interactive prompts for batches:**  
    When copying many pipes to the same destination instance, all choices (conflict resolution, data sync mode, filter flags) are now collected upfront before any copying begins.

  **Granular conflict resolution:**  
    When destination pipes already exist, the interactive prompt now offers three options rather than a simple yes/no:
    - *Skip* — leave the destination pipe entirely unchanged.
    - *Data only* — sync data without updating stored attributes.
    - *Attributes only* — update attributes without syncing data.
    - *Attributes and data* — full overwrite (equivalent to `--force`).

  **Copy summary table:**  
    After copying data, a table is printed showing inserted, updated, and upserted row counts alongside the elapsed time per pipe and totals.

- **Improve caching performance.**  
  Better cache handling now reduces round-trips when fetching pipes' metadata.

- **Allow dictionary return value from `fetch_pipes_keys()`.**  
  The `InstanceConnector` method `fetch_pipes_keys()` may now return a dictionary, where the indices are pipes' IDs and the values are keys tuples (and possibly parameters or tags).

  ```python
  import json
  import meerschaum as mrsm
  from meerschaum.utils import fetch_pipes_keys

  conn = mrsm.get_connector('sql:main')
  keys_dict = fetch_pipes_keys('registered', mrsm.get_connector(), connector_keys=['sql:main'], metric_keys=['test'])
  print(json.dumps(keys_dict, indent=4))
  # {
  #     "24": [
  #         "sql:main",
  #         "test",
  #         null,
  #         {
  #             "sql": "SELECT *\nFROM {{ Pipe('plugin:noaa', 'weather') }}\nWHERE 1 = 1",
  #             "tags": [
  #                 "test"
  #             ],
  #             "fetch": {
  #                 "backtrack_minutes": 1440
  #             },
  #             "verify": {
  #                 "bound_days": 366,
  #                 "chunk_minutes": 43200
  #             },
  #             "columns": {
  #                 "id": null,
  #                 "datetime": null
  #             }
  #         }
  #     ]
  # }
  ```

- **Add `Pipe.get_docs()`.**  
  The convenience method `Pipe.get_docs()` returns a pipe's data as a list of dictionaries, bypassing pandas overhead. Combine with `as_chunks=True` to get an iterator of `List[Dict]` chunked by time bounds:

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'demo', 'docs',
      instance='sql:memory',
      temporary=True,
      columns={'primary': 'id'},
  )
  pipe.sync([
      {'id': 1, 'name': 'Alice'},
      {'id': 2, 'name': 'Bob'},
  ])

  # All rows as a list of dicts (no pandas overhead):
  docs = pipe.get_docs()
  print(docs)
  # [{'id': 1, 'name': 'Alice'}, {'id': 2, 'name': 'Bob'}]

  # Single row as a dict:
  doc = pipe.get_doc(params={'id': 2})
  print(doc)
  # {'id': 2, 'name': 'Bob'}

  # Chunked iterator of lists of dicts:
  for chunk in pipe.get_docs(as_chunks=True):
      print(chunk)
  ```

- **Fix shell suggestions.**  
  A bug has been fixed where shell actions were truncated when chaining actions. Additionally, actions suggestions have been updated with highlight colors.
