### PR TITLE
🐛 v3.4.5 Invalidate cached plugins package on scope change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.5
+
+- **Fix a breaking bug in `bootstrap plugin`.**  
+  A bug in `package_venv()` has been fixed, unblocking `bootstrap plugin`.
+
+- **Fix warning bug on shell launch.**  
+  The plugin updater thread was throwing a login warning for `api:mrsm`; this warning has been surpressed.
+
+- **Require `importlib_metadata` when starting the API.**  
+  Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Require `importlib_metadata` when starting the API.**  
   Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
 
+- **Fix plugins environment scope for `compose`.**  
+  The `plugins` namespace scope has been fixed to harden the isolation of `compose`.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/docs/zensical/llms-full.txt
+++ b/docs/zensical/llms-full.txt
@@ -8241,6 +8241,17 @@ Source: https://meerschaum.io/news/changelog/
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.5
+
+- **Fix a breaking bug in `bootstrap plugin`.**  
+  A bug in `package_venv()` has been fixed, unblocking `bootstrap plugin`.
+
+- **Fix warning bug on shell launch.**  
+  The plugin updater thread was throwing a login warning for `api:mrsm`; this warning has been surpressed.
+
+- **Require `importlib_metadata` when starting the API.**  
+  Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/docs/zensical/llms-full.txt
+++ b/docs/zensical/llms-full.txt
@@ -8252,6 +8252,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Require `importlib_metadata` when starting the API.**  
   Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
 
+- **Fix plugins environment scope for `compose`.**  
+  The `plugins` namespace scope has been fixed to harden the isolation of `compose`.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -4,6 +4,17 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.5
+
+- **Fix a breaking bug in `bootstrap plugin`.**  
+  A bug in `package_venv()` has been fixed, unblocking `bootstrap plugin`.
+
+- **Fix warning bug on shell launch.**  
+  The plugin updater thread was throwing a login warning for `api:mrsm`; this warning has been surpressed.
+
+- **Require `importlib_metadata` when starting the API.**  
+  Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -15,6 +15,9 @@ This is the current release cycle, so stay tuned for future releases!
 - **Require `importlib_metadata` when starting the API.**  
   Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.
 
+- **Fix plugins environment scope for `compose`.**  
+  The `plugins` namespace scope has been fixed to harden the isolation of `compose`.
+
 ### v3.4.3 – v3.4.4
 
 - **Add a plugin version API endpoint.**  

--- a/meerschaum/api/__init__.py
+++ b/meerschaum/api/__init__.py
@@ -42,12 +42,14 @@ uv = attempt_import('uv', lazy=False, check_update=CHECK_UPDATE)
     starlette_responses,
     multipart,
     packaging_version,
+    importlib_metadata,
 ) = attempt_import(
     'fastapi',
     'aiofiles',
     'starlette.responses',
     'multipart',
     'packaging.version',
+    'importlib_metadata',
     lazy=False,
     check_update=CHECK_UPDATE,
 )

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.4.4"
+__version__ = "3.4.5"

--- a/meerschaum/config/environment.py
+++ b/meerschaum/config/environment.py
@@ -269,6 +269,21 @@ def replace_env(env: Union[Dict[str, Any], None]):
         apply_environment_patches(env)
         apply_environment_uris(env)
 
+        ### The `plugins` package in `sys.modules` caches a `__path__` resolved
+        ### against the previous scope's `PLUGINS_RESOURCES_PATH`. If the root or
+        ### plugins-dir scope actually changed, drop that cache so the next plugin
+        ### import re-discovers plugins under the new scope (otherwise module-level
+        ### `from_plugin_import` of a sibling plugin fails with
+        ### "Unable to import plugin '<name>'" and connector-providing plugins
+        ### don't register their connectors).
+        plugins_scope_changed = (
+            (replaced_root and paths.ROOT_DIR_PATH != old_root_dir_path)
+            or (replaced_plugins and paths.PLUGINS_DIR_PATHS != old_plugins_dir_paths)
+        )
+        if plugins_scope_changed:
+            from meerschaum.plugins import invalidate_plugins_cache
+            invalidate_plugins_cache()
+
     try:
         yield
     finally:
@@ -300,3 +315,10 @@ def replace_env(env: Union[Dict[str, Any], None]):
 
             _config().clear()
             set_config(old_config)
