### PR TITLE
🐛 v3.5.1 Fix upserting all-null special-dtype columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.5.1
+
+- **Fix upserting rows which null out `json`, `numeric`, or `uuid` columns.**  
+  Patching a row so that a special-dtype column becomes `NULL` failed on PostgreSQL-like flavors with an error such as `column "j" is of type jsonb but expression is of type text`. An all-null column carries no values to inspect, so the temporary staging table created it as `TEXT` instead of the column's real type. Staged columns now fall back to the pipe's registered dtype when every incoming value is null.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'test', 'upsert', 'nulls',
+      instance='sql:main',
+      columns={'primary': 'id'},
+      upsert=True,
+      dtypes={'id': 'int', 'j': 'json'},
+  )
+  pipe.sync([{'id': 1, 'j': [1, 2]}])
+  pipe.sync([{'id': 1, 'j': None}])
+  ```
+
 ### v3.5.0
 
 - **Add a first-class [MCP server](/reference/mcp/).**  

--- a/docs/zensical/llms-full.txt
+++ b/docs/zensical/llms-full.txt
@@ -8886,6 +8886,25 @@ Source: https://meerschaum.io/news/changelog/
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.5.1
+
+- **Fix upserting rows which null out `json`, `numeric`, or `uuid` columns.**  
+  Patching a row so that a special-dtype column becomes `NULL` failed on PostgreSQL-like flavors with an error such as `column "j" is of type jsonb but expression is of type text`. An all-null column carries no values to inspect, so the temporary staging table created it as `TEXT` instead of the column's real type. Staged columns now fall back to the pipe's registered dtype when every incoming value is null.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'test', 'upsert', 'nulls',
+      instance='sql:main',
+      columns={'primary': 'id'},
+      upsert=True,
+      dtypes={'id': 'int', 'j': 'json'},
+  )
+  pipe.sync([{'id': 1, 'j': [1, 2]}])
+  pipe.sync([{'id': 1, 'j': None}])
+  ```
+
 ### v3.5.0
 
 - **Add a first-class [MCP server](/reference/mcp/).**  

--- a/docs/zensical/news/changelog.md
+++ b/docs/zensical/news/changelog.md
@@ -4,6 +4,25 @@
 
 This is the current release cycle, so stay tuned for future releases!
 
+### v3.5.1
+
+- **Fix upserting rows which null out `json`, `numeric`, or `uuid` columns.**  
+  Patching a row so that a special-dtype column becomes `NULL` failed on PostgreSQL-like flavors with an error such as `column "j" is of type jsonb but expression is of type text`. An all-null column carries no values to inspect, so the temporary staging table created it as `TEXT` instead of the column's real type. Staged columns now fall back to the pipe's registered dtype when every incoming value is null.
+
+  ```python
+  import meerschaum as mrsm
+
+  pipe = mrsm.Pipe(
+      'test', 'upsert', 'nulls',
+      instance='sql:main',
+      columns={'primary': 'id'},
+      upsert=True,
+      dtypes={'id': 'int', 'j': 'json'},
+  )
+  pipe.sync([{'id': 1, 'j': [1, 2]}])
+  pipe.sync([{'id': 1, 'j': None}])
+  ```
+
 ### v3.5.0
 
 - **Add a first-class [MCP server](/reference/mcp/).**  

--- a/meerschaum/config/_version.py
+++ b/meerschaum/config/_version.py
@@ -2,4 +2,4 @@
 Specify the Meerschaum release version.
 """
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"

--- a/meerschaum/connectors/sql/_pipes.py
+++ b/meerschaum/connectors/sql/_pipes.py
@@ -2078,12 +2078,18 @@ def sync_pipe(
             label=('update' if not upsert else 'upsert'),
         )
         self._log_temporary_tables_creation(temp_target, create=(not pipe.temporary), debug=debug)
+        pipe_dtypes = pipe.dtypes
         update_dtypes = {
             **{
                 col: str(typ)
                 for col, typ in update_df.dtypes.items()
             },
-            **get_special_cols(update_df)
+            **get_special_cols(update_df),
+            **{
+                col: pipe_dtypes[col]
+                for col in update_df.columns
+                if col in pipe_dtypes and update_df[col].isnull().all()
+            },
         }
 
         temp_pipe = Pipe(

--- a/tests/test_pipes_dtypes.py
+++ b/tests/test_pipes_dtypes.py
@@ -11,7 +11,7 @@ from tests import debug
 from tests.connectors import conns, get_flavors
 import meerschaum as mrsm
 from meerschaum import Pipe
-from meerschaum.utils.dtypes import are_dtypes_equal
+from meerschaum.utils.dtypes import are_dtypes_equal, value_is_null
 from meerschaum.utils.sql import sql_item_name
 from meerschaum.utils.dtypes.sql import PD_TO_DB_DTYPES_FLAVORS
 
@@ -870,6 +870,46 @@ def test_sync_uuids_simple_upsert(flavor: str):
     assert len(df) == 1
     assert isinstance(df['val'][0], UUID)
     assert df['val'][0] == UUID('d1cc1516-16e5-4471-8ab9-e969a1def655')
+
+
+@pytest.mark.parametrize("flavor", get_flavors())
+def test_upsert_null_special_dtypes(flavor: str):
+    """
+    Test that an upsert patch of all-null special columns keeps the pipe's dtypes.
+    """
+    conn = conns[flavor]
+    parameters = {
+        'columns': {'primary': 'id'},
+        'upsert': True,
+        'dtypes': {'id': 'int', 'j': 'json', 'n': 'numeric', 'u': 'uuid', 't': 'string'},
+    }
+    pipe = mrsm.Pipe('test', 'upsert', 'null_special', instance=conn)
+    pipe.delete()
+    pipe = mrsm.Pipe('test', 'upsert', 'null_special', instance=conn, parameters=parameters)
+    success, msg = pipe.sync(
+        [
+            {
+                'id': 1,
+                'j': [1, 2],
+                'n': Decimal('1.5'),
+                'u': UUID('7d78f4a7-8c0d-4cc3-9636-9516aa0c32ce'),
+                't': 'first',
+            },
+        ],
+        debug=debug,
+    )
+    assert success, msg
+
+    success, msg = pipe.sync(
+        [{'id': 1, 'j': None, 'n': None, 'u': None, 't': 'second'}],
+        debug=debug,
+    )
+    assert success, msg
+    df = pipe.get_data(debug=debug)
+    assert len(df) == 1
+    assert df['t'][0] == 'second'
+    for col in ('j', 'n', 'u'):
+        assert value_is_null(df[col][0]), f"'{col}' is not null: {df[col][0]}"
 
 
 @pytest.mark.parametrize("flavor", get_flavors())


### PR DESCRIPTION
# v3.5.1

- **Fix upserting rows which null out `json`, `numeric`, or `uuid` columns.**  
  Patching a row so that a special-dtype column becomes `NULL` failed on PostgreSQL-like flavors with an error such as `column "j" is of type jsonb but expression is of type text`. An all-null column carries no values to inspect, so the temporary staging table created it as `TEXT` instead of the column's real type. Staged columns now fall back to the pipe's registered dtype when every incoming value is null.

  ```python
  import meerschaum as mrsm

  pipe = mrsm.Pipe(
      'test', 'upsert', 'nulls',
      instance='sql:main',
      columns={'primary': 'id'},
      upsert=True,
      dtypes={'id': 'int', 'j': 'json'},
  )
  pipe.sync([{'id': 1, 'j': [1, 2]}])
  pipe.sync([{'id': 1, 'j': None}])
  ```
