### PR TITLE
🐛 v3.4.6 Derive venvs path from root when MRSM_VENVS_DIR is unset

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: release
+description: Meerschaum release process — bump version, update changelog, stage dev→main PR, run CI, publish to PyPI, tag, GitHub release, build/push Docker images, rebuild docs on prod VPS. Use when cutting a new Meerschaum release or preparing a release PR.
+---
+
+# Meerschaum Release Process
+
+Follow these steps in order. The finished state: version bumped in `meerschaum/config/_version.py`, PR merged into `main` with CI passing, git tag pushed, GitHub release created, package on PyPI, Docker images on DockerHub, docs rebuilt on prod.
+
+## 1. Bump version
+
+Edit `meerschaum/config/_version.py` (`__version__ = "X.Y.Z"`).
+
+## 2. Update the changelog
+
+Edit `docs/zensical/news/changelog.md` (the source of truth — root `CHANGELOG.md` is generated from it by `scripts/docs.sh`, which `scripts/build.sh` calls). Follow the existing style exactly:
+
+- New `### vX.Y.Z` heading under the current release-cycle `##` section, above the previous version.
+- One bullet per change: `- **Bolded title ending with a period.**` followed by **two trailing spaces** (markdown line break), then an indented explanation paragraph on the next line.
+- Code blocks and examples are fine inside a bullet's explanation (indented to match).
+
+Do NOT hand-edit root `CHANGELOG.md`; it's overwritten by the build.
+
+## 3. Stage the release branch and PR
+
+`dev` is recreated fresh from `main` for each release:
+
+```bash
+git checkout main && git pull
+git branch -D dev
+git checkout -b dev
+# ...commit release changes (version bump, changelog, fixes)...
+```
+
+Before the final commit, run `./scripts/build.sh` — it may update `requirements/*.txt` and regenerate `CHANGELOG.md`; commit those too.
+
+Push and open a PR from `dev` to `main`:
+
+- **Title:** relevant gitmoji + version + short summary, e.g. `🐛 v3.4.6 Derive venvs path from root when MRSM_VENVS_DIR is unset`.
+- **Body:** the changelog notes for this version verbatim, except the version heading uses one `#` instead of `###`.
+
+## 4. CI
+
+The PR triggers `.github/workflows/pytest.yaml` on a self-hosted runner (`~/actions-runner/run.sh` on this machine). It runs `./scripts/test.sh db` with `MRSM_TEST_FLAVORS=all` against the databases in `tests/docker-compose.yaml`.
+
+If tests fail unexpectedly (stale DB state), reset the test databases:
+
+```bash
+cd tests/
+docker compose down -v
+docker compose up -d
+```
+
+Never run two test.sh invocations concurrently (shared `test_root` + API port 8989).
+
+## 5. Merge, build, publish to PyPI
+
+Once CI is green and the PR is merged:
+
+```bash
+git checkout main && git pull
+./scripts/build.sh          # cleans, builds docs, regenerates requirements, builds wheel + sdist into dist/
+```
+
+Publish (token in `.env` as `PYPI_TOKEN`):
+
+```bash
+source .env
+TWINE_USERNAME=__token__ TWINE_PASSWORD="$PYPI_TOKEN" twine upload dist/*
+```
+
+## 6. Tag and GitHub release
+
+```bash
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+Create a GitHub release for the tag (`gh release create vX.Y.Z --title "<same as PR title>" --notes-file <notes>`). The release description = the PR body = the changelog notes, with the version heading demoted to a single `#`.
+
+## 7. Prod VPS: Docker images and docs
+
+```bash
+ssh -p 2269 meerschaum@mrsm.io
+cd ~/docs/Meerschaum
+git pull
+./scripts/docker/buildx.sh --push   # build multi-arch Docker images and push to DockerHub
+./scripts/build.sh                  # rebuild on Ubuntu/older Python (catches last-minute bugs); calls docs.sh which rebuilds the website docs
+```
+
+Optionally run `./scripts/setup.sh` (locally and on the VPS) to ensure latest dev packages before building.
+
+## Checklist
+
+- [ ] `meerschaum/config/_version.py` bumped
+- [ ] `docs/zensical/news/changelog.md` updated (style matched)
+- [ ] `./scripts/build.sh` run before final commit (requirements + CHANGELOG.md regenerated)
+- [ ] PR `dev` → `main`, gitmoji title, changelog-verbatim body, CI green, merged
+- [ ] Wheel/sdist built from `main` and uploaded to PyPI via twine
+- [ ] `vX.Y.Z` tag pushed; GitHub release created with same notes
+- [ ] Docker images built and pushed from prod VPS
+- [ ] Docs rebuilt on prod VPS