+
+            ### Mirror the invalidation on exit: the scope is being restored,
+            ### so the `plugins` package cached during the temporary scope is
+            ### now the stale one.
+            if plugins_scope_changed:
+                from meerschaum.plugins import invalidate_plugins_cache
+                invalidate_plugins_cache()

--- a/meerschaum/connectors/api/_plugins.py
+++ b/meerschaum/connectors/api/_plugins.py
@@ -162,7 +162,7 @@ def get_plugin_version(
     """
     from meerschaum.utils.warnings import warn
     r_url = plugin_r_url(plugin) + '/version'
-    response = self.get(r_url, use_token=True, debug=debug)
+    response = self.get(r_url, use_token=(self.label != 'mrsm'), debug=debug)
     if not response:
         return None
     try:

--- a/meerschaum/plugins/__init__.py
+++ b/meerschaum/plugins/__init__.py
@@ -41,6 +41,7 @@ __all__ = (
     "web_page",
     "import_plugins",
     "from_plugin_import",
+    "invalidate_plugins_cache",
     "reload_plugins",
     "get_plugins",
     "get_data_plugins",
@@ -922,6 +923,40 @@ def unload_plugins(
                     file_symlink_path.unlink()
             except Exception:
                 pass
+
+
+def invalidate_plugins_cache() -> None:
+    """
+    Pop the cached `plugins` package and its submodules from `sys.modules`
+    and reset the loaded-plugins state.
+
+    The `plugins` package caches its `__path__` (the resolved
+    `PLUGINS_RESOURCES_PATH`) at import time. When the active root or
+    plugins-dir scope changes in-process (e.g. via
+    `meerschaum.config.environment.replace_env`), that stale `__path__`
+    makes subsequent plugin imports re-discover plugins under the previous
+    scope's `.internal/plugins` directory. Call this whenever the plugins
+    scope changes so the next import rebuilds against the current
+    `PLUGINS_RESOURCES_PATH`.
+    """
+    global _loaded_plugins, _synced_symlinks
+    import sys
+    import meerschaum.config.paths as paths
+
+    plugins_stem = paths.PLUGINS_RESOURCES_PATH.stem
+    module_prefix = plugins_stem + '.'
+    for mod_name in [
+        mod_name
+        for mod_name in sys.modules
+        if mod_name == plugins_stem or mod_name.startswith(module_prefix)
+    ]:
+        _ = sys.modules.pop(mod_name, None)
+
+    _loaded_plugins = False
+    ### Also reset the symlinks counter — it's per-scope state, and leaving it
+    ### >1 makes `sync_plugins_symlinks` skip creating the new scope's
+    ### `.internal/plugins` (so `plugins` imports as an empty namespace package).
+    _synced_symlinks = 0
 
 
 def reload_plugins(plugins: Optional[List[str]] = None, debug: bool = False) -> None:

--- a/meerschaum/utils/debug.py
+++ b/meerschaum/utils/debug.py
@@ -33,7 +33,7 @@ def dprint(
     leader: bool = True,
     timestamp: bool = True,
     package: bool = True,
-    color: Optional[Union[str, List[str]]] = None,
+    color: Optional[Union[str, List[str]], bool] = None,
     attrs: Optional[List[str]] = None,
     nopretty: bool = False,
     _progress: Optional['rich.progress.Progress'] = None,

--- a/meerschaum/utils/packages/__init__.py
+++ b/meerschaum/utils/packages/__init__.py
@@ -1853,7 +1853,7 @@ def package_venv(package: 'ModuleType') -> Union[str, None]:
     Inspect a package and return the virtual environment in which it presides.
     """
     import os
-    import meerschaum.confing.paths as paths
+    import meerschaum.config.paths as paths
     if str(paths.VIRTENV_RESOURCES_PATH) not in package.__file__:
         return None
     return package.__file__.split(str(paths.VIRTENV_RESOURCES_PATH))[1].split(os.path.sep)[1]

--- a/meerschaum/utils/packages/_packages.py
+++ b/meerschaum/utils/packages/_packages.py
@@ -56,6 +56,7 @@ packages: Dict[str, Dict[str, str]] = {
         'uv'                         : 'uv>=0.2.11',
         'pydantic'                   : 'pydantic>=2.11.7',
         'annotated-types'            : 'annotated-types>=0.7.0',
+        'importlib_metadata'         : 'importlib-metadata>=4.12.0',
     },
     '_internal'                      : {
         'apscheduler'                : (
@@ -128,7 +129,6 @@ packages: Dict[str, Dict[str, str]] = {
         'ruamel.yaml'                : 'ruamel.yaml>=0.16.12',
         'modin'                      : 'modin[ray]>=0.8.3',
         'nanoid'                     : 'nanoid>=2.0.0',
-        'importlib_metadata'         : 'importlib-metadata>=4.12.0',
     },
 }
 packages['sql'] = {

--- a/tests/test_plugins_scope.py
+++ b/tests/test_plugins_scope.py
@@ -1,0 +1,94 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+"""
+Regression tests for plugin loading across in-process scope switches
+(`meerschaum.config.environment.replace_env`).
+
+Before the fix, the `plugins` package lingered in `sys.modules` with a
+`__path__` pointing at the previous scope's `.internal/plugins`, so a plugin
+doing a module-level `from_plugin_import` of a sibling failed with
+"Unable to import plugin '<name>'" after a scope switch.
+"""
+
+import sys
+import pathlib
+
+import pytest
+
+import meerschaum as mrsm
+from meerschaum._internal.static import STATIC_CONFIG
+from meerschaum.config.environment import replace_env
+
+DEP_PLUGIN_SOURCE = """
+def get_value():
+    return 'scoped-dep-value'
+"""
+
+USER_PLUGIN_SOURCE = """
+from meerschaum.plugins import from_plugin_import
+
+get_value = from_plugin_import('plugins.scope_dep', 'get_value')
+
+def get_dep_value():
+    return get_value()
+"""
+
+
+@pytest.fixture
+def project_scope(tmp_path):
+    """Create a temporary root + plugins dir containing two sibling plugins."""
+    root_dir = tmp_path / 'root'
+    plugins_dir = tmp_path / 'project_plugins'
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / 'scope_dep.py').write_text(DEP_PLUGIN_SOURCE)
+    (plugins_dir / 'scope_user.py').write_text(USER_PLUGIN_SOURCE)
+    return {
+        STATIC_CONFIG['environment']['root']: str(root_dir),
+        STATIC_CONFIG['environment']['plugins']: str(plugins_dir),
+    }
+
+
+def _load_scope_plugins():
+    from meerschaum.plugins import sync_plugins_symlinks, load_plugins
+    sync_plugins_symlinks()
+    load_plugins(skip_if_loaded=False)
+
+
+def test_replace_env_invalidates_plugins_cache(project_scope):
+    """
+    Entering and exiting `replace_env` with a different root/plugins-dir
+    must drop the cached `plugins` package from `sys.modules`.
+    """
+    import meerschaum.config.paths as paths
+    plugins_stem = paths.PLUGINS_RESOURCES_PATH.stem
+
+    with replace_env(project_scope):
+        assert plugins_stem not in sys.modules
+        _load_scope_plugins()
+        plugins_mod = sys.modules.get(plugins_stem)
+        assert plugins_mod is not None
+        assert str(paths.PLUGINS_RESOURCES_PATH) in [
+            str(pathlib.Path(path_str)) for path_str in plugins_mod.__path__
+        ]
+
+    ### On exit, the package cached under the project scope must be gone.
+    assert plugins_stem not in sys.modules
+
+
+def test_sibling_plugin_import_after_scope_switch(project_scope):
+    """
+    A plugin doing a module-level `from_plugin_import` of a sibling must be
+    importable after switching scopes (the original `mrsm compose` failure).
+    """
+    with replace_env(project_scope):
+        _load_scope_plugins()
+
+    ### Re-enter the scope (like a second compose subaction) — before the fix,
+    ### submodule discovery walked the stale scope's directory.
+    with replace_env(project_scope):
+        _load_scope_plugins()
+        plugin = mrsm.Plugin('scope_user')
+        assert plugin.module is not None, "Unable to import plugin 'scope_user'."
+        assert plugin.module.get_dep_value() == 'scoped-dep-value'


### PR DESCRIPTION
# v3.4.5

- **Fix a breaking bug in `bootstrap plugin`.**  
  A bug in `package_venv()` has been fixed, unblocking `bootstrap plugin`.

- **Fix warning bug on shell launch.**  
  The plugin updater thread was throwing a login warning for `api:mrsm`; this warning has been surpressed.

- **Require `importlib_metadata` when starting the API.**  
  Some `dash` dependencies require the legacy `importlib_metadata`, so this behavior has been accounted for.

- **Fix plugins environment scope for `compose`.**  
  The `plugins` namespace scope has been fixed to harden the isolation of `compose`.