--- a/.gitignore
+++ b/.gitignore
@@ -146,4 +146,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .aider*
-.claude/
+.claude/*
+!.claude/skills/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.6
+
+- **Fix venvs path not following `set_root()`.**  
+  When `MRSM_VENVS_DIR` is unset, `VIRTENV_RESOURCES_PATH` now derives from `ROOT_DIR_PATH` dynamically, so in-process root swaps (e.g. `compose` running custom actions under `replace_root_dir()`) activate venvs from `{root}/venvs` — matching where subprocess-mode commands like `install required` install packages. Previously the path was frozen at import time, so custom plugin actions run through `compose` could not import their own `required` dependencies.
+
 ### v3.4.5
 
 - **Fix a breaking bug in `bootstrap plugin`.**  

--- a/docs/zensical/llms-full.txt
+++ b/docs/zensical/llms-full.txt
@@ -8241,6 +8241,11 @@ Source: https://meerschaum.io/news/changelog/
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.6
+
+- **Fix venvs path not following `set_root()`.**  
+  When `MRSM_VENVS_DIR` is unset, `VIRTENV_RESOURCES_PATH` now derives from `ROOT_DIR_PATH` dynamically, so in-process root swaps (e.g. `compose` running custom actions under `replace_root_dir()`) activate venvs from `{root}/venvs` — matching where subprocess-mode commands like `install required` install packages. Previously the path was frozen at import time, so custom plugin actions run through `compose` could not import their own `required` dependencies.
+
 ### v3.4.5
 
 - **Fix a breaking bug in `bootstrap plugin`.**  

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -4,6 +4,11 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.4.6
+
+- **Fix venvs path not following `set_root()`.**  
+  When `MRSM_VENVS_DIR` is unset, `VIRTENV_RESOURCES_PATH` now derives from `ROOT_DIR_PATH` dynamically, so in-process root swaps (e.g. `compose` running custom actions under `replace_root_dir()`) activate venvs from `{root}/venvs` — matching where subprocess-mode commands like `install required` install packages. Previously the path was frozen at import time, so custom plugin actions run through `compose` could not import their own `required` dependencies.
+
 ### v3.4.5
 
 - **Fix a breaking bug in `bootstrap plugin`.**  

--- a/meerschaum/config/_paths.py
+++ b/meerschaum/config/_paths.py
@@ -123,10 +123,18 @@ if ENVIRONMENT_VENVS_DIR in os.environ:
 else:
     _VENVS_DIR_PATH = _ROOT_DIR_PATH / 'venvs'
 
+### When MRSM_VENVS_DIR is unset, keep the venvs path derived from the root so
+### `set_root()` (e.g. compose running actions in-process) re-derives it too.
+_VENVS_DIR_PATH_VALUE = (
+    _VENVS_DIR_PATH.as_posix()
+    if ENVIRONMENT_VENVS_DIR in os.environ
+    else ('{ROOT_DIR_PATH}', 'venvs')
+)
+
 paths = {
     'PACKAGE_ROOT_PATH'              : Path(__file__).parent.parent.resolve().as_posix(),
     'ROOT_DIR_PATH'                  : _ROOT_DIR_PATH.as_posix(),
-    'VIRTENV_RESOURCES_PATH'         : _VENVS_DIR_PATH.as_posix(),
+    'VIRTENV_RESOURCES_PATH'         : _VENVS_DIR_PATH_VALUE,
     'CONFIG_DIR_PATH'                : _CONFIG_DIR_PATH.as_posix(),
     'DEFAULT_CONFIG_DIR_PATH'        : ('{ROOT_DIR_PATH}', 'default_config'),
     'PATCH_DIR_PATH'                 : ('{ROOT_DIR_PATH}', 'patch_config'),
@@ -239,6 +247,9 @@ def set_plugins_dir_paths(plugins_dir_paths: Union[List[Path], Path, str]):
 def set_venvs_dir_path(venvs_dir_path: Union[str, Path]):
     """Modify the value of `VIRTENV_RESOURCES_PATH`."""
     paths['VIRTENV_RESOURCES_PATH'] = Path(venvs_dir_path).resolve().as_posix()
+    ### `set_root()` may have cached the resolved path as a module global,
+    ### which shadows `__getattr__` — drop it so lookups hit `paths` again.
+    globals().pop('VIRTENV_RESOURCES_PATH', None)
 
 def set_config_dir_path(config_dir_path: Union[str, Path]):
     paths['CONFIG_DIR_PATH'] = Path(config_dir_path).resolve().as_posix()
@@ -302,7 +313,10 @@ def replace_venvs_dir_path(venvs_dir_path: Union[Path, None]):
     try:
         yield
     finally:
-        set_venvs_dir_path(old_venvs_dir_path)
+        ### Restore the raw value — it may be a ('{ROOT_DIR_PATH}', 'venvs')
+        ### template, which `set_venvs_dir_path` would mangle via `Path()`.
+        paths['VIRTENV_RESOURCES_PATH'] = old_venvs_dir_path
+        globals().pop('VIRTENV_RESOURCES_PATH', None)
 
 @contextlib.contextmanager
 def replace_config_dir_path(config_dir_path: Union[Path, None]):

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.4.5"
+__version__ = "3.4.6"


### PR DESCRIPTION
# v3.4.6

- **Fix venvs path not following `set_root()`.**  
  When `MRSM_VENVS_DIR` is unset, `VIRTENV_RESOURCES_PATH` now derives from `ROOT_DIR_PATH` dynamically, so in-process root swaps (e.g. `compose` running custom actions under `replace_root_dir()`) activate venvs from `{root}/venvs` — matching where subprocess-mode commands like `install required` install packages. Previously the path was frozen at import time, so custom plugin actions run through `compose` could not import their own `required` dependencies